### PR TITLE
provider send an offer to marketplace

### DIFF
--- a/esi_leap/conf/__init__.py
+++ b/esi_leap/conf/__init__.py
@@ -10,14 +10,14 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from oslo_config import cfg
 
 from esi_leap.conf import api
 from esi_leap.conf import dummy_node
+from esi_leap.conf import flocx_market
 from esi_leap.conf import ironic
 from esi_leap.conf import netconf
 from esi_leap.conf import pecan
-
+from oslo_config import cfg
 
 CONF = cfg.CONF
 
@@ -28,3 +28,4 @@ dummy_node.register_opts(CONF)
 ironic.register_opts(CONF)
 netconf.register_opts(CONF)
 pecan.register_opts(CONF)
+flocx_market.register_opts(CONF)

--- a/esi_leap/conf/flocx_market.py
+++ b/esi_leap/conf/flocx_market.py
@@ -1,0 +1,61 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import copy
+
+from keystoneauth1 import loading
+from oslo_config import cfg
+
+
+opts = []
+
+flocx_market_group = cfg.OptGroup(
+    'flocx_market',
+    title='flocx_market option')
+
+
+def register_opts(conf):
+    conf.register_opts(opts, group=flocx_market_group)
+    loading.register_session_conf_options(conf, flocx_market_group)
+    loading.register_auth_conf_options(conf, flocx_market_group)
+    loading.register_adapter_conf_options(conf, flocx_market_group)
+    conf.set_default('valid_interfaces', ['internal', 'public'],
+                     group=flocx_market_group)
+    conf.set_default('service_type', 'marketplace', group=flocx_market_group)
+
+
+def list_opts():
+    def add_options(opts, opts_to_add):
+        for new_opt in opts_to_add:
+            for opt in opts:
+                if opt.name == new_opt.name:
+                    break
+            else:
+                opts.append(new_opt)
+
+    opts_copy = copy.deepcopy(opts)
+    opts_copy.insert(0, loading.get_auth_common_conf_options()[0])
+
+    plugins = ['password', 'v2password', 'v3password']
+    for name in plugins:
+        plugin = loading.get_plugin_loader(name)
+        add_options(opts_copy, loading.get_auth_plugin_conf_options(plugin))
+    add_options(opts_copy, loading.get_session_conf_options())
+
+    adapter_opts = loading.get_adapter_conf_options(
+        include_deprecated=False)
+    # adding defaults for valid interfaces
+    cfg.set_defaults(adapter_opts, service_type='marketplace',
+                     valid_interfaces=['internal', 'public'])
+    add_options(opts_copy, adapter_opts)
+    opts_copy.sort(key=lambda x: x.name)
+    return opts_copy

--- a/esi_leap/conf/opts.py
+++ b/esi_leap/conf/opts.py
@@ -18,6 +18,7 @@ _opts = [
     ('dummy_node', esi_leap.conf.dummy_node.opts),
     ('ironic', esi_leap.conf.ironic.list_opts()),
     ('pecan', esi_leap.conf.pecan.opts),
+    ('flocx_market', esi_leap.conf.flocx_market.list_opts()),
 ]
 
 

--- a/esi_leap/objects/base.py
+++ b/esi_leap/objects/base.py
@@ -9,7 +9,6 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
 from oslo_log import log
 from oslo_versionedobjects import base as object_base
 

--- a/esi_leap/objects/flocx_market_client.py
+++ b/esi_leap/objects/flocx_market_client.py
@@ -1,0 +1,65 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+# borrowed from Nova
+import esi_leap.conf
+from oslo_log import log as logging
+
+LOG = logging.getLogger(__name__)
+CONF = esi_leap.conf.CONF
+
+
+class FlocxMarketClient(object):
+    """Client class for flocx-market."""
+
+    def __init__(self, adapter=None):
+        self._adapter = adapter
+        self._client = self._create_client()
+
+    def _create_client(self):
+        """Create the HTTP session accessing the flocx-market service."""
+        client = self._adapter
+        client.additional_headers = {'accept': 'application/json'}
+        return client
+
+    def get(self, url, version=None, global_request_id=None):
+        headers = ({request_id.INBOUND_HEADER: global_request_id}
+                   if global_request_id else {})
+        return self._client.get(url, microversion=version, headers=headers)
+
+    def post(self, url, data, version=None, global_request_id=None):
+        headers = ({request_id.INBOUND_HEADER: global_request_id}
+                   if global_request_id else {})
+        return self._client.post(url, json=data, microversion=version,
+                                 headers=headers)
+
+    def put(self, url, data, version=None, global_request_id=None):
+        kwargs = {'microversion': version,
+                  'headers': {request_id.INBOUND_HEADER:
+                              global_request_id} if global_request_id else {}}
+        if data is not None:
+            kwargs['json'] = data
+        return self._client.put(url, **kwargs)
+
+    def delete(self, url, version=None, global_request_id=None):
+        headers = ({request_id.INBOUND_HEADER: global_request_id}
+                   if global_request_id else {})
+        return self._client.delete(url, microversion=version, headers=headers)
+
+    def send_offer(self, data):
+        url = CONF.flocx_market.endpoint_override + '/offer'
+        r = self.post(url, data)
+        if r.status_code != 201:
+            LOG.warning(
+                "Failed to send an offer to flocx-market. Got HTTP %s: %s",
+                r.status_code,
+                r.text)
+        return r.status_code

--- a/esi_leap/objects/offer.py
+++ b/esi_leap/objects/offer.py
@@ -10,18 +10,21 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from oslo_versionedobjects import base as versioned_objects_base
 
 from esi_leap.common import statuses
 from esi_leap.db import api as dbapi
 from esi_leap.objects import base
 import esi_leap.objects.contract
 from esi_leap.objects import fields
+from esi_leap.objects import flocx_market_client
 from esi_leap.resource_objects import resource_object_factory as ro_factory
-import json
-from keystoneauth1.identity import v3
-from keystoneauth1 import session
+import datetime
+from keystoneauth1 import adapter
 from keystoneauth1 import loading as ks_loading
+from oslo_config import cfg
+from oslo_versionedobjects import base as versioned_objects_base
+
+CONF = cfg.CONF
 
 
 @versioned_objects_base.VersionedObjectRegistry.register
@@ -62,30 +65,27 @@ class Offer(base.ESILEAPObject):
             context, status)
         return cls._from_db_object_list(context, db_offers)
 
-    @classmethod
-    def send(cls, context, offer_uuid):
-        o = Offer.get(context, offer_uuid)
+    def send_to_flocx_market(self):
+        auth_plugin = ks_loading.load_auth_from_conf_options(
+            CONF, 'flocx_market')
+        sess = ks_loading.load_session_from_conf_options(CONF, 'flocx_market',
+                                                         auth=auth_plugin)
+        marketplace_offer_dict = self.to_marketplace_dict()
 
-        auth = v3.Password(auth_url='http://localhost:5000/v3',
-                           username='flocx-provider',
-                           password='password',
-                           project_name='service',
-                           user_domain_id='default',
-                           project_domain_id='default')
-        sess = session.Session(auth=auth)
-        
-        marketplace_offer_dict = o.to_marketplace_dict()
+        adpt = adapter.Adapter(
+            session=sess,
+            service_type='marketplace',
+            interface='public')
+        marketplace_client = flocx_market_client.FlocxMarketClient(adpt)
+        res_status_code = marketplace_client.send_offer(marketplace_offer_dict)
 
-        response = sess.post(
-            'http://localhost:8081/offer',
-            data=json.dumps(marketplace_offer_dict))
-
-        return response
+        return res_status_code
 
     def create(self, context=None):
         updates = self.obj_get_changes()
         db_offer = self.dbapi.offer_create(context, updates)
-        self._from_db_object(context, self, db_offer)
+        o = self._from_db_object(context, self, db_offer)
+        return o.send_to_flocx_market()
 
     def destroy(self, context=None):
         self.dbapi.offer_destroy(context, self.uuid)
@@ -114,23 +114,22 @@ class Offer(base.ESILEAPObject):
         self.save(context)
 
     def to_marketplace_dict(self):
-        # modifiy the offer data in order to be compatible with flocx-market POST offer api
         # change fields name
         offer_dict = self.to_dict()
         offer_dict['start_time'] = offer_dict.pop('start_date').isoformat()
         offer_dict['end_time'] = offer_dict.pop('end_date').isoformat()
+        offer_dict['cost'] = offer_dict['properties'].get('floor_price', 0)
         offer_dict['server_config'] = offer_dict.pop('properties')
         offer_dict['server_id'] = offer_dict.pop('resource_uuid')
         offer_dict['provider_id'] = offer_dict.pop('uuid')
+        offer_dict['creator_id'] = offer_dict.pop('project_id')
+
         # remove unnecessary feilds
         offer_dict.pop('created_at')
         offer_dict.pop('updated_at')
         offer_dict.pop('id')
-        offer_dict.pop('project_id')
         offer_dict.pop('resource_type')
         # fake fields
-        offer_dict['creator_id'] = 'Alice1992'
-        offer_dict['marketplace_date_created'] = '2016-07-16T19:20:30'
-        offer_dict['cost'] = 11.5
+        offer_dict['marketplace_date_created'] = datetime.datetime.utcnow()
 
         return offer_dict

--- a/esi_leap/tests/api/controllers/v1/test_offer.py
+++ b/esi_leap/tests/api/controllers/v1/test_offer.py
@@ -9,15 +9,18 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
+import datetime
 from esi_leap.objects import offer
 from esi_leap.tests.api import base as test_api_base
+import mock
 
 
 def create_test_offer(context):
     o = offer.Offer(
         resource_type='test_node',
         resource_uuid='1234567890',
+        start_date=datetime.datetime(2016, 7, 16, 19, 20, 30),
+        end_date=datetime.datetime(2016, 8, 16, 19, 20, 30)
     )
     o.create(context)
     return o
@@ -33,6 +36,10 @@ class TestListOffers(test_api_base.APITestCase):
         self.assertEqual([], data['offers'])
 
     def test_one(self):
-        offer = create_test_offer(self.context)
-        data = self.get_json('/offers')
-        self.assertEqual(offer.uuid, data['offers'][0]["uuid"])
+        with mock.patch.object(
+                offer.Offer, 'send_to_flocx_market', autospec=True
+        ) as mock_send:
+            mock_send.return_value = 201
+            o = create_test_offer(self.context)
+            data = self.get_json('/offers')
+            self.assertEqual(o.uuid, data['offers'][0]["uuid"])

--- a/esi_leap/tests/objects/test_offer.py
+++ b/esi_leap/tests/objects/test_offer.py
@@ -24,9 +24,9 @@ def get_test_offer():
         'uuid': '534653c9-880d-4c2d-6d6d-f4f2a09e384',
         'project_id': '01d4e6a72f5c408813e02f664cc8c83e',
         'resource_type': 'ironic_node',
-        'resource_uuid': '8010c964-9637-4ea0-b492-9c99b07ea1db',
-        'start_date': None,
-        'end_date': None,
+        'resource_uuid': '8010c964-9637-4ea0-b492-9c99b07ea1dt',
+        'start_date': datetime.datetime(2016, 7, 16, 19, 20, 30),
+        'end_date': datetime.datetime(2016, 8, 16, 19, 20, 30),
         'status': statuses.OPEN,
         'properties': {'floor_price': 3},
         'created_at': None,
@@ -146,3 +146,16 @@ class TestOfferObject(base.DBTestCase):
                 self.context, o.uuid, updated_values)
             self.assertEqual(self.context, o._context)
             self.assertEqual(updated_at, o.updated_at)
+
+    def test_send(self):
+        offer_uuid = self.fake_offer['uuid']
+        with mock.patch.object(self.db_api, 'offer_get',
+                               autospec=True) as mock_offer_send:
+            mock_offer_send.return_value = self.fake_offer
+
+            res = offer.Offer.send(self.context, offer_uuid)
+
+            mock_offer_send.assert_called_once_with(
+                self.context, offer_uuid)
+
+            self.assertEqual(res.status_code, 201)


### PR DESCRIPTION
Implemented send_offer function in objects layer and test_send_offer code.
Provider can make a POST request to send offers by uuid to marketplace using keystoneauth session.
Still need to:
- replace hard-coded places with oslo config (keystone/marketplace endpoint)
- modify offer data model(from provider/marketplace side) to make the post request data consistent with each side.