### PR TITLE
provider retrieves contracts from marketplace and creates contracts

### DIFF
--- a/esi_leap/common/flocx_market.py
+++ b/esi_leap/common/flocx_market.py
@@ -1,0 +1,121 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from esi_leap.common import statuses
+from esi_leap.objects import flocx_market_client
+from esi_leap.objects import offer
+import json
+from keystoneauth1 import adapter
+from keystoneauth1 import loading as ks_loading
+from oslo_config import cfg
+from oslo_log import log as logging
+
+CONF = cfg.CONF
+LOG = logging.getLogger(__name__)
+
+
+def get_flocx_market_client():
+    auth_plugin = ks_loading.load_auth_from_conf_options(
+        CONF, 'flocx_market')
+    sess = ks_loading.load_session_from_conf_options(CONF, 'flocx_market',
+                                                     auth=auth_plugin)
+    adpt = adapter.Adapter(
+        session=sess,
+        service_type='marketplace',
+        interface='public')
+    return flocx_market_client.FlocxMarketClient(adpt)
+
+
+def retrieve_from_flocx_market(context):
+    marketplace_client = get_flocx_market_client()
+    contract_list = get_contracts(context, marketplace_client)
+    return contract_list
+
+
+def get_contracts(context, marketplace_client):
+    contracts = []
+    contract_offer_list = get_ocr_by_status(marketplace_client)
+    if len(contract_offer_list) == 0:
+        return []
+    for contract_offer in contract_offer_list:
+        contract_data = {}
+        contract_id = contract_offer["contract_id"]
+        marketplace_offer_id = contract_offer["marketplace_offer_id"]
+        ocr_id = contract_offer["offer_contract_relationship_id"]
+        contract_data["marketplace_offer_contract_relationship_id"] = ocr_id
+        c = get_contract_by_id(contract_id, marketplace_client)
+        contract_data["start_date"] = c["start_time"]
+        contract_data["end_date"] = c["end_time"]
+        contract_data["status"] = statuses.OPEN
+        bid = get_bid_by_id(c["bid_id"], marketplace_client)
+        contract_data["project_id"] = bid["project_id"]
+        offer_marketplace = get_offer_by_id(
+            marketplace_offer_id, marketplace_client)
+        provider_offer_id = offer_marketplace["provider_offer_id"]
+        offer_provider = offer.Offer.get(context, provider_offer_id).to_dict()
+        contract_data["offer_uuid"] = provider_offer_id
+        contract_data["properties"] = offer_provider["properties"]
+        contracts.append(contract_data)
+    return contracts
+
+
+def get_ocr_by_status(marketplace_client):
+    url = CONF.flocx_market.endpoint_override + \
+        '/offer_contract_relationship?status=unretrieved'
+    r = marketplace_client.get(url)
+    if r.status_code != 200:
+        LOG.warning(
+            "Failed to retrieve contracts from flocx-market. Got HTTP %s: %s",
+            r.status_code,
+            r.text)
+        return []
+    if r.content is not None:
+        return json.loads(r.content)
+    else:
+        return []
+
+
+def get_contract_by_id(contract_id, marketplace_client):
+    url = CONF.flocx_market.endpoint_override + '/contract/' + contract_id
+    res = marketplace_client.get(url)
+    return json.loads(res.content)
+
+
+def get_bid_by_id(bid_id, marketplace_client):
+    url = CONF.flocx_market.endpoint_override + '/bid/' + bid_id
+    res = marketplace_client.get(url)
+    return json.loads(res.content)
+
+
+def get_offer_by_id(offer_id, marketplace_client):
+    url = CONF.flocx_market.endpoint_override + '/offer/' + offer_id
+    res = marketplace_client.get(url)
+    return json.loads(res.content)
+
+
+def update_contract(o_c_r_id, marketplace_client):
+    url = CONF.flocx_market.endpoint_override + \
+        '/offer_contract_relationship/' + o_c_r_id
+    data = {"status": "retrieved"}
+    r = marketplace_client.put(url, data)
+    if r.status_code != 200:
+        LOG.warning(
+            "Failed to update a contract to flocx-market. Got HTTP %s: %s",
+            r.status_code,
+            r.text)
+    return r.status_code
+
+
+def update_flocx_market_contract(o_c_r_id):
+    marketplace_client = get_flocx_market_client()
+    res_status_code = update_contract(o_c_r_id, marketplace_client)
+    return res_status_code

--- a/esi_leap/db/sqlalchemy/api.py
+++ b/esi_leap/db/sqlalchemy/api.py
@@ -253,7 +253,6 @@ def contract_get_all_by_status(context, status):
 def contract_create(context, values):
     contract_ref = models.Contract()
     values['uuid'] = uuidutils.generate_uuid()
-    values['project_id'] = context.project_id
     contract_ref.update(values)
     contract_ref.save(get_session())
     return contract_ref

--- a/esi_leap/db/sqlalchemy/models.py
+++ b/esi_leap/db/sqlalchemy/models.py
@@ -70,6 +70,8 @@ class Contract(Base):
     id = Column(Integer, primary_key=True, nullable=False, autoincrement=True)
     uuid = Column(String(36), nullable=False, unique=True)
     project_id = Column(String(255), nullable=False)
+    marketplace_offer_contract_relationship_id = Column(String(36),
+                                                        nullable=False)
     start_date = Column(DateTime)
     end_date = Column(DateTime)
     status = Column(String(15), nullable=False, default=statuses.OPEN)
@@ -77,7 +79,6 @@ class Contract(Base):
     offer_uuid = Column(String(36),
                         ForeignKey('offers.uuid'),
                         nullable=False)
-
     offer = orm.relationship(
         Offer,
         backref=orm.backref('offers'),

--- a/esi_leap/objects/contract.py
+++ b/esi_leap/objects/contract.py
@@ -10,13 +10,15 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from oslo_versionedobjects import base as versioned_objects_base
-
 from esi_leap.common import statuses
 from esi_leap.db import api as dbapi
 from esi_leap.objects import base
 from esi_leap.objects import fields
 import esi_leap.objects.offer
+from oslo_config import cfg
+from oslo_versionedobjects import base as versioned_objects_base
+
+CONF = cfg.CONF
 
 
 @versioned_objects_base.VersionedObjectRegistry.register
@@ -32,6 +34,7 @@ class Contract(base.ESILEAPObject):
         'status': fields.StringField(),
         'properties': fields.FlexibleDictField(nullable=True),
         'offer_uuid': fields.UUIDField(),
+        'marketplace_offer_contract_relationship_id': fields.UUIDField()
     }
 
     @classmethod

--- a/esi_leap/objects/offer.py
+++ b/esi_leap/objects/offer.py
@@ -10,7 +10,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-
+import datetime
 from esi_leap.common import statuses
 from esi_leap.db import api as dbapi
 from esi_leap.objects import base
@@ -18,7 +18,6 @@ import esi_leap.objects.contract
 from esi_leap.objects import fields
 from esi_leap.objects import flocx_market_client
 from esi_leap.resource_objects import resource_object_factory as ro_factory
-import datetime
 from keystoneauth1 import adapter
 from keystoneauth1 import loading as ks_loading
 from oslo_config import cfg
@@ -122,9 +121,8 @@ class Offer(base.ESILEAPObject):
         offer_dict['end_time'] = offer_dict.pop('end_date').isoformat()
         offer_dict['cost'] = offer_dict['properties'].get('floor_price', 0)
         offer_dict['server_id'] = offer_dict.pop('resource_uuid')
-        offer_dict['provider_id'] = offer_dict.pop('uuid')
-        offer_dict['creator_id'] = offer_dict.pop('project_id')
-
+        offer_dict['provider_offer_id'] = offer_dict.pop('uuid')
+        offer_dict['project_id'] = offer_dict.pop('project_id')
         # remove unnecessary feilds
         offer_dict.pop('created_at')
         offer_dict.pop('updated_at')

--- a/esi_leap/tests/objects/test_contract.py
+++ b/esi_leap/tests/objects/test_contract.py
@@ -23,6 +23,8 @@ def get_test_contract():
         'id': 27,
         'uuid': '534653c9-880d-4c2d-6d6d-f4f2a09e384',
         'project_id': '01d4e6a72f5c408813e02f664cc8c83e',
+        'marketplace_offer_contract_relationship_id':
+        'dce3f6e7b0dc4b3cb096a3ba10f826c0',
         'start_date': None,
         'end_date': None,
         'status': statuses.OPEN,


### PR DESCRIPTION
1. add a new periodic job: checking for new contracts in marketplace (haven't test yet)
2. flocx_market_client can send a get request to marketplace to retrieve all contracts (request with get_all_contracts REST api for now)
3. the objects.contract has a method retrieve_from_flocx_market that create a flocx_market_client and get the contracts list
4. the split method takes a flocx-market contract dict argument and split it into several small contracts with one offer
5. pass the test for objects.contract.retrieve_from_flocx_market and objects.contract.split