### PR TITLE
Offers should use 'available' rather than 'open' status

### DIFF
--- a/esi_leap/common/statuses.py
+++ b/esi_leap/common/statuses.py
@@ -10,7 +10,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-OPEN = 'open'
+AVAILABLE = 'available'
 CLAIMED = 'claimed'
-FULFILLED = 'fulfilled'
 EXPIRED = 'expired'
+FULFILLED = 'fulfilled'
+OPEN = 'open'

--- a/esi_leap/db/sqlalchemy/models.py
+++ b/esi_leap/db/sqlalchemy/models.py
@@ -53,7 +53,7 @@ class Offer(Base):
     resource_uuid = Column(String(36), nullable=False)
     start_date = Column(DateTime)
     end_date = Column(DateTime)
-    status = Column(String(15), nullable=False, default=statuses.OPEN)
+    status = Column(String(15), nullable=False, default=statuses.AVAILABLE)
     properties = Column(db_types.JsonEncodedDict, nullable=True)
 
 

--- a/esi_leap/manager/service.py
+++ b/esi_leap/manager/service.py
@@ -100,7 +100,7 @@ class ManagerService(service.Service):
     def _expire_offers(self):
         LOG.info("Checking for expiring offers")
         offers = offer.Offer.get_all_by_status(
-            self._context, statuses.OPEN)
+            self._context, statuses.AVAILABLE)
         for o in offers:
             if o.end_date and \
                o.end_date <= timeutils.utcnow():

--- a/esi_leap/tests/objects/test_offer.py
+++ b/esi_leap/tests/objects/test_offer.py
@@ -29,7 +29,7 @@ def get_test_offer():
         'resource_uuid': '1718',
         'start_date': datetime.datetime(2016, 7, 16, 19, 20, 30),
         'end_date': datetime.datetime(2016, 8, 16, 19, 20, 30),
-        'status': statuses.OPEN,
+        'status': statuses.AVAILABLE,
         'properties': {'floor_price': 3},
         'created_at': None,
         'updated_at': None


### PR DESCRIPTION
This PR updates offers to use 'available' rather than 'open'. Note
that contracts still use 'open'.