### PR TITLE
Fixed posting readonly variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ password = <ironic password>
 dummy_node_dir=/tmp/nodes
 ```
 
+### Create the Openstack Service
+
+```
+    $ openstack service create --name esi-leap lease
+    $ openstack endpoint create esi-leap --region RegionOne public http://localhost:7777
+```
+
 
 ### Run the Services
 

--- a/esi_leap/api/controllers/v1/contract.py
+++ b/esi_leap/api/controllers/v1/contract.py
@@ -25,14 +25,13 @@ from esi_leap.objects import contract
 
 class Contract(base.ESILEAPBase):
 
-    id = wsme.wsattr(int)
-    uuid = wsme.wsattr(wtypes.text)
-    project_id = wsme.wsattr(wtypes.text)
+    uuid = wsme.wsattr(wtypes.text, readonly=True)
+    project_id = wsme.wsattr(wtypes.text, readonly=True)
     start_date = wsme.wsattr(datetime.datetime)
     end_date = wsme.wsattr(datetime.datetime)
     status = wsme.wsattr(wtypes.text)
     properties = {wtypes.text: types.jsontype}
-    offer_uuid = wsme.wsattr(wtypes.text)
+    offer_uuid = wsme.wsattr(wtypes.text, mandatory=True)
 
     def __init__(self, **kwargs):
         self.fields = contract.Contract.fields

--- a/esi_leap/api/controllers/v1/offer.py
+++ b/esi_leap/api/controllers/v1/offer.py
@@ -25,11 +25,10 @@ from esi_leap.objects import offer
 
 class Offer(base.ESILEAPBase):
 
-    id = wsme.wsattr(int)
-    uuid = wsme.wsattr(wtypes.text)
-    project_id = wsme.wsattr(wtypes.text)
-    resource_type = wsme.wsattr(wtypes.text)
-    resource_uuid = wsme.wsattr(wtypes.text)
+    uuid = wsme.wsattr(wtypes.text, readonly=True)
+    project_id = wsme.wsattr(wtypes.text, readonly=True)
+    resource_type = wsme.wsattr(wtypes.text, mandatory=True)
+    resource_uuid = wsme.wsattr(wtypes.text, mandatory=True)
     start_date = wsme.wsattr(datetime.datetime)
     end_date = wsme.wsattr(datetime.datetime)
     status = wsme.wsattr(wtypes.text)

--- a/esi_leap/db/sqlalchemy/api.py
+++ b/esi_leap/db/sqlalchemy/api.py
@@ -253,6 +253,7 @@ def contract_get_all_by_status(context, status):
 def contract_create(context, values):
     contract_ref = models.Contract()
     values['uuid'] = uuidutils.generate_uuid()
+    values['project_id'] = context.project_id
     contract_ref.update(values)
     contract_ref.save(get_session())
     return contract_ref

--- a/esi_leap/db/sqlalchemy/models.py
+++ b/esi_leap/db/sqlalchemy/models.py
@@ -36,7 +36,7 @@ Base = declarative_base(cls=ESILEAPBase)
 
 
 class Offer(Base):
-    """Represents a resource that is offered to the FLOCX marketplace."""
+    """Represents a resource that is offered."""
 
     __tablename__ = 'offers'
     __table_args__ = (
@@ -58,7 +58,7 @@ class Offer(Base):
 
 
 class Contract(Base):
-    """Represents an accepted contract from the FLOCX marketplace."""
+    """Represents an accepted contract."""
 
     __tablename__ = 'contracts'
     __table_args__ = (
@@ -70,8 +70,6 @@ class Contract(Base):
     id = Column(Integer, primary_key=True, nullable=False, autoincrement=True)
     uuid = Column(String(36), nullable=False, unique=True)
     project_id = Column(String(255), nullable=False)
-    marketplace_offer_contract_relationship_id = Column(String(36),
-                                                        nullable=False)
     start_date = Column(DateTime)
     end_date = Column(DateTime)
     status = Column(String(15), nullable=False, default=statuses.OPEN)

--- a/esi_leap/objects/contract.py
+++ b/esi_leap/objects/contract.py
@@ -34,7 +34,6 @@ class Contract(base.ESILEAPObject):
         'status': fields.StringField(),
         'properties': fields.FlexibleDictField(nullable=True),
         'offer_uuid': fields.UUIDField(),
-        'marketplace_offer_contract_relationship_id': fields.UUIDField()
     }
 
     @classmethod

--- a/esi_leap/tests/objects/test_contract.py
+++ b/esi_leap/tests/objects/test_contract.py
@@ -23,8 +23,6 @@ def get_test_contract():
         'id': 27,
         'uuid': '534653c9-880d-4c2d-6d6d-f4f2a09e384',
         'project_id': '01d4e6a72f5c408813e02f664cc8c83e',
-        'marketplace_offer_contract_relationship_id':
-        'dce3f6e7b0dc4b3cb096a3ba10f826c0',
         'start_date': None,
         'end_date': None,
         'status': statuses.OPEN,


### PR DESCRIPTION
Adjusted the offer and contrcat apis such that certain
attributes such as project_id are read only. Updated READEME
to include instructions for creating the lease service. Removed
the marketplace_offer_contract_relaitonship_id column from
contracts.