### PR TITLE
url variables and filtering

### DIFF
--- a/esi_leap/api/controllers/v1/contract.py
+++ b/esi_leap/api/controllers/v1/contract.py
@@ -57,14 +57,28 @@ class ContractsController(rest.RestController):
         c = contract.Contract.get(request, contract_uuid)
         return Contract(**c.to_dict())
 
-    @wsme_pecan.wsexpose(ContractCollection)
-    def get_all(self):
+    @wsme_pecan.wsexpose(ContractCollection, wtypes.text,
+                         datetime.datetime, datetime.datetime, wtypes.text,
+                         wtypes.text)
+    def get_all(self, project_id=None, start_date=None, end_date=None,
+                status=None, offer_uuid=None):
         request = pecan.request.context
         cdict = request.to_policy_values()
         policy.authorize('esi_leap:contract:get', cdict, cdict)
 
+        possible_filters = {
+            'project_id': project_id,
+            'status': status,
+            'offer_uuid': offer_uuid,
+        }
+
+        filters = {}
+        for k, v in possible_filters.items():
+            if v is not None:
+                filters[k] = v
+
         contract_collection = ContractCollection()
-        contracts = contract.Contract.get_all(request)
+        contracts = contract.Contract.get_all(request, filters)
         contract_collection.contracts = [
             Contract(**c.to_dict()) for c in contracts]
         return contract_collection

--- a/esi_leap/api/controllers/v1/offer.py
+++ b/esi_leap/api/controllers/v1/offer.py
@@ -58,14 +58,31 @@ class OffersController(rest.RestController):
         o = offer.Offer.get(request, offer_uuid)
         return Offer(**o.to_dict())
 
-    @wsme_pecan.wsexpose(OfferCollection)
-    def get_all(self):
+    @wsme_pecan.wsexpose(OfferCollection, wtypes.text, wtypes.text,
+                         wtypes.text, datetime.datetime, datetime.datetime,
+                         wtypes.text)
+    def get_all(self, project_id=None, resource_type=None,
+                resource_uuid=None, start_date=None, end_date=None,
+                status=None):
+
         request = pecan.request.context
         cdict = request.to_policy_values()
         policy.authorize('esi_leap:offer:get', cdict, cdict)
 
+        possible_filters = {
+            'project_id': project_id,
+            'resource_type': resource_type,
+            'resource_uuid': resource_uuid,
+            'status': status,
+        }
+
+        filters = {}
+        for k, v in possible_filters.items():
+            if v is not None:
+                filters[k] = v
+
         offer_collection = OfferCollection()
-        offers = offer.Offer.get_all(request)
+        offers = offer.Offer.get_all(request, filters)
         offer_collection.offers = [
             Offer(**o.to_dict()) for o in offers]
         return offer_collection

--- a/esi_leap/db/sqlalchemy/api.py
+++ b/esi_leap/db/sqlalchemy/api.py
@@ -128,29 +128,10 @@ def offer_get(context, offer_uuid):
     return result
 
 
-def offer_get_all(context):
-    if not context.is_admin:
-        return offer_get_all_by_project_id(context, context.project_id)
+def offer_get_all(context, filters):
+
     query = model_query(context, models.Offer, get_session())
-    return query.all()
-
-
-def offer_get_all_by_project_id(context, project_id):
-    if not context.is_admin:
-        if context.project_id != project_id:
-            raise exception.ProjectNoPermission(project_id=project_id)
-
-    query = (model_query(context, models.Offer,
-                         get_session()).filter_by(project_id=project_id))
-    return query.all()
-
-
-def offer_get_all_by_status(context, status):
-    query = (model_query(context, models.Offer,
-                         get_session()).filter_by(status=status))
-    if not context.is_admin:
-        query.filter_by(project_id=context.project_id)
-    return query.all()
+    return query.filter_by(**filters)
 
 
 def offer_create(context, values):
@@ -222,32 +203,9 @@ def contract_get(context, contract_uuid):
     return result
 
 
-def contract_get_all(context):
+def contract_get_all(context, filters):
     query = model_query(context, models.Contract, get_session())
-    return query.all()
-
-
-def contract_get_all_by_project_id(context, project_id):
-    query = (model_query(
-        context,
-        models.Contract,
-        get_session()).filter(
-            models.Contract.offer.has(project_id=project_id)))
-    return query.all()
-
-
-def contract_get_all_by_offer_uuid(context, offer_uuid):
-    query = (model_query(context, models.Contract,
-                         get_session()).filter_by(offer_uuid=offer_uuid))
-    return query.all()
-
-
-def contract_get_all_by_status(context, status):
-    query = (model_query(context, models.Contract,
-                         get_session()).filter_by(status=status))
-    if not context.is_admin:
-        query.filter_by(project_id=context.project_id)
-    return query.all()
+    return query.filter_by(**filters)
 
 
 def contract_create(context, values):

--- a/esi_leap/objects/contract.py
+++ b/esi_leap/objects/contract.py
@@ -42,26 +42,8 @@ class Contract(base.ESILEAPObject):
         return cls._from_db_object(context, cls(), db_contract)
 
     @classmethod
-    def get_all(cls, context):
-        db_contracts = cls.dbapi.contract_get_all(context)
-        return cls._from_db_object_list(context, db_contracts)
-
-    @classmethod
-    def get_all_by_project_id(cls, context, project_id):
-        db_contracts = cls.dbapi.contract_get_all_by_project_id(
-            context, project_id)
-        return cls._from_db_object_list(context, db_contracts)
-
-    @classmethod
-    def get_all_by_offer_uuid(cls, context, offer_uuid):
-        db_contracts = cls.dbapi.contract_get_all_by_offer_uuid(
-            context, offer_uuid)
-        return cls._from_db_object_list(context, db_contracts)
-
-    @classmethod
-    def get_all_by_status(cls, context, status):
-        db_contracts = cls.dbapi.contract_get_all_by_status(
-            context, status)
+    def get_all(cls, context, filters):
+        db_contracts = cls.dbapi.contract_get_all(context, filters)
         return cls._from_db_object_list(context, db_contracts)
 
     def create(self, context=None):

--- a/esi_leap/objects/offer.py
+++ b/esi_leap/objects/offer.py
@@ -45,20 +45,8 @@ class Offer(base.ESILEAPObject):
         return cls._from_db_object(context, cls(), db_offer)
 
     @classmethod
-    def get_all(cls, context):
-        db_offers = cls.dbapi.offer_get_all(context)
-        return cls._from_db_object_list(context, db_offers)
-
-    @classmethod
-    def get_all_by_project_id(cls, context, project_id):
-        db_offers = cls.dbapi.offer_get_all_by_project_id(
-            context, project_id)
-        return cls._from_db_object_list(context, db_offers)
-
-    @classmethod
-    def get_all_by_status(cls, context, status):
-        db_offers = cls.dbapi.offer_get_all_by_status(
-            context, status)
+    def get_all(cls, context, filters):
+        db_offers = cls.dbapi.offer_get_all(context, filters)
         return cls._from_db_object_list(context, db_offers)
 
     def create(self, context=None):

--- a/esi_leap/tests/objects/test_contract.py
+++ b/esi_leap/tests/objects/test_contract.py
@@ -60,64 +60,13 @@ class TestContractObject(base.DBTestCase):
                 self.fake_contract]
 
             contracts = contract.Contract.get_all(
-                self.context)
+                self.context, {})
 
             mock_contract_get_all.assert_called_once_with(
-                self.context)
+                self.context, {})
             self.assertEqual(len(contracts), 1)
             self.assertIsInstance(
                 contracts[0], contract.Contract)
-            self.assertEqual(self.context, contracts[0]._context)
-
-    def test_get_all_by_project_id(self):
-        project_id = self.fake_contract['project_id']
-        with mock.patch.object(
-                self.db_api,
-                'contract_get_all_by_project_id',
-                autospec=True) as mock_contract_get_all_by_project_id:
-            mock_contract_get_all_by_project_id.return_value = [
-                self.fake_contract]
-            contracts = contract.Contract.get_all_by_project_id(
-                self.context, project_id)
-
-            mock_contract_get_all_by_project_id.assert_called_once_with(
-                self.context, project_id)
-            self.assertEqual(len(contracts), 1)
-            self.assertIsInstance(contracts[0], contract.Contract)
-            self.assertEqual(self.context, contracts[0]._context)
-
-    def test_get_all_by_offer_uuid(self):
-        offer_uuid = self.fake_contract['offer_uuid']
-        with mock.patch.object(
-                self.db_api,
-                'contract_get_all_by_offer_uuid',
-                autospec=True) as mock_contract_get_all_by_offer_uuid:
-            mock_contract_get_all_by_offer_uuid.return_value = [
-                self.fake_contract]
-            contracts = contract.Contract.get_all_by_offer_uuid(
-                self.context, offer_uuid)
-
-            mock_contract_get_all_by_offer_uuid.assert_called_once_with(
-                self.context, offer_uuid)
-            self.assertEqual(len(contracts), 1)
-            self.assertIsInstance(contracts[0], contract.Contract)
-            self.assertEqual(self.context, contracts[0]._context)
-
-    def test_get_all_by_status(self):
-        status = self.fake_contract['status']
-        with mock.patch.object(
-                self.db_api,
-                'contract_get_all_by_status',
-                autospec=True) as mock_contract_get_all_by_status:
-            mock_contract_get_all_by_status.return_value = [
-                self.fake_contract]
-            contracts = contract.Contract.get_all_by_status(
-                self.context, status)
-
-            mock_contract_get_all_by_status.assert_called_once_with(
-                self.context, status)
-            self.assertEqual(len(contracts), 1)
-            self.assertIsInstance(contracts[0], contract.Contract)
             self.assertEqual(self.context, contracts[0]._context)
 
     def test_create(self):

--- a/esi_leap/tests/objects/test_offer.py
+++ b/esi_leap/tests/objects/test_offer.py
@@ -62,47 +62,13 @@ class TestOfferObject(base.DBTestCase):
                 self.fake_offer]
 
             offers = offer.Offer.get_all(
-                self.context)
+                self.context, {})
 
             mock_offer_get_all.assert_called_once_with(
-                self.context)
+                self.context, {})
             self.assertEqual(len(offers), 1)
             self.assertIsInstance(
                 offers[0], offer.Offer)
-            self.assertEqual(self.context, offers[0]._context)
-
-    def test_get_all_by_project_id(self):
-        project_id = self.fake_offer['project_id']
-        with mock.patch.object(
-                self.db_api,
-                'offer_get_all_by_project_id',
-                autospec=True) as mock_offer_get_all_by_project_id:
-            mock_offer_get_all_by_project_id.return_value = [
-                self.fake_offer]
-            offers = offer.Offer.get_all_by_project_id(
-                self.context, project_id)
-
-            mock_offer_get_all_by_project_id.assert_called_once_with(
-                self.context, project_id)
-            self.assertEqual(len(offers), 1)
-            self.assertIsInstance(offers[0], offer.Offer)
-            self.assertEqual(self.context, offers[0]._context)
-
-    def test_get_all_by_status(self):
-        status = self.fake_offer['status']
-        with mock.patch.object(
-                self.db_api,
-                'offer_get_all_by_status',
-                autospec=True) as mock_offer_get_all_by_status:
-            mock_offer_get_all_by_status.return_value = [
-                self.fake_offer]
-            offers = offer.Offer.get_all_by_status(
-                self.context, status)
-
-            mock_offer_get_all_by_status.assert_called_once_with(
-                self.context, status)
-            self.assertEqual(len(offers), 1)
-            self.assertIsInstance(offers[0], offer.Offer)
             self.assertEqual(self.context, offers[0]._context)
 
     def test_create(self):


### PR DESCRIPTION
Allows GET requests to grab all offers or contracts with
matching inputted variables. This type of filtering behavior
will be expected by offer owners who may want to see all of their
unexpired offers or lessees who want to see the status of all their
contracts.