### PR TITLE
Policy on contract get_all

### DIFF
--- a/esi_leap/api/controllers/v1/utils.py
+++ b/esi_leap/api/controllers/v1/utils.py
@@ -1,0 +1,24 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import oslo_policy
+
+from esi_leap.common import policy
+
+
+def verify_admin(cdict):
+    try:
+        policy.authorize('is_admin', cdict, cdict)
+        return True
+
+    except oslo_policy.policy.PolicyNotAuthorized:
+        return False

--- a/esi_leap/common/exception.py
+++ b/esi_leap/common/exception.py
@@ -76,3 +76,8 @@ class InvalidTimeRange(ESILeapException):
 class InvalidTimeCommand(ESILeapException):
     msg_fmt = _("Attempted to get %(resource)s resource without providing "
                 "a Start Time and End Time. Got %(start_time)s, %(end_time)s")
+
+
+class InvalidOwnerCommand(ESILeapException):
+    msg_fmt = _("Cannot set variable 'owner' without setting view='owned' "
+                "(Got view=%(view)s, owner=%(owner)s.")

--- a/esi_leap/common/policy.py
+++ b/esi_leap/common/policy.py
@@ -20,12 +20,15 @@ CONF = esi_leap.conf.CONF
 _ENFORCER = None
 
 default_policies = [
-    policy.RuleDefault('is_owner',
-                       'role:owner or role:esi_leap_owner',
-                       description='Owner API access'),
     policy.RuleDefault('is_admin',
                        'role:admin or role:esi_leap_admin',
                        description='Full read/write API access'),
+    policy.RuleDefault('is_owner',
+                       'role:owner or role:esi_leap_owner',
+                       description='Owner API access'),
+    policy.RuleDefault('is_lessee',
+                       'role:lessee or role:esi_leap_lessee',
+                       description='Lessee API access'),
 ]
 
 contract_policies = [
@@ -36,10 +39,20 @@ contract_policies = [
         [{'path': '/contracts', 'method': 'POST'}]),
     policy.DocumentedRuleDefault(
         'esi_leap:contract:get',
-        'rule:is_admin or rule:is_owner',
+        'rule:is_admin or rule:is_owner or rule:is_lessee',
         'Retrieve contract',
-        [{'path': '/contracts', 'method': 'GET'},
-         {'path': '/contracts/{contract_ident}', 'method': 'GET'}]),
+        [{'path': '/offers', 'method': 'GET'},
+         {'path': '/offers/{offer_ident}', 'method': 'GET'}]),
+    policy.DocumentedRuleDefault(
+        'esi_leap:contract:list',
+        'rule:is_admin or rule:is_lessee or rule:is_owner',
+        'Retrieve all contracts owned by project_id',
+        [{'path': '/contracts', 'method': 'GET'}]),
+    policy.DocumentedRuleDefault(
+        'esi_leap:contract:list_all',
+        'rule:is_admin',
+        'Retrieve all contracts',
+        [{'path': '/contracts', 'method': 'GET'}]),
     policy.DocumentedRuleDefault(
         'esi_leap:contract:delete',
         'rule:is_admin',

--- a/esi_leap/db/api.py
+++ b/esi_leap/db/api.py
@@ -99,16 +99,6 @@ def offer_get_all(context):
     return IMPL.offer_get_all(context)
 
 
-@to_dict
-def offer_get_all_by_project_id(context, project_id):
-    return IMPL.offer_get_all_by_project_id(context, project_id)
-
-
-@to_dict
-def offer_get_all_by_status(context, status):
-    return IMPL.offer_get_all_by_status(context, status)
-
-
 def offer_create(context, values):
     return IMPL.offer_create(context, values)
 
@@ -128,23 +118,8 @@ def contract_get(context, contract_uuid):
 
 
 @to_dict
-def contract_get_all(context):
-    return IMPL.contract_get_all(context)
-
-
-@to_dict
-def contract_get_all_by_project_id(context, project_id):
-    return IMPL.contract_get_all_by_project_id(context, project_id)
-
-
-@to_dict
-def contract_get_all_by_offer_uuid(context, offer_uuid):
-    return IMPL.contract_get_all_by_offer_uuid(context, offer_uuid)
-
-
-@to_dict
-def contract_get_all_by_status(context, status):
-    return IMPL.contract_get_all_by_status(context, status)
+def contract_get_all():
+    return IMPL.contract_get_all()
 
 
 def contract_create(context, values):

--- a/esi_leap/objects/contract.py
+++ b/esi_leap/objects/contract.py
@@ -43,7 +43,7 @@ class Contract(base.ESILEAPObject):
 
     @classmethod
     def get_all(cls, context, filters):
-        db_contracts = cls.dbapi.contract_get_all(context, filters)
+        db_contracts = cls.dbapi.contract_get_all(filters)
         return cls._from_db_object_list(context, db_contracts)
 
     def create(self, context=None):

--- a/esi_leap/tests/api/base.py
+++ b/esi_leap/tests/api/base.py
@@ -10,7 +10,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
 import pecan
 import pecan.testing
 
@@ -34,12 +33,6 @@ class APITestCase(base.DBTestCase):
         self.app = pecan.testing.load_test_app(
             dict(app.get_pecan_config())
         )
-
-        self.patch_context = mock.patch(
-            'oslo_context.context.RequestContext.from_environ'
-        )
-        self.mock_context = self.patch_context.start()
-        self.mock_context.return_value = self.context
 
     # borrowed from Ironic
     def get_json(self, path, expect_errors=False, headers=None,

--- a/esi_leap/tests/api/controllers/v1/test_contract.py
+++ b/esi_leap/tests/api/controllers/v1/test_contract.py
@@ -11,8 +11,55 @@
 #    under the License.
 
 import datetime
+from oslo_context import context as ctx
+from oslo_policy import policy
+import testtools
+
+from esi_leap.api.controllers.v1.contract import ContractsController
+from esi_leap.common import exception
 from esi_leap.objects import contract
 from esi_leap.tests.api import base as test_api_base
+
+
+admin_context = ctx.RequestContext()
+admin_context.roles = ['admin']
+admin_context = admin_context.to_policy_values()
+admin_project = 'adminid'
+
+owner_context = ctx.RequestContext()
+owner_context.roles = ['owner']
+owner_context = owner_context.to_policy_values()
+owner_project = "ownerid"
+
+lessee_context = ctx.RequestContext()
+lessee_context.roles = ['lessee']
+lessee_context = lessee_context.to_policy_values()
+lessee_project = 'lesseeid'
+
+admin_owner_context = ctx.RequestContext()
+admin_owner_context.roles = ['admin', 'owner']
+admin_owner_context = admin_owner_context.to_policy_values()
+admin_ownerproject = 'admin_ownerid'
+
+admin_lessee_context = ctx.RequestContext()
+admin_lessee_context.roles = ['admin', 'lessee']
+admin_lessee_context = admin_lessee_context.to_policy_values()
+admin_lesseeproject = 'admin_lesseeid'
+
+owner_lessee_context = ctx.RequestContext()
+owner_lessee_context.roles = ['owner', 'lessee']
+owner_lessee_context = owner_lessee_context.to_policy_values()
+owner_lesseeproject = 'owner_lesseeid'
+
+admin_owner_lessee_context = ctx.RequestContext()
+admin_owner_lessee_context.roles = ['admin', 'owner', 'lessee']
+admin_owner_lessee_context = admin_owner_lessee_context.to_policy_values()
+admin_owner_lesseeproject = 'admin_owner_lesseeid'
+
+random_context = ctx.RequestContext()
+random_context.roles = ['randomrole']
+random_context = random_context.to_policy_values()
+random_project = 'randomid'
 
 
 def create_test_contract(context):
@@ -25,10 +72,11 @@ def create_test_contract(context):
     return c
 
 
-class TestContractsController(test_api_base.APITestCase):
+class TestContractsControllerAdmin(test_api_base.APITestCase):
 
     def setUp(self):
-        super(TestContractsController, self).setUp()
+
+        super(TestContractsControllerAdmin, self).setUp()
 
     def test_empty(self):
         data = self.get_json('/contracts')
@@ -39,3 +87,250 @@ class TestContractsController(test_api_base.APITestCase):
         c = create_test_contract(self.context)
         data = self.get_json('/contracts')
         self.assertEqual(c.uuid, data['contracts'][0]["uuid"])
+
+
+class TestContractControllersGetAllFilters(testtools.TestCase):
+
+    def test_contract_get_all_no_view_no_projectid_no_owner(self):
+
+        expected_filters = {
+            'status': 'available',
+            'offer_uuid': 'offeruuid',
+        }
+
+        # admin
+        expected_filters['project_id'] = admin_project
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_context, admin_project,
+            status='available', offer_uuid='offeruuid')
+        self.assertEqual(expected_filters, filters)
+
+        expected_filters['project_id'] = admin_lesseeproject
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_lessee_context, admin_lesseeproject,
+            status='available', offer_uuid='offeruuid')
+        self.assertEqual(expected_filters, filters)
+
+        # admin owner
+        expected_filters['project_id'] = admin_ownerproject
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_owner_context, admin_ownerproject,
+            status='available', offer_uuid='offeruuid')
+        self.assertEqual(expected_filters, filters)
+
+        # owner lessee
+        expected_filters['project_id'] = owner_lesseeproject
+        filters = ContractsController._contract_get_all_authorize_filters(
+            owner_lessee_context, owner_lesseeproject,
+            status='available', offer_uuid='offeruuid')
+        self.assertEqual(expected_filters, filters)
+
+        # admin lessee owner
+        expected_filters['project_id'] = admin_owner_lesseeproject
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_owner_lessee_context,
+            admin_owner_lesseeproject,
+            status='available', offer_uuid='offeruuid')
+        self.assertEqual(expected_filters, filters)
+
+        # random
+        self.assertRaises(policy.PolicyNotAuthorized,
+                          ContractsController.
+                          _contract_get_all_authorize_filters,
+                          random_context, random_project,
+                          status='available', offer_uuid='offeruuid')
+
+    def test_contract_get_all_no_view_project_no_owner(self):
+
+        expected_filters = {}
+
+        # admin
+        expected_filters['project_id'] = admin_project
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_context, admin_project,
+            project_id=admin_project)
+        self.assertEqual(expected_filters, filters)
+
+        expected_filters['project_id'] = random_project
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_context, admin_project,
+            project_id=random_project)
+        self.assertEqual(expected_filters, filters)
+
+        # admin lessee
+        expected_filters['project_id'] = admin_lesseeproject
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_lessee_context, admin_lesseeproject,
+            project_id=admin_lesseeproject)
+        self.assertEqual(expected_filters, filters)
+
+        expected_filters['project_id'] = random_project
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_lessee_context, admin_lesseeproject,
+            project_id=random_project)
+        self.assertEqual(expected_filters, filters)
+
+        # admin owner
+        expected_filters['project_id'] = admin_ownerproject
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_owner_context, admin_ownerproject,
+            project_id=admin_ownerproject)
+        self.assertEqual(expected_filters, filters)
+
+        expected_filters['project_id'] = random_project
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_owner_context, admin_ownerproject,
+            project_id=random_project)
+        self.assertEqual(expected_filters, filters)
+
+        # owner lessee
+        expected_filters['project_id'] = owner_lesseeproject
+        filters = ContractsController._contract_get_all_authorize_filters(
+            owner_lessee_context, owner_lesseeproject,
+            project_id=owner_lesseeproject)
+        self.assertEqual(expected_filters, filters)
+
+        self.assertRaises(exception.ProjectNoPermission,
+                          ContractsController.
+                          _contract_get_all_authorize_filters,
+                          owner_lessee_context, owner_lesseeproject,
+                          project_id=random_project)
+
+        # admin lessee owner
+        expected_filters['project_id'] = admin_owner_lesseeproject
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_owner_lessee_context,
+            admin_owner_lesseeproject,
+            project_id=admin_owner_lesseeproject)
+        self.assertEqual(expected_filters, filters)
+
+        expected_filters['project_id'] = random_project
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_owner_lessee_context,
+            admin_owner_lesseeproject,
+            project_id=random_project)
+        self.assertEqual(expected_filters, filters)
+
+        # random
+        self.assertRaises(policy.PolicyNotAuthorized,
+                          ContractsController.
+                          _contract_get_all_authorize_filters,
+                          random_context, random_project,
+                          project_id=random_project)
+
+    def test_contract_get_all_no_view_any_projectid_owner(self):
+
+        expected_filters = {}
+
+        # admin
+        expected_filters['owner'] = admin_project
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_context, admin_project,
+            owner=admin_project)
+        self.assertEqual(expected_filters, filters)
+
+        expected_filters['owner'] = random_project
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_context, admin_project,
+            owner=random_project)
+        self.assertEqual(expected_filters, filters)
+
+        # admin lessee
+        expected_filters['owner'] = random_project
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_lessee_context, admin_lesseeproject,
+            owner=random_project)
+        self.assertEqual(expected_filters, filters)
+
+        # admin owner
+        expected_filters['owner'] = random_project
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_owner_context, admin_ownerproject,
+            owner=random_project)
+        self.assertEqual(expected_filters, filters)
+
+        # owner lessee
+        expected_filters['owner'] = owner_lesseeproject
+        filters = ContractsController._contract_get_all_authorize_filters(
+            owner_lessee_context, owner_lesseeproject,
+            owner=owner_lesseeproject)
+        self.assertEqual(expected_filters, filters)
+
+        self.assertRaises(exception.ProjectNoPermission,
+                          ContractsController.
+                          _contract_get_all_authorize_filters,
+                          owner_lessee_context, owner_lesseeproject,
+                          owner=random_project)
+
+        # admin lessee owner
+        expected_filters['owner'] = admin_owner_lesseeproject
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_owner_context, admin_owner_lesseeproject,
+            owner=admin_owner_lesseeproject)
+        self.assertEqual(expected_filters, filters)
+
+        expected_filters['owner'] = random_project
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_owner_context, admin_owner_lesseeproject,
+            owner=random_project)
+        self.assertEqual(expected_filters, filters)
+
+        # random
+        self.assertRaises(policy.PolicyNotAuthorized,
+                          ContractsController.
+                          _contract_get_all_authorize_filters,
+                          random_context, random_project,
+                          owner=random_project)
+
+        # owner w/ project_id
+        expected_filters['owner'] = owner_project
+        expected_filters['project_id'] = random_project
+        filters = ContractsController._contract_get_all_authorize_filters(
+            owner_context, owner_project,
+            owner=owner_project, project_id=random_project)
+        self.assertEqual(expected_filters, filters)
+
+    def test_contract_get_all_all_view(self):
+
+        expected_filters = {}
+
+        # admin
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_context, admin_project,
+            view='all')
+        self.assertEqual(expected_filters, filters)
+
+        # not admin
+        self.assertRaises(policy.PolicyNotAuthorized,
+                          ContractsController.
+                          _contract_get_all_authorize_filters,
+                          owner_lessee_context, owner_lesseeproject,
+                          view='all')
+
+    def test_contract_get_all_all_view_times(self):
+
+        start = datetime.datetime(2016, 7, 16, 19, 20, 30)
+        end = datetime.datetime(2020, 7, 16, 19, 20, 30)
+
+        expected_filters = {
+            'start_time': start,
+            'end_time': end
+        }
+
+        # admin
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_context, admin_project,
+            view='all', start_time=start, end_time=end)
+        self.assertEqual(expected_filters, filters)
+
+        self.assertRaises(exception.InvalidTimeCommand,
+                          ContractsController.
+                          _contract_get_all_authorize_filters,
+                          admin_context, admin_project,
+                          view='all', start_time=start)
+
+        self.assertRaises(exception.InvalidTimeCommand,
+                          ContractsController.
+                          _contract_get_all_authorize_filters,
+                          admin_context, admin_project,
+                          view='all', end_time=end)

--- a/esi_leap/tests/api/controllers/v1/test_offer.py
+++ b/esi_leap/tests/api/controllers/v1/test_offer.py
@@ -40,13 +40,3 @@ class TestListOffers(test_api_base.APITestCase):
         o = create_test_offer(self.context)
         data = self.get_json('/offers')
         self.assertEqual(o.uuid, data['offers'][0]["uuid"])
-
-    def test_get_invalid_time(self):
-
-        start = datetime.datetime(2016, 7, 16, 19, 20, 30)
-        response = self.get_json('/offers?start_time=' + str(start),
-                                 expect_errors=True)
-
-        self.assertEqual(500, response.status_int)
-        self.assertEqual('application/json', response.content_type)
-        self.assertIn(str(start), response.json_body['faultstring'])

--- a/esi_leap/tests/api/controllers/v1/test_utils.py
+++ b/esi_leap/tests/api/controllers/v1/test_utils.py
@@ -1,0 +1,28 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_context import context as ctx
+
+from esi_leap.api.controllers.v1 import utils
+
+admin_context = ctx.RequestContext()
+admin_context.roles = ['admin']
+admin_context = admin_context.to_policy_values()
+
+random_context = ctx.RequestContext()
+random_context.roles = ['randomrole']
+random_context = random_context.to_policy_values()
+
+
+def test_verify_admin():
+    assert utils.verify_admin(admin_context) is True
+    assert utils.verify_admin(random_context) is False

--- a/esi_leap/tests/objects/test_contract.py
+++ b/esi_leap/tests/objects/test_contract.py
@@ -62,8 +62,7 @@ class TestContractObject(base.DBTestCase):
             contracts = contract.Contract.get_all(
                 self.context, {})
 
-            mock_contract_get_all.assert_called_once_with(
-                self.context, {})
+            mock_contract_get_all.assert_called_once_with({})
             self.assertEqual(len(contracts), 1)
             self.assertIsInstance(
                 contracts[0], contract.Contract)


### PR DESCRIPTION
Implemented policies on contract get all. This commit extends
the functionality of contract get_all to allow filtering by
project id and ownership in order to accomodate owner and lessee
use cases. Implements policy on top of these new filters.