### PR TITLE
Rework destroy to cancel

### DIFF
--- a/esi_leap/api/controllers/v1/contract.py
+++ b/esi_leap/api/controllers/v1/contract.py
@@ -21,6 +21,7 @@ from esi_leap.api.controllers import base
 from esi_leap.api.controllers import types
 from esi_leap.common import exception
 from esi_leap.common import policy
+from esi_leap.common import statuses
 from esi_leap.objects import contract
 from esi_leap.objects import offer
 
@@ -31,7 +32,7 @@ class Contract(base.ESILEAPBase):
     project_id = wsme.wsattr(wtypes.text)
     start_time = wsme.wsattr(datetime.datetime)
     end_time = wsme.wsattr(datetime.datetime)
-    status = wsme.wsattr(wtypes.text)
+    status = wsme.wsattr(wtypes.text, readonly=True)
     properties = {wtypes.text: types.jsontype}
     offer_uuid = wsme.wsattr(wtypes.text, mandatory=True)
 
@@ -119,7 +120,7 @@ class ContractsController(rest.RestController):
                 policy.authorize('esi_leap:contract:contract_admin',
                                  cdict, cdict)
 
-        c.destroy()
+        c.cancel()
 
     @staticmethod
     def _contract_get_all_authorize_filters(cdict, r_project_id,
@@ -127,6 +128,11 @@ class ContractsController(rest.RestController):
                                             status=None, offer_uuid=None,
                                             project_id=None, view=None,
                                             owner=None):
+
+        if status is None:
+            status = [statuses.CREATED, statuses.ACTIVE]
+        elif status == 'any':
+            status = None
 
         possible_filters = {
             'status': status,

--- a/esi_leap/common/exception.py
+++ b/esi_leap/common/exception.py
@@ -59,9 +59,14 @@ class OfferNotFound(ESILeapException):
     msg_fmt = _("Offer %(offer_uuid)s not found.")
 
 
+class OfferNoTimeAvailabilities(ESILeapException):
+    msg_fmt = _("Offer %(offer_uuid)s has no availabilities at given "
+                "time range %(start_time)s, %(end_time)s.")
+
+
 class OfferNotAvailable(ESILeapException):
-    msg_fmt = _("Offer %(offer_uuid)s is not available at given time range "
-                "%(start_time)s, %(end_time)s.")
+    msg_fmt = _("Offer %(offer_uuid)s does not have status "
+                "'available'. Got offer status '%(status)s'.")
 
 
 class ProjectNoPermission(ESILeapException):

--- a/esi_leap/common/statuses.py
+++ b/esi_leap/common/statuses.py
@@ -10,8 +10,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+ACTIVE = 'active'
 AVAILABLE = 'available'
-CLAIMED = 'claimed'
+CANCELLED = 'cancelled'
+CREATED = 'created'
 EXPIRED = 'expired'
-FULFILLED = 'fulfilled'
-OPEN = 'open'

--- a/esi_leap/db/sqlalchemy/models.py
+++ b/esi_leap/db/sqlalchemy/models.py
@@ -72,7 +72,7 @@ class Contract(Base):
     project_id = Column(String(255), nullable=False)
     start_time = Column(DateTime)
     end_time = Column(DateTime)
-    status = Column(String(15), nullable=False, default=statuses.OPEN)
+    status = Column(String(15), nullable=False, default=statuses.CREATED)
     properties = Column(db_types.JsonEncodedDict, nullable=True)
     offer_uuid = Column(String(36),
                         ForeignKey('offers.uuid'),

--- a/esi_leap/manager/service.py
+++ b/esi_leap/manager/service.py
@@ -64,7 +64,7 @@ class ManagerService(service.Service):
     def _fulfill_contracts(self):
         LOG.info("Checking for contracts to fulfill")
         contracts = contract.Contract.get_all_by_status(
-            self._context, statuses.OPEN)
+            self._context, statuses.CREATED)
         for c in contracts:
             if c.start_time and \
                c.start_time <= timeutils.utcnow():
@@ -74,7 +74,7 @@ class ManagerService(service.Service):
     def _expire_contracts(self):
         LOG.info("Checking for expiring contracts")
         contracts = contract.Contract.get_all_by_status(
-            self._context, statuses.FULFILLED)
+            self._context, statuses.ACTIVE)
         for c in contracts:
             if c.end_time and \
                c.end_time <= timeutils.utcnow():

--- a/esi_leap/objects/contract.py
+++ b/esi_leap/objects/contract.py
@@ -10,12 +10,16 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import datetime
+
+from esi_leap.common import exception
 from esi_leap.common import statuses
 from esi_leap.db import api as dbapi
 from esi_leap.objects import base
 from esi_leap.objects import fields
 import esi_leap.objects.offer
 from oslo_config import cfg
+from oslo_utils import uuidutils
 from oslo_versionedobjects import base as versioned_objects_base
 
 CONF = cfg.CONF
@@ -48,8 +52,46 @@ class Contract(base.ESILEAPObject):
 
     def create(self, context=None):
         updates = self.obj_get_changes()
+        updates['uuid'] = uuidutils.generate_uuid()
+
+        if 'offer_uuid' not in updates:
+            raise exception.ContractNoOfferUUID()
+
+        related_offer = self.dbapi.offer_get(updates['offer_uuid'])
+        if related_offer is None:
+            raise exception.OfferNotFound(offer_uuid=updates['offer_uuid'])
+
+        if related_offer.status != statuses.AVAILABLE:
+            raise exception.OfferNotAvailable(offer_uuid=related_offer.uuid,
+                                              status=related_offer.status)
+
+        if 'start_time' not in updates:
+            updates['start_time'] = datetime.datetime.now()
+
+        if 'end_time' not in updates:
+            q = self.dbapi.offer_get_first_availability(related_offer,
+                                                        updates['start_time'])
+            if q is None:
+                updates['end_time'] = related_offer.end_time
+            else:
+                updates['end_time'] = q.start_time
+
+        self.dbapi.offer_verify_availability(related_offer,
+                                             updates['start_time'],
+                                             updates['end_time'])
+
         db_contract = self.dbapi.contract_create(updates)
         self._from_db_object(context, self, db_contract)
+
+    def cancel(self):
+        o = esi_leap.objects.offer.Offer.get(None, self.offer_uuid)
+
+        resource = o.resource_object()
+        if resource.get_contract_uuid() == self.uuid:
+            resource.set_contract(None)
+
+        self.status = statuses.CANCELLED
+        self.save(None)
 
     def destroy(self):
         self.dbapi.contract_destroy(self.uuid)
@@ -69,13 +111,17 @@ class Contract(base.ESILEAPObject):
         resource.set_contract(self)
 
         # expire contract
-        self.status = statuses.FULFILLED
+        self.status = statuses.ACTIVE
         self.save(context)
 
     def expire(self, context=None):
         # unassign resource
         o = esi_leap.objects.offer.Offer.get(
             context, self.offer_uuid)
+        if o.status != statuses.AVAILABLE:
+            raise exception.OfferNotAvailable(offer_uuid=o.uuid,
+                                              status=o.status)
+
         resource = o.resource_object()
         if resource.get_contract_uuid() == self.uuid:
             resource.set_contract(None)

--- a/esi_leap/tests/api/controllers/v1/test_contract.py
+++ b/esi_leap/tests/api/controllers/v1/test_contract.py
@@ -116,7 +116,7 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
     def test_contract_get_all_no_view_no_projectid_no_owner(self):
 
         expected_filters = {
-            'status': 'available',
+            'status': 'random',
             'offer_uuid': 'offeruuid',
         }
 
@@ -124,27 +124,27 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
         expected_filters['project_id'] = admin_project
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_context, admin_project,
-            status='available', offer_uuid='offeruuid')
+            status='random', offer_uuid='offeruuid')
         self.assertEqual(expected_filters, filters)
 
         expected_filters['project_id'] = admin_lesseeproject
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_lessee_context, admin_lesseeproject,
-            status='available', offer_uuid='offeruuid')
+            status='random', offer_uuid='offeruuid')
         self.assertEqual(expected_filters, filters)
 
         # admin owner
         expected_filters['project_id'] = admin_ownerproject
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_owner_context, admin_ownerproject,
-            status='available', offer_uuid='offeruuid')
+            status='random', offer_uuid='offeruuid')
         self.assertEqual(expected_filters, filters)
 
         # owner lessee
         expected_filters['project_id'] = owner_lesseeproject
         filters = ContractsController._contract_get_all_authorize_filters(
             owner_lessee_context, owner_lesseeproject,
-            status='available', offer_uuid='offeruuid')
+            status='random', offer_uuid='offeruuid')
         self.assertEqual(expected_filters, filters)
 
         # admin lessee owner
@@ -152,7 +152,7 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_owner_lessee_context,
             admin_owner_lesseeproject,
-            status='available', offer_uuid='offeruuid')
+            status='random', offer_uuid='offeruuid')
         self.assertEqual(expected_filters, filters)
 
         # random
@@ -160,77 +160,89 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
                           ContractsController.
                           _contract_get_all_authorize_filters,
                           random_context, random_project,
-                          status='available', offer_uuid='offeruuid')
+                          status='random', offer_uuid='offeruuid')
 
     def test_contract_get_all_no_view_project_no_owner(self):
 
-        expected_filters = {}
+        expected_filters = {
+            'status': 'random'
+        }
 
         # admin
         expected_filters['project_id'] = admin_project
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_context, admin_project,
-            project_id=admin_project)
+            project_id=admin_project,
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         expected_filters['project_id'] = random_project
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_context, admin_project,
-            project_id=random_project)
+            project_id=random_project,
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         # admin lessee
         expected_filters['project_id'] = admin_lesseeproject
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_lessee_context, admin_lesseeproject,
-            project_id=admin_lesseeproject)
+            project_id=admin_lesseeproject,
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         expected_filters['project_id'] = random_project
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_lessee_context, admin_lesseeproject,
-            project_id=random_project)
+            project_id=random_project,
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         # admin owner
         expected_filters['project_id'] = admin_ownerproject
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_owner_context, admin_ownerproject,
-            project_id=admin_ownerproject)
+            project_id=admin_ownerproject,
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         expected_filters['project_id'] = random_project
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_owner_context, admin_ownerproject,
-            project_id=random_project)
+            project_id=random_project,
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         # owner lessee
         expected_filters['project_id'] = owner_lesseeproject
         filters = ContractsController._contract_get_all_authorize_filters(
             owner_lessee_context, owner_lesseeproject,
-            project_id=owner_lesseeproject)
+            project_id=owner_lesseeproject,
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         self.assertRaises(policy.PolicyNotAuthorized,
                           ContractsController.
                           _contract_get_all_authorize_filters,
                           owner_lessee_context, owner_lesseeproject,
-                          project_id=random_project)
+                          project_id=random_project,
+                          status='random')
 
         # admin lessee owner
         expected_filters['project_id'] = admin_owner_lesseeproject
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_owner_lessee_context,
             admin_owner_lesseeproject,
-            project_id=admin_owner_lesseeproject)
+            project_id=admin_owner_lesseeproject,
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         expected_filters['project_id'] = random_project
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_owner_lessee_context,
             admin_owner_lesseeproject,
-            project_id=random_project)
+            project_id=random_project,
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         # random
@@ -238,63 +250,74 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
                           ContractsController.
                           _contract_get_all_authorize_filters,
                           random_context, random_project,
-                          project_id=random_project)
+                          project_id=random_project,
+                          status='random')
 
     def test_contract_get_all_no_view_any_projectid_owner(self):
 
-        expected_filters = {}
+        expected_filters = {
+            'status': 'random'
+        }
 
         # admin
         expected_filters['owner'] = admin_project
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_context, admin_project,
-            owner=admin_project)
+            owner=admin_project,
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         expected_filters['owner'] = random_project
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_context, admin_project,
-            owner=random_project)
+            owner=random_project,
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         # admin lessee
         expected_filters['owner'] = random_project
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_lessee_context, admin_lesseeproject,
-            owner=random_project)
+            owner=random_project,
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         # admin owner
         expected_filters['owner'] = random_project
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_owner_context, admin_ownerproject,
-            owner=random_project)
+            owner=random_project,
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         # owner lessee
         expected_filters['owner'] = owner_lesseeproject
         filters = ContractsController._contract_get_all_authorize_filters(
             owner_lessee_context, owner_lesseeproject,
-            owner=owner_lesseeproject)
+            owner=owner_lesseeproject,
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         self.assertRaises(policy.PolicyNotAuthorized,
                           ContractsController.
                           _contract_get_all_authorize_filters,
                           owner_lessee_context, owner_lesseeproject,
-                          owner=random_project)
+                          owner=random_project,
+                          status='random')
 
         # admin lessee owner
         expected_filters['owner'] = admin_owner_lesseeproject
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_owner_context, admin_owner_lesseeproject,
-            owner=admin_owner_lesseeproject)
+            owner=admin_owner_lesseeproject,
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         expected_filters['owner'] = random_project
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_owner_context, admin_owner_lesseeproject,
-            owner=random_project)
+            owner=random_project,
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         # random
@@ -302,24 +325,28 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
                           ContractsController.
                           _contract_get_all_authorize_filters,
                           random_context, random_project,
-                          owner=random_project)
+                          owner=random_project,
+                          status='random')
 
         # owner w/ project_id
         expected_filters['owner'] = owner_project
         expected_filters['project_id'] = random_project
         filters = ContractsController._contract_get_all_authorize_filters(
             owner_context, owner_project,
-            owner=owner_project, project_id=random_project)
+            owner=owner_project, project_id=random_project, status='random')
         self.assertEqual(expected_filters, filters)
 
     def test_contract_get_all_all_view(self):
 
-        expected_filters = {}
+        expected_filters = {
+            'status': 'random'
+        }
 
         # admin
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_context, admin_project,
-            view='all')
+            view='all',
+            status='random')
         self.assertEqual(expected_filters, filters)
 
         # not admin
@@ -327,7 +354,8 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
                           ContractsController.
                           _contract_get_all_authorize_filters,
                           owner_lessee_context, owner_lesseeproject,
-                          view='all')
+                          view='all',
+                          status='random')
 
     def test_contract_get_all_all_view_times(self):
 
@@ -335,6 +363,7 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
         end = datetime.datetime(2020, 7, 16, 19, 20, 30)
 
         expected_filters = {
+            'status': 'random',
             'start_time': start,
             'end_time': end
         }
@@ -342,17 +371,34 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
         # admin
         filters = ContractsController._contract_get_all_authorize_filters(
             admin_context, admin_project,
-            view='all', start_time=start, end_time=end)
+            view='all', start_time=start, end_time=end, status='random')
         self.assertEqual(expected_filters, filters)
 
         self.assertRaises(exception.InvalidTimeAPICommand,
                           ContractsController.
                           _contract_get_all_authorize_filters,
                           admin_context, admin_project,
-                          view='all', start_time=start)
+                          view='all', start_time=start, status='random')
 
         self.assertRaises(exception.InvalidTimeAPICommand,
                           ContractsController.
                           _contract_get_all_authorize_filters,
                           admin_context, admin_project,
-                          view='all', end_time=end)
+                          view='all', end_time=end, status='random')
+
+    def test_contract_get_all_status(self):
+
+        expected_filters = {
+            'project_id': 'adminid',
+            'status': ['created', 'active']
+        }
+
+        # admin
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_context, admin_project)
+        self.assertEqual(expected_filters, filters)
+
+        del(expected_filters['status'])
+        filters = ContractsController._contract_get_all_authorize_filters(
+            admin_context, admin_project, status='any')
+        self.assertEqual(expected_filters, filters)

--- a/esi_leap/tests/db/sqlalchemy/test_api.py
+++ b/esi_leap/tests/db/sqlalchemy/test_api.py
@@ -13,36 +13,53 @@
 import datetime
 
 from esi_leap.common import exception as e
+from esi_leap.common import statuses
 from esi_leap.db.sqlalchemy import api
 import esi_leap.tests.base as base
 
 now = datetime.datetime(2016, 7, 16, 19, 20, 30)
 
 test_offer_1 = dict(
+    uuid='abc123',
     project_id='0wn3r',
     resource_uuid='1111',
     resource_type='dummy_node',
     start_time=now,
     end_time=now + datetime.timedelta(days=100),
     properties={'foo': 'bar'},
+    status=statuses.AVAILABLE,
 )
 
 test_contract_1 = dict(
+    uuid='11111',
     project_id='1e5533',
     start_time=now + datetime.timedelta(days=10),
     end_time=now + datetime.timedelta(days=20),
+    status=statuses.CREATED,
 )
 
 test_contract_2 = dict(
+    uuid='22222',
     project_id='1e5533',
     start_time=now + datetime.timedelta(days=20),
     end_time=now + datetime.timedelta(days=30),
+    status=statuses.CREATED,
 )
 
 test_contract_3 = dict(
+    uuid='33333',
     project_id='1e5533',
     start_time=now + datetime.timedelta(days=50),
     end_time=now + datetime.timedelta(days=60),
+    status=statuses.ACTIVE,
+)
+
+test_contract_4 = dict(
+    uuid='44444',
+    project_id='1e5533',
+    start_time=now + datetime.timedelta(days=85),
+    end_time=now + datetime.timedelta(days=90),
+    status=statuses.CANCELLED,
 )
 
 
@@ -91,63 +108,69 @@ class TestAPI(base.DBTestCase):
 
         start = now + datetime.timedelta(days=15)
         end = now + datetime.timedelta(days=16)
-        self.assertRaises(e.OfferNotAvailable, api.offer_verify_availability,
-                          offer, start, end)
+        self.assertRaises(e.OfferNoTimeAvailabilities,
+                          api.offer_verify_availability, offer, start, end)
 
         start = now + datetime.timedelta(days=45)
         end = now + datetime.timedelta(days=55)
-        self.assertRaises(e.OfferNotAvailable, api.offer_verify_availability,
-                          offer, start, end)
+        self.assertRaises(e.OfferNoTimeAvailabilities,
+                          api.offer_verify_availability, offer, start, end)
 
         start = now + datetime.timedelta(days=55)
         end = now + datetime.timedelta(days=65)
-        self.assertRaises(e.OfferNotAvailable, api.offer_verify_availability,
-                          offer, start, end)
+        self.assertRaises(e.OfferNoTimeAvailabilities,
+                          api.offer_verify_availability, offer, start, end)
 
         start = now + datetime.timedelta(days=50)
         end = now + datetime.timedelta(days=65)
-        self.assertRaises(e.OfferNotAvailable, api.offer_verify_availability,
-                          offer, start, end)
+        self.assertRaises(e.OfferNoTimeAvailabilities,
+                          api.offer_verify_availability, offer, start, end)
 
         start = now + datetime.timedelta(days=45)
         end = now + datetime.timedelta(days=60)
-        self.assertRaises(e.OfferNotAvailable, api.offer_verify_availability,
-                          offer, start, end)
+        self.assertRaises(e.OfferNoTimeAvailabilities,
+                          api.offer_verify_availability, offer, start, end)
 
         start = now + datetime.timedelta(days=90)
         end = now + datetime.timedelta(days=105)
-        self.assertRaises(e.OfferNotAvailable, api.offer_verify_availability,
-                          offer, start, end)
+        self.assertRaises(e.OfferNoTimeAvailabilities,
+                          api.offer_verify_availability, offer, start, end)
 
         start = now + datetime.timedelta(days=100)
         end = now + datetime.timedelta(days=105)
-        self.assertRaises(e.OfferNotAvailable, api.offer_verify_availability,
-                          offer, start, end)
+        self.assertRaises(e.OfferNoTimeAvailabilities,
+                          api.offer_verify_availability, offer, start, end)
 
         start = now + datetime.timedelta(days=105)
         end = now + datetime.timedelta(days=110)
-        self.assertRaises(e.OfferNotAvailable, api.offer_verify_availability,
-                          offer, start, end)
+        self.assertRaises(e.OfferNoTimeAvailabilities,
+                          api.offer_verify_availability, offer, start, end)
 
         start = now - datetime.timedelta(days=1)
         end = now + datetime.timedelta(days=5)
-        self.assertRaises(e.OfferNotAvailable, api.offer_verify_availability,
-                          offer, start, end)
+        self.assertRaises(e.OfferNoTimeAvailabilities,
+                          api.offer_verify_availability, offer, start, end)
 
         start = now - datetime.timedelta(days=1)
         end = now
-        self.assertRaises(e.OfferNotAvailable, api.offer_verify_availability,
-                          offer, start, end)
+        self.assertRaises(e.OfferNoTimeAvailabilities,
+                          api.offer_verify_availability, offer, start, end)
 
         start = now - datetime.timedelta(days=10)
         end = now - datetime.timedelta(days=5)
-        self.assertRaises(e.OfferNotAvailable, api.offer_verify_availability,
-                          offer, start, end)
+        self.assertRaises(e.OfferNoTimeAvailabilities,
+                          api.offer_verify_availability, offer, start, end)
 
         start = now + datetime.timedelta(days=45)
         end = now + datetime.timedelta(days=55)
-        self.assertRaises(e.OfferNotAvailable, api.offer_verify_availability,
-                          offer, start, end)
+        self.assertRaises(e.OfferNoTimeAvailabilities,
+                          api.offer_verify_availability, offer, start, end)
+
+        test_contract_4['offer_uuid'] = offer.uuid
+        api.contract_create(test_contract_4)
+        start = now + datetime.timedelta(days=86)
+        end = now + datetime.timedelta(days=87)
+        api.offer_verify_availability(offer, start, end)
 
     def test_offer_get(self):
 
@@ -159,5 +182,4 @@ class TestAPI(base.DBTestCase):
 
     def test_offer_get_not_found(self):
 
-        self.assertRaises(e.OfferNotFound,
-                          api.offer_get, 'some_uuid')
+        self.assertRaises(e.OfferNotFound, api.offer_get, 'some_uuid')

--- a/esi_leap/tests/objects/test_offer.py
+++ b/esi_leap/tests/objects/test_offer.py
@@ -138,24 +138,30 @@ class TestOfferObject(base.DBTestCase):
             self.context, **self.fake_offer)
         with mock.patch.object(self.db_api, 'offer_create',
                                autospec=True) as mock_offer_create:
-            mock_offer_create.return_value = get_test_offer()
-            o.create(self.context)
-            mock_offer_create.assert_called_once_with(
-                get_test_offer())
+            with mock.patch(
+                    'esi_leap.objects.offer.uuidutils.generate_uuid') \
+                    as mock_uuid:
+                mock_uuid.return_value = '534653c9-880d-4c2d-6d6d-' \
+                                         'f4f2a09e384'
+                mock_offer_create.return_value = get_test_offer()
+
+                o.create(self.context)
+                mock_offer_create.assert_called_once_with(
+                    get_test_offer())
 
     def test_destroy(self):
         o = offer.Offer(self.context, **self.fake_offer)
         with mock.patch.object(self.db_api, 'offer_destroy',
-                               autospec=True) as mock_offer_destroy:
+                               autospec=True) as mock_offer_cancel:
 
             o.destroy()
 
-            mock_offer_destroy.assert_called_once_with(
+            mock_offer_cancel.assert_called_once_with(
                 o.uuid)
 
     def test_save(self):
         o = offer.Offer(self.context, **self.fake_offer)
-        new_status = statuses.CLAIMED
+        new_status = statuses.CANCELLED
         updated_at = datetime.datetime(2006, 12, 11, 0, 0)
         with mock.patch.object(self.db_api, 'offer_update',
                                autospec=True) as mock_offer_update:


### PR DESCRIPTION
Changed the way the DELETE requets on offers and contracts
function. Instead of deleting the object from the database,
we instead change the object's status to a new 'cancelled'
status. Additionally, cancelling an offer will cancel all
associated contracts and free up the availability on the offer.