### PR TITLE
Offer and contract api no longer can set project_id

### DIFF
--- a/esi_leap/api/controllers/v1/offer.py
+++ b/esi_leap/api/controllers/v1/offer.py
@@ -29,7 +29,7 @@ from esi_leap.resource_objects import resource_object_factory as ro_factory
 class Offer(base.ESILEAPBase):
 
     uuid = wsme.wsattr(wtypes.text, readonly=True)
-    project_id = wsme.wsattr(wtypes.text)
+    project_id = wsme.wsattr(wtypes.text, readonly=True)
     resource_type = wsme.wsattr(wtypes.text, mandatory=True)
     resource_uuid = wsme.wsattr(wtypes.text, mandatory=True)
     start_time = wsme.wsattr(datetime.datetime)
@@ -141,12 +141,7 @@ class OffersController(rest.RestController):
         policy.authorize('esi_leap:offer:create', cdict, cdict)
 
         offer_dict = new_offer.to_dict()
-
-        if 'project_id' in offer_dict:
-            if offer_dict['project_id'] != request.project_id:
-                policy.authorize('esi_leap:offer:offer_admin', cdict, cdict)
-        else:
-            offer_dict['project_id'] = request.project_id
+        offer_dict['project_id'] = request.project_id
 
         OffersController._verify_resource_permission(cdict, offer_dict)
 

--- a/esi_leap/tests/api/base.py
+++ b/esi_leap/tests/api/base.py
@@ -11,6 +11,7 @@
 #    under the License.
 
 import datetime
+import mock
 import pecan
 import pecan.testing
 
@@ -57,8 +58,14 @@ class APITestCase(base.DBTestCase):
                           group='pecan')
 
         self.app = pecan.testing.load_test_app(
-            dict(app.get_pecan_config())
+            dict(app.get_pecan_config()))
+
+        self.patch_context = mock.patch(
+            'oslo_context.context.RequestContext.from_environ'
         )
+        self.mock_context = self.patch_context.start()
+
+        self.mock_context.return_value = self.context
 
     # borrowed from Ironic
     def get_json(self, path, expect_errors=False, headers=None,

--- a/esi_leap/tests/api/controllers/v1/test_contract.py
+++ b/esi_leap/tests/api/controllers/v1/test_contract.py
@@ -22,58 +22,36 @@ from esi_leap.objects import contract
 from esi_leap.tests.api import base as test_api_base
 
 
-admin_context = ctx.RequestContext()
-admin_context.roles = ['admin']
-admin_context = admin_context.to_policy_values()
-admin_project = 'adminid'
+admin_ctx = ctx.RequestContext(project_id='adminid',
+                               roles=['admin'])
+admin_ctx_dict = admin_ctx.to_policy_values()
 
-owner_context = ctx.RequestContext()
-owner_context.roles = ['owner']
-owner_context = owner_context.to_policy_values()
-owner_project = "ownerid"
+owner_ctx = ctx.RequestContext(project_id='ownerid',
+                               roles=['owner'])
+owner_ctx_dict = owner_ctx.to_policy_values()
 
-lessee_context = ctx.RequestContext()
-lessee_context.roles = ['lessee']
-lessee_context = lessee_context.to_policy_values()
-lessee_project = 'lesseeid'
+lessee_ctx = ctx.RequestContext(project_id="lesseeid",
+                                roles=['lessee'])
+lessee_ctx_dict = lessee_ctx.to_policy_values()
 
-admin_owner_context = ctx.RequestContext()
-admin_owner_context.roles = ['admin', 'owner']
-admin_owner_context = admin_owner_context.to_policy_values()
-admin_ownerproject = 'admin_ownerid'
-
-admin_lessee_context = ctx.RequestContext()
-admin_lessee_context.roles = ['admin', 'lessee']
-admin_lessee_context = admin_lessee_context.to_policy_values()
-admin_lesseeproject = 'admin_lesseeid'
-
-owner_lessee_context = ctx.RequestContext()
-owner_lessee_context.roles = ['owner', 'lessee']
-owner_lessee_context = owner_lessee_context.to_policy_values()
-owner_lesseeproject = 'owner_lesseeid'
-
-admin_owner_lessee_context = ctx.RequestContext()
-admin_owner_lessee_context.roles = ['admin', 'owner', 'lessee']
-admin_owner_lessee_context = admin_owner_lessee_context.to_policy_values()
-admin_owner_lesseeproject = 'admin_owner_lesseeid'
-
-random_context = ctx.RequestContext()
-random_context.roles = ['randomrole']
-random_context = random_context.to_policy_values()
-random_project = 'randomid'
+random_ctx = ctx.RequestContext(project_id='randomid',
+                                roles=['randomrole'])
+random_ctx_dict = random_ctx.to_policy_values()
 
 
 def create_test_contract_data():
     return {
-        "project_id": "some_id",
         "offer_uuid": "some_uuid",
-        "end_time": "2020-07-25T00:00:00"
+        "start_time": "2016-07-16T19:20:30",
+        "end_time": "2016-08-16T19:20:30"
     }
 
 
 class TestContractsControllerAdmin(test_api_base.APITestCase):
 
     def setUp(self):
+
+        self.context = lessee_ctx
 
         super(TestContractsControllerAdmin, self).setUp()
 
@@ -84,7 +62,7 @@ class TestContractsControllerAdmin(test_api_base.APITestCase):
             end_date=datetime.datetime(2016, 8, 16, 19, 20, 30),
             uuid='1111111111',
             offer_uuid=o.uuid,
-            project_id="222222222222"
+            project_id=lessee_ctx.project_id
         )
 
     def test_empty(self):
@@ -103,9 +81,12 @@ class TestContractsControllerAdmin(test_api_base.APITestCase):
     def test_post(self, mock_create):
 
         mock_create.return_value = self.test_contract
+
         data = create_test_contract_data()
         request = self.post_json('/contracts', data)
         self.assertEqual(1, mock_create.call_count)
+
+        data['project_id'] = lessee_ctx.project_id
         self.assertEqual(request.json, data)
         # FIXME: post returns incorrect status code
         # self.assertEqual(http_client.CREATED, request.status_int)
@@ -121,37 +102,23 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
         }
 
         # admin
-        expected_filters['project_id'] = admin_project
+        expected_filters['project_id'] = admin_ctx_dict['project_id']
         filters = ContractsController._contract_get_all_authorize_filters(
-            admin_context, admin_project,
+            admin_ctx_dict,
             status='random', offer_uuid='offeruuid')
         self.assertEqual(expected_filters, filters)
 
-        expected_filters['project_id'] = admin_lesseeproject
+        # owner
+        expected_filters['project_id'] = owner_ctx.project_id
         filters = ContractsController._contract_get_all_authorize_filters(
-            admin_lessee_context, admin_lesseeproject,
+            owner_ctx_dict,
             status='random', offer_uuid='offeruuid')
         self.assertEqual(expected_filters, filters)
 
-        # admin owner
-        expected_filters['project_id'] = admin_ownerproject
+        # lessee
+        expected_filters['project_id'] = lessee_ctx.project_id
         filters = ContractsController._contract_get_all_authorize_filters(
-            admin_owner_context, admin_ownerproject,
-            status='random', offer_uuid='offeruuid')
-        self.assertEqual(expected_filters, filters)
-
-        # owner lessee
-        expected_filters['project_id'] = owner_lesseeproject
-        filters = ContractsController._contract_get_all_authorize_filters(
-            owner_lessee_context, owner_lesseeproject,
-            status='random', offer_uuid='offeruuid')
-        self.assertEqual(expected_filters, filters)
-
-        # admin lessee owner
-        expected_filters['project_id'] = admin_owner_lesseeproject
-        filters = ContractsController._contract_get_all_authorize_filters(
-            admin_owner_lessee_context,
-            admin_owner_lesseeproject,
+            lessee_ctx_dict,
             status='random', offer_uuid='offeruuid')
         self.assertEqual(expected_filters, filters)
 
@@ -159,7 +126,7 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
         self.assertRaises(policy.PolicyNotAuthorized,
                           ContractsController.
                           _contract_get_all_authorize_filters,
-                          random_context, random_project,
+                          random_ctx_dict,
                           status='random', offer_uuid='offeruuid')
 
     def test_contract_get_all_no_view_project_no_owner(self):
@@ -169,88 +136,56 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
         }
 
         # admin
-        expected_filters['project_id'] = admin_project
+        expected_filters['project_id'] = admin_ctx_dict['project_id']
         filters = ContractsController._contract_get_all_authorize_filters(
-            admin_context, admin_project,
-            project_id=admin_project,
+            admin_ctx_dict,
+            project_id=admin_ctx_dict['project_id'],
             status='random')
         self.assertEqual(expected_filters, filters)
 
-        expected_filters['project_id'] = random_project
+        expected_filters['project_id'] = random_ctx.project_id
         filters = ContractsController._contract_get_all_authorize_filters(
-            admin_context, admin_project,
-            project_id=random_project,
+            admin_ctx_dict,
+            project_id=random_ctx.project_id,
             status='random')
         self.assertEqual(expected_filters, filters)
 
-        # admin lessee
-        expected_filters['project_id'] = admin_lesseeproject
+        # lessee
+        expected_filters['project_id'] = lessee_ctx.project_id
         filters = ContractsController._contract_get_all_authorize_filters(
-            admin_lessee_context, admin_lesseeproject,
-            project_id=admin_lesseeproject,
-            status='random')
-        self.assertEqual(expected_filters, filters)
-
-        expected_filters['project_id'] = random_project
-        filters = ContractsController._contract_get_all_authorize_filters(
-            admin_lessee_context, admin_lesseeproject,
-            project_id=random_project,
-            status='random')
-        self.assertEqual(expected_filters, filters)
-
-        # admin owner
-        expected_filters['project_id'] = admin_ownerproject
-        filters = ContractsController._contract_get_all_authorize_filters(
-            admin_owner_context, admin_ownerproject,
-            project_id=admin_ownerproject,
-            status='random')
-        self.assertEqual(expected_filters, filters)
-
-        expected_filters['project_id'] = random_project
-        filters = ContractsController._contract_get_all_authorize_filters(
-            admin_owner_context, admin_ownerproject,
-            project_id=random_project,
-            status='random')
-        self.assertEqual(expected_filters, filters)
-
-        # owner lessee
-        expected_filters['project_id'] = owner_lesseeproject
-        filters = ContractsController._contract_get_all_authorize_filters(
-            owner_lessee_context, owner_lesseeproject,
-            project_id=owner_lesseeproject,
+            lessee_ctx_dict,
+            project_id=lessee_ctx.project_id,
             status='random')
         self.assertEqual(expected_filters, filters)
 
         self.assertRaises(policy.PolicyNotAuthorized,
                           ContractsController.
                           _contract_get_all_authorize_filters,
-                          owner_lessee_context, owner_lesseeproject,
-                          project_id=random_project,
+                          lessee_ctx_dict,
+                          project_id=random_ctx.project_id,
                           status='random')
 
-        # admin lessee owner
-        expected_filters['project_id'] = admin_owner_lesseeproject
+        # owner
+        expected_filters['project_id'] = owner_ctx.project_id
         filters = ContractsController._contract_get_all_authorize_filters(
-            admin_owner_lessee_context,
-            admin_owner_lesseeproject,
-            project_id=admin_owner_lesseeproject,
+            owner_ctx_dict,
+            project_id=owner_ctx.project_id,
             status='random')
         self.assertEqual(expected_filters, filters)
 
-        expected_filters['project_id'] = random_project
-        filters = ContractsController._contract_get_all_authorize_filters(
-            admin_owner_lessee_context,
-            admin_owner_lesseeproject,
-            project_id=random_project,
-            status='random')
-        self.assertEqual(expected_filters, filters)
+        self.assertRaises(policy.PolicyNotAuthorized,
+                          ContractsController.
+                          _contract_get_all_authorize_filters,
+                          lessee_ctx_dict,
+                          project_id=random_ctx.project_id,
+                          status='random')
 
         # random
         self.assertRaises(policy.PolicyNotAuthorized,
                           ContractsController.
                           _contract_get_all_authorize_filters,
-                          random_context, random_project,
-                          project_id=random_project,
+                          random_ctx_dict,
+                          project_id=random_ctx.project_id,
                           status='random')
 
     def test_contract_get_all_no_view_any_projectid_owner(self):
@@ -260,63 +195,64 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
         }
 
         # admin
-        expected_filters['owner'] = admin_project
+        expected_filters['owner'] = admin_ctx_dict['project_id']
         filters = ContractsController._contract_get_all_authorize_filters(
-            admin_context, admin_project,
-            owner=admin_project,
+            admin_ctx_dict,
+            owner=admin_ctx_dict['project_id'],
             status='random')
         self.assertEqual(expected_filters, filters)
 
-        expected_filters['owner'] = random_project
+        expected_filters['owner'] = random_ctx.project_id
         filters = ContractsController._contract_get_all_authorize_filters(
-            admin_context, admin_project,
-            owner=random_project,
+            admin_ctx_dict,
+            owner=random_ctx.project_id,
             status='random')
         self.assertEqual(expected_filters, filters)
 
-        # admin lessee
-        expected_filters['owner'] = random_project
+        # lessee
+        expected_filters['owner'] = lessee_ctx.project_id
         filters = ContractsController._contract_get_all_authorize_filters(
-            admin_lessee_context, admin_lesseeproject,
-            owner=random_project,
-            status='random')
-        self.assertEqual(expected_filters, filters)
-
-        # admin owner
-        expected_filters['owner'] = random_project
-        filters = ContractsController._contract_get_all_authorize_filters(
-            admin_owner_context, admin_ownerproject,
-            owner=random_project,
-            status='random')
-        self.assertEqual(expected_filters, filters)
-
-        # owner lessee
-        expected_filters['owner'] = owner_lesseeproject
-        filters = ContractsController._contract_get_all_authorize_filters(
-            owner_lessee_context, owner_lesseeproject,
-            owner=owner_lesseeproject,
+            lessee_ctx_dict,
+            owner=lessee_ctx.project_id,
             status='random')
         self.assertEqual(expected_filters, filters)
 
         self.assertRaises(policy.PolicyNotAuthorized,
                           ContractsController.
                           _contract_get_all_authorize_filters,
-                          owner_lessee_context, owner_lesseeproject,
-                          owner=random_project,
+                          lessee_ctx_dict,
+                          owner=random_ctx.project_id,
                           status='random')
 
-        # admin lessee owner
-        expected_filters['owner'] = admin_owner_lesseeproject
+        expected_filters['owner'] = lessee_ctx.project_id
+        expected_filters['project_id'] = random_ctx.project_id
         filters = ContractsController._contract_get_all_authorize_filters(
-            admin_owner_context, admin_owner_lesseeproject,
-            owner=admin_owner_lesseeproject,
+            lessee_ctx_dict,
+            owner=lessee_ctx.project_id, project_id=random_ctx.project_id,
+            status='random')
+        self.assertEqual(expected_filters, filters)
+        del expected_filters['project_id']
+
+        # owner
+        expected_filters['owner'] = owner_ctx.project_id
+        filters = ContractsController._contract_get_all_authorize_filters(
+            owner_ctx_dict,
+            owner=owner_ctx.project_id,
             status='random')
         self.assertEqual(expected_filters, filters)
 
-        expected_filters['owner'] = random_project
+        self.assertRaises(policy.PolicyNotAuthorized,
+                          ContractsController.
+                          _contract_get_all_authorize_filters,
+                          lessee_ctx_dict,
+                          owner=random_ctx.project_id,
+                          status='random')
+
+        expected_filters['owner'] = owner_ctx_dict['project_id']
+        expected_filters['project_id'] = random_ctx.project_id
         filters = ContractsController._contract_get_all_authorize_filters(
-            admin_owner_context, admin_owner_lesseeproject,
-            owner=random_project,
+            owner_ctx_dict,
+            owner=owner_ctx.project_id, project_id=random_ctx.project_id,
             status='random')
         self.assertEqual(expected_filters, filters)
 
@@ -324,17 +260,9 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
         self.assertRaises(policy.PolicyNotAuthorized,
                           ContractsController.
                           _contract_get_all_authorize_filters,
-                          random_context, random_project,
-                          owner=random_project,
+                          random_ctx_dict,
+                          owner=random_ctx.project_id,
                           status='random')
-
-        # owner w/ project_id
-        expected_filters['owner'] = owner_project
-        expected_filters['project_id'] = random_project
-        filters = ContractsController._contract_get_all_authorize_filters(
-            owner_context, owner_project,
-            owner=owner_project, project_id=random_project, status='random')
-        self.assertEqual(expected_filters, filters)
 
     def test_contract_get_all_all_view(self):
 
@@ -344,7 +272,7 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
 
         # admin
         filters = ContractsController._contract_get_all_authorize_filters(
-            admin_context, admin_project,
+            admin_ctx_dict,
             view='all',
             status='random')
         self.assertEqual(expected_filters, filters)
@@ -353,7 +281,21 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
         self.assertRaises(policy.PolicyNotAuthorized,
                           ContractsController.
                           _contract_get_all_authorize_filters,
-                          owner_lessee_context, owner_lesseeproject,
+                          lessee_ctx_dict,
+                          view='all',
+                          status='random')
+
+        self.assertRaises(policy.PolicyNotAuthorized,
+                          ContractsController.
+                          _contract_get_all_authorize_filters,
+                          owner_ctx_dict,
+                          view='all',
+                          status='random')
+
+        self.assertRaises(policy.PolicyNotAuthorized,
+                          ContractsController.
+                          _contract_get_all_authorize_filters,
+                          random_ctx_dict,
                           view='all',
                           status='random')
 
@@ -370,20 +312,20 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
 
         # admin
         filters = ContractsController._contract_get_all_authorize_filters(
-            admin_context, admin_project,
+            admin_ctx_dict,
             view='all', start_time=start, end_time=end, status='random')
         self.assertEqual(expected_filters, filters)
 
         self.assertRaises(exception.InvalidTimeAPICommand,
                           ContractsController.
                           _contract_get_all_authorize_filters,
-                          admin_context, admin_project,
+                          admin_ctx_dict,
                           view='all', start_time=start, status='random')
 
         self.assertRaises(exception.InvalidTimeAPICommand,
                           ContractsController.
                           _contract_get_all_authorize_filters,
-                          admin_context, admin_project,
+                          admin_ctx_dict,
                           view='all', end_time=end, status='random')
 
     def test_contract_get_all_status(self):
@@ -395,10 +337,10 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
 
         # admin
         filters = ContractsController._contract_get_all_authorize_filters(
-            admin_context, admin_project)
+            admin_ctx_dict)
         self.assertEqual(expected_filters, filters)
 
         del(expected_filters['status'])
         filters = ContractsController._contract_get_all_authorize_filters(
-            admin_context, admin_project, status='any')
+            admin_ctx_dict, status='any')
         self.assertEqual(expected_filters, filters)

--- a/esi_leap/tests/api/controllers/v1/test_offer.py
+++ b/esi_leap/tests/api/controllers/v1/test_offer.py
@@ -10,9 +10,15 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import datetime
+import mock
+from oslo_context import context as ctx
+
 from esi_leap.objects import offer
 from esi_leap.tests.api import base as test_api_base
-import mock
+
+
+owner_ctx = ctx.RequestContext(project_id='ownerid',
+                               roles=['owner'])
 
 
 def create_test_offer_data():
@@ -22,20 +28,22 @@ def create_test_offer_data():
         "resource_uuid": "1234567890",
         "start_time": "2016-07-16T19:20:30",
         "end_time": "2016-08-16T19:20:30",
-        "project_id": "111111111111"
     }
 
 
 class TestListOffers(test_api_base.APITestCase):
 
     def setUp(self):
+
+        self.context = owner_ctx
+
         super(TestListOffers, self).setUp()
         self.test_offer = offer.Offer(
             resource_type='test_node',
             resource_uuid='1234567890',
             start_time=datetime.datetime(2016, 7, 16, 19, 20, 30),
             end_time=datetime.datetime(2016, 8, 16, 19, 20, 30),
-            project_id="111111111111"
+            project_id=owner_ctx.project_id
         )
 
     def test_empty(self):
@@ -58,6 +66,7 @@ class TestListOffers(test_api_base.APITestCase):
         mock_create.return_value = self.test_offer
         data = create_test_offer_data()
         request = self.post_json('/offers', data)
+        data['project_id'] = owner_ctx.project_id
         self.assertEqual(1, mock_create.call_count)
         self.assertEqual(request.json, {})
         # FIXME: post returns incorrect status code

--- a/esi_leap/tests/base.py
+++ b/esi_leap/tests/base.py
@@ -40,11 +40,13 @@ class TestCase(base.BaseTestCase):
 
     def setUp(self):
         super(TestCase, self).setUp()
-        self.context = ctx.RequestContext(
-            auth_token=None,
-            project_id='12345',
-            is_admin=True,
-            overwrite=False)
+
+        if not hasattr(self, 'context'):
+            self.context = ctx.RequestContext(
+                auth_token=None,
+                project_id='12345',
+                is_admin=True,
+                overwrite=False)
 
 
 class DBTestCase(TestCase):


### PR DESCRIPTION
Updated the offer and contract api to disallow setting
the project_id. This is to make esi-leap more consistent
with other openstack services and to prevent vague ownership
conditions. project_id is now a read only variable in both apis.