### PR TITLE
Changed owner url variable to set itself to project_id

### DIFF
--- a/esi_leap/api/controllers/v1/contract.py
+++ b/esi_leap/api/controllers/v1/contract.py
@@ -149,11 +149,13 @@ class ContractsController(rest.RestController):
             policy.authorize('esi_leap:contract:get', cdict, cdict)
 
             if owner:
-                if r_project_id != owner:
-                    policy.authorize('esi_leap:contract:contract_admin',
-                                     cdict, cdict)
-
-                possible_filters['owner'] = owner
+                if owner == 'self':
+                    possible_filters['owner'] = cdict['project_id']
+                else:
+                    if r_project_id != owner:
+                        policy.authorize('esi_leap:contract:contract_admin',
+                                         cdict, cdict)
+                    possible_filters['owner'] = owner
                 possible_filters['project_id'] = project_id
             else:
 


### PR DESCRIPTION
The url variable when se to the value 'self' will set to the
project_id of the requester. This makes it so the user does
not have to enter their project_id every time they want to do
a related contracts request.