### PR TITLE
Added names for api objects

### DIFF
--- a/esi_leap/common/exception.py
+++ b/esi_leap/common/exception.py
@@ -42,8 +42,12 @@ class ContractNoPermission(ESILeapException):
                 "contract %(contract_uuid)s.")
 
 
+class ContractDuplicateName(ESILeapException):
+    msg_fmt = _("Duplicate contracts with name %(name)s.")
+
+
 class ContractNotFound(ESILeapException):
-    msg_fmt = _("Contract %(contract_uuid)s not found.")
+    msg_fmt = _("Contract with name or uuid %(contract_id)s not found.")
 
 
 class ContractNoOfferUUID(ESILeapException):
@@ -55,8 +59,12 @@ class OfferNoPermission(ESILeapException):
                 "offer %(offer_uuid)s.")
 
 
+class OfferDuplicateName(ESILeapException):
+    msg_fmt = _("Duplicate offers with name %(name)s.")
+
+
 class OfferNotFound(ESILeapException):
-    msg_fmt = _("Offer %(offer_uuid)s not found.")
+    msg_fmt = _("Offer with name or uuid %(offer_uuid)s not found.")
 
 
 class OfferNoTimeAvailabilities(ESILeapException):

--- a/esi_leap/db/api.py
+++ b/esi_leap/db/api.py
@@ -90,8 +90,13 @@ def to_dict(func):
 
 # Offer
 @to_dict
-def offer_get(offer_uuid):
-    return IMPL.offer_get(offer_uuid)
+def offer_get_by_uuid(offer_uuid):
+    return IMPL.offer_get_by_uuid(offer_uuid)
+
+
+@to_dict
+def offer_get_by_name(offer_name):
+    return IMPL.offer_get(offer_name)
 
 
 @to_dict
@@ -123,8 +128,13 @@ def offer_destroy(offer_uuid):
 
 # Contract
 @to_dict
-def contract_get(contract_uuid):
+def contract_get_by_uuid(contract_uuid):
     return IMPL.contract_get(contract_uuid)
+
+
+@to_dict
+def contract_get_by_name(contract_name):
+    return IMPL.contract_get(contract_name)
 
 
 @to_dict

--- a/esi_leap/db/sqlalchemy/api.py
+++ b/esi_leap/db/sqlalchemy/api.py
@@ -116,13 +116,16 @@ class InequalityCondition(object):
 
 
 # Offer
-def offer_get(offer_uuid):
+def offer_get_by_uuid(offer_uuid):
     query = model_query(models.Offer, get_session())
     offer_ref = query.filter_by(uuid=offer_uuid).one_or_none()
-    if not offer_ref:
-        raise exception.OfferNotFound(offer_uuid=offer_uuid)
-
     return offer_ref
+
+
+def offer_get_by_name(name):
+    query = model_query(models.Offer, get_session())
+    offers = query.filter_by(name=name).all()
+    return offers
 
 
 def offer_get_all(filters):
@@ -257,14 +260,16 @@ def offer_destroy(offer_uuid):
 
 
 # Contracts
-def contract_get(contract_uuid):
+def contract_get_by_uuid(contract_uuid):
     query = model_query(models.Contract, get_session())
-
     result = query.filter_by(uuid=contract_uuid).one_or_none()
-
-    if not result:
-        raise exception.ContractNotFound(contract_uuid=contract_uuid)
     return result
+
+
+def contract_get_by_name(name):
+    query = model_query(models.Contract, get_session())
+    contracts = query.filter_by(name=name).all()
+    return contracts
 
 
 def contract_get_all(filters):

--- a/esi_leap/db/sqlalchemy/models.py
+++ b/esi_leap/db/sqlalchemy/models.py
@@ -48,6 +48,7 @@ class Offer(Base):
 
     id = Column(Integer, primary_key=True, nullable=False, autoincrement=True)
     uuid = Column(String(36), nullable=False, unique=True)
+    name = Column(String(35), nullable=True, unique=False)
     project_id = Column(String(255), nullable=False)
     resource_type = Column(String(36), nullable=False)
     resource_uuid = Column(String(36), nullable=False)
@@ -69,6 +70,7 @@ class Contract(Base):
 
     id = Column(Integer, primary_key=True, nullable=False, autoincrement=True)
     uuid = Column(String(36), nullable=False, unique=True)
+    name = Column(String(35), nullable=True, unique=False)
     project_id = Column(String(255), nullable=False)
     start_time = Column(DateTime)
     end_time = Column(DateTime)

--- a/esi_leap/objects/offer.py
+++ b/esi_leap/objects/offer.py
@@ -33,6 +33,7 @@ class Offer(base.ESILEAPObject):
 
     fields = {
         'id': fields.IntegerField(),
+        'name': fields.StringField(nullable=True),
         'uuid': fields.UUIDField(),
         'project_id': fields.StringField(),
         'resource_type': fields.StringField(),
@@ -44,9 +45,25 @@ class Offer(base.ESILEAPObject):
     }
 
     @classmethod
-    def get(cls, context, offer_uuid):
-        db_offer = cls.dbapi.offer_get(offer_uuid)
-        return cls._from_db_object(context, cls(), db_offer)
+    def get_by_uuid(cls, offer_uuid, context=None):
+        db_offer = cls.dbapi.offer_get_by_uuid(offer_uuid)
+        if db_offer:
+            return cls._from_db_object(context, cls(), db_offer)
+
+    @classmethod
+    def get_by_name(cls, offer_name, context=None):
+        db_contract = cls.dbapi.offer_get_by_name(offer_name)
+        return cls._from_db_object_list(context, db_contract)
+
+    @classmethod
+    def get(cls, offer_id, context=None):
+        o_uuid = cls.get_by_uuid(offer_id, context)
+        if o_uuid:
+            return [o_uuid]
+
+        o_name = cls.get_by_name(offer_id, context)
+
+        return o_name
 
     @classmethod
     def get_all(cls, context, filters):

--- a/esi_leap/resource_objects/test_node.py
+++ b/esi_leap/resource_objects/test_node.py
@@ -13,14 +13,15 @@
 
 class TestNode(object):
 
-    def __init__(self, uuid):
+    def __init__(self, uuid, project_id='12345'):
         self._uuid = uuid
+        self._project_id = project_id
 
     def get_contract_uuid(self):
         return '12345'
 
     def get_project_id(self):
-        return '12345'
+        return self._project_id
 
     def get_node_config(self):
         return {}
@@ -29,4 +30,4 @@ class TestNode(object):
         return
 
     def is_resource_admin(self, project_id):
-        return True
+        return project_id == self._project_id

--- a/esi_leap/tests/api/controllers/v1/test_offer.py
+++ b/esi_leap/tests/api/controllers/v1/test_offer.py
@@ -12,37 +12,119 @@
 import datetime
 import mock
 from oslo_context import context as ctx
+from oslo_policy import policy
+import testtools
 
+from esi_leap.api.controllers.v1.offer import OffersController
+from esi_leap.common import statuses
 from esi_leap.objects import offer
+from esi_leap.resource_objects.test_node import TestNode
 from esi_leap.tests.api import base as test_api_base
 
 
 owner_ctx = ctx.RequestContext(project_id='ownerid',
-                               roles=['owner'])
+                               roles=['owner'],)
+
+owner_ctx_2 = ctx.RequestContext(project_id='ownerid2',
+                                 roles=['owner'],
+                                 is_admin_project=False)
+
+admin_ctx = ctx.RequestContext(project_id='adminid',
+                               roles=['admin'])
+
+lessee_ctx = ctx.RequestContext(project_id='lesseeid',
+                                roles=['lessee'])
+
+start = datetime.datetime(2016, 7, 16)
+start_iso = '2016-07-16T00:00:00'
+
+end = start + datetime.timedelta(days=100)
+end_iso = '2016-10-24T00:00:00'
 
 
-def create_test_offer_data():
+test_node_1 = TestNode('aaa', owner_ctx.project_id)
+test_node_2 = TestNode('bbb', owner_ctx_2.project_id)
 
+
+def get_offer_response(o):
     return {
-        "resource_type": "test_node",
-        "resource_uuid": "1234567890",
-        "start_time": "2016-07-16T19:20:30",
-        "end_time": "2016-08-16T19:20:30",
+        'resource_type': o.resource_type,
+        'resource_uuid': o.resource_uuid,
+        'name': o.name,
+        'project_id': o.project_id,
+        'start_time': start_iso,
+        'end_time': end_iso,
+        'status': o.status,
+        'availabilities': [],
+        'uuid': o.uuid
     }
+
+
+create_test_offer_data = {
+    "resource_type": "test_node",
+    "resource_uuid": 'aaa',
+    "name": "o",
+    "start_time": str(start),
+    "end_time": str(end),
+}
+
+test_offer = offer.Offer(
+    resource_type='test_node',
+    resource_uuid=test_node_1._uuid,
+    name="o",
+    uuid='11111',
+    status=statuses.AVAILABLE,
+    start_time=start,
+    end_time=end,
+    project_id=owner_ctx.project_id
+)
+
+test_offer_2 = offer.Offer(
+    resource_type='test_node',
+    resource_uuid=test_node_1._uuid,
+    start_time=start,
+    status=statuses.CANCELLED,
+    name="o",
+    uuid='22222',
+    end_time=end,
+    project_id=owner_ctx.project_id
+)
+
+
+test_offer_3 = offer.Offer(
+    resource_type='test_node',
+    resource_uuid=test_node_2._uuid,
+    name="o",
+    uuid='33333',
+    status=statuses.AVAILABLE,
+    start_time=start,
+    end_time=end,
+    project_id=owner_ctx_2.project_id
+)
+
+
+test_offer_4 = offer.Offer(
+    resource_type='test_node',
+    resource_uuid=test_node_2._uuid,
+    name="o2",
+    uuid='44444',
+    status=statuses.AVAILABLE,
+    start_time=start,
+    end_time=end,
+    project_id=owner_ctx_2.project_id
+)
 
 
 class TestListOffers(test_api_base.APITestCase):
 
     def setUp(self):
 
-        self.context = owner_ctx
-
         super(TestListOffers, self).setUp()
         self.test_offer = offer.Offer(
             resource_type='test_node',
             resource_uuid='1234567890',
-            start_time=datetime.datetime(2016, 7, 16, 19, 20, 30),
-            end_time=datetime.datetime(2016, 8, 16, 19, 20, 30),
+            start_time=start,
+            end_time=end,
             project_id=owner_ctx.project_id
         )
 
@@ -64,10 +146,177 @@ class TestListOffers(test_api_base.APITestCase):
     def test_post(self, mock_aoa, mock_vrp, mock_create):
 
         mock_create.return_value = self.test_offer
-        data = create_test_offer_data()
+        data = create_test_offer_data
         request = self.post_json('/offers', data)
         data['project_id'] = owner_ctx.project_id
         self.assertEqual(1, mock_create.call_count)
         self.assertEqual(request.json, {})
         # FIXME: post returns incorrect status code
         # self.assertEqual(http_client.CREATED, request.status_int)
+
+
+class TestOffersControllerOwner(test_api_base.APITestCase):
+
+    def setUp(self):
+        self.context = owner_ctx
+        super(TestOffersControllerOwner, self).setUp()
+
+    @mock.patch('esi_leap.api.controllers.v1.offer.offer.Offer.'
+                'get_availabilities')
+    @mock.patch('esi_leap.api.controllers.v1.offer.offer.Offer.get_all')
+    def test_get_nofilters(self, mock_get_all, mock_get_availabilities):
+
+        mock_get_all.return_value = [test_offer, test_offer_2,
+                                     test_offer_3, test_offer_4]
+        mock_get_availabilities.return_value = []
+
+        expected_filters = {'status': 'available'}
+        expected_resp = {'offers': [get_offer_response(test_offer),
+                                    get_offer_response(test_offer_2),
+                                    get_offer_response(test_offer_3),
+                                    get_offer_response(test_offer_4)]}
+
+        request = self.get_json('/offers')
+
+        mock_get_all.assert_called_once_with(self.context, expected_filters)
+        assert mock_get_availabilities.call_count == 4
+        self.assertEqual(request, expected_resp)
+
+    @mock.patch('esi_leap.api.controllers.v1.offer.offer.Offer.'
+                'get_availabilities')
+    @mock.patch('esi_leap.api.controllers.v1.offer.offer.Offer.get_all')
+    def test_get_any_status(self, mock_get_all, mock_get_availabilities):
+
+        mock_get_all.return_value = [test_offer, test_offer_2,
+                                     test_offer_3, test_offer_4]
+        mock_get_availabilities.return_value = []
+
+        expected_filters = {'status': 'available'}
+        expected_resp = {'offers': [get_offer_response(test_offer),
+                                    get_offer_response(test_offer_2),
+                                    get_offer_response(test_offer_3),
+                                    get_offer_response(test_offer_4)]}
+
+        request = self.get_json('/offers')
+
+        mock_get_all.assert_called_once_with(self.context, expected_filters)
+        assert mock_get_availabilities.call_count == 4
+        self.assertEqual(request, expected_resp)
+
+
+class TestOffersControllerStaticMethods(testtools.TestCase):
+
+    @mock.patch('esi_leap.api.controllers.v1.offer.offer.Offer.'
+                'get_availabilities')
+    def test__add_offer_availabilities(self, mock_get_availabilities):
+        mock_get_availabilities.return_value = []
+
+        o = offer.Offer(
+            resource_type='test_node',
+            resource_uuid='1234567890',
+            name="o",
+            status=statuses.AVAILABLE,
+            start_time=start,
+            end_time=end,
+            project_id=owner_ctx.project_id
+        )
+
+        o_dict = OffersController._add_offer_availabilities(o)
+
+        expected_offer_dict = {
+            'resource_type': o.resource_type,
+            'resource_uuid': o.resource_uuid,
+            'name': o.name,
+            'project_id': o.project_id,
+            'start_time': o.start_time,
+            'end_time': o.end_time,
+            'status': o.status,
+            'availabilities': [],
+        }
+
+        self.assertEqual(o_dict, expected_offer_dict)
+
+    @mock.patch.object(test_node_1, 'is_resource_admin',
+                       return_value=True)
+    @mock.patch('esi_leap.api.controllers.v1.offer.policy.authorize')
+    @mock.patch('esi_leap.api.controllers.v1.offer.ro_factory.'
+                'ResourceObjectFactory.get_resource_object',
+                return_value=test_node_1)
+    def test__verify_resource_permission_owner(self,
+                                               mock_gro,
+                                               mock_authorize,
+                                               mock_is_resource_admin):
+
+        OffersController._verify_resource_permission(
+            owner_ctx.to_policy_values(), test_offer.to_dict())
+
+        mock_gro.assert_called_once_with(
+            test_offer.resource_type,
+            test_offer.resource_uuid)
+        mock_is_resource_admin.assert_called_once_with(test_offer.project_id)
+        assert not mock_authorize.called
+
+    @mock.patch.object(test_node_2, 'is_resource_admin',
+                       return_value=False)
+    @mock.patch('esi_leap.api.controllers.v1.offer.policy.authorize')
+    @mock.patch('esi_leap.api.controllers.v1.offer.ro_factory.'
+                'ResourceObjectFactory.get_resource_object',
+                return_value=test_node_2)
+    def test__verify_resource_permission_invalid_owner(self,
+                                                       mock_gro,
+                                                       mock_authorize,
+                                                       mock_is_resource_admin):
+
+        mock_authorize.side_effect = policy.PolicyNotAuthorized(
+            'esi_leap:offer:offer_admin',
+            owner_ctx.to_dict(), owner_ctx.to_dict())
+
+        bad_test_offer = offer.Offer(
+            resource_type='test_node',
+            resource_uuid=test_node_2._uuid,
+            project_id=owner_ctx.project_id
+        )
+
+        self.assertRaises(policy.PolicyNotAuthorized,
+                          OffersController._verify_resource_permission,
+                          owner_ctx_2.to_policy_values(),
+                          bad_test_offer.to_dict())
+
+        mock_gro.assert_called_once_with(
+            bad_test_offer.resource_type,
+            bad_test_offer.resource_uuid)
+        mock_is_resource_admin.assert_called_once_with(
+            bad_test_offer.project_id)
+        mock_authorize.assert_called_once_with('esi_leap:offer:offer_admin',
+                                               owner_ctx_2.to_policy_values(),
+                                               owner_ctx_2.to_policy_values())
+
+    @mock.patch.object(test_node_2, 'is_resource_admin',
+                       return_value=False)
+    @mock.patch('esi_leap.api.controllers.v1.offer.policy.authorize')
+    @mock.patch('esi_leap.api.controllers.v1.offer.ro_factory.'
+                'ResourceObjectFactory.get_resource_object',
+                return_value=test_node_2)
+    def test__verify_resource_permission_admin(self,
+                                               mock_gro,
+                                               mock_authorize,
+                                               mock_is_resource_admin):
+
+        bad_test_offer = offer.Offer(
+            resource_type='test_node',
+            resource_uuid=test_node_2._uuid,
+            project_id=owner_ctx.project_id
+        )
+
+        assert OffersController._verify_resource_permission(
+            admin_ctx.to_policy_values(),
+            bad_test_offer.to_dict()) is None
+
+        mock_gro.assert_called_once_with(
+            bad_test_offer.resource_type,
+            bad_test_offer.resource_uuid)
+        mock_is_resource_admin.assert_called_once_with(
+            bad_test_offer.project_id)
+        mock_authorize.assert_called_once_with('esi_leap:offer:offer_admin',
+                                               admin_ctx.to_policy_values(),
+                                               admin_ctx.to_policy_values())

--- a/esi_leap/tests/db/sqlalchemy/test_api.py
+++ b/esi_leap/tests/db/sqlalchemy/test_api.py
@@ -20,8 +20,45 @@ import esi_leap.tests.base as base
 now = datetime.datetime(2016, 7, 16, 19, 20, 30)
 
 test_offer_1 = dict(
-    uuid='abc123',
+    uuid='11111',
     project_id='0wn3r',
+    name='o1',
+    resource_uuid='1111',
+    resource_type='dummy_node',
+    start_time=now,
+    end_time=now + datetime.timedelta(days=100),
+    properties={'foo': 'bar'},
+    status=statuses.AVAILABLE,
+)
+
+test_offer_2 = dict(
+    uuid='22222',
+    project_id='0wn3r',
+    name='o1',
+    resource_uuid='1111',
+    resource_type='dummy_node',
+    start_time=now,
+    end_time=now + datetime.timedelta(days=100),
+    properties={'foo': 'bar'},
+    status=statuses.AVAILABLE,
+)
+
+test_offer_3 = dict(
+    uuid='33333',
+    project_id='0wn3r_2',
+    name='o1',
+    resource_uuid='1111',
+    resource_type='dummy_node',
+    start_time=now,
+    end_time=now + datetime.timedelta(days=100),
+    properties={'foo': 'bar'},
+    status=statuses.AVAILABLE,
+)
+
+test_offer_4 = dict(
+    uuid='44444',
+    project_id='0wn3r_2',
+    name='o2',
     resource_uuid='1111',
     resource_type='dummy_node',
     start_time=now,
@@ -33,6 +70,7 @@ test_offer_1 = dict(
 test_contract_1 = dict(
     uuid='11111',
     project_id='1e5533',
+    name='c1',
     start_time=now + datetime.timedelta(days=10),
     end_time=now + datetime.timedelta(days=20),
     status=statuses.CREATED,
@@ -41,6 +79,7 @@ test_contract_1 = dict(
 test_contract_2 = dict(
     uuid='22222',
     project_id='1e5533',
+    name='c1',
     start_time=now + datetime.timedelta(days=20),
     end_time=now + datetime.timedelta(days=30),
     status=statuses.CREATED,
@@ -48,7 +87,8 @@ test_contract_2 = dict(
 
 test_contract_3 = dict(
     uuid='33333',
-    project_id='1e5533',
+    project_id='1e5533_2',
+    name='c1',
     start_time=now + datetime.timedelta(days=50),
     end_time=now + datetime.timedelta(days=60),
     status=statuses.ACTIVE,
@@ -56,7 +96,8 @@ test_contract_3 = dict(
 
 test_contract_4 = dict(
     uuid='44444',
-    project_id='1e5533',
+    project_id='1e5533_2',
+    name='c2',
     start_time=now + datetime.timedelta(days=85),
     end_time=now + datetime.timedelta(days=90),
     status=statuses.CANCELLED,
@@ -65,7 +106,7 @@ test_contract_4 = dict(
 
 class TestAPI(base.DBTestCase):
 
-    def test_offer_create(db):
+    def test_offer_create(self):
         offer = api.offer_create(test_offer_1)
         o = api.offer_get_all({}).all()
         assert len(o) == 1
@@ -172,14 +213,38 @@ class TestAPI(base.DBTestCase):
         end = now + datetime.timedelta(days=87)
         api.offer_verify_availability(offer, start, end)
 
-    def test_offer_get(self):
+    def test_offer_get_by_uuid(self):
 
         offer = api.offer_create(test_offer_1)
-        res = api.offer_get(offer.uuid)
+        api.offer_create(test_offer_2)
+
+        res = api.offer_get_by_uuid(offer.uuid)
         self.assertEqual(offer.uuid, res.uuid)
         self.assertEqual(offer.project_id, res.project_id)
         self.assertEqual(offer.properties, res.properties)
 
-    def test_offer_get_not_found(self):
+    def test_offer_get_by_uuid_not_found(self):
 
-        self.assertRaises(e.OfferNotFound, api.offer_get, 'some_uuid')
+        assert api.offer_get_by_uuid('some_uuid') is None
+
+    def test_offer_get_by_name(self):
+
+        o1 = api.offer_create(test_offer_1)
+        o2 = api.offer_create(test_offer_2)
+        o3 = api.offer_create(test_offer_3)
+        api.offer_create(test_offer_4)
+
+        res = api.offer_get_by_name('o1')
+        assert len(res) == 3
+        self.assertEqual(o1.uuid, res[0].uuid)
+        self.assertEqual(o1.project_id, res[0].project_id)
+
+        self.assertEqual(o2.uuid, res[1].uuid)
+        self.assertEqual(o2.project_id, res[1].project_id)
+
+        self.assertEqual(o3.uuid, res[2].uuid)
+        self.assertEqual(o3.project_id, res[2].project_id)
+
+    def test_offer_get_by_name_not_found(self):
+
+        assert api.offer_get_by_uuid('some_uuid') is None

--- a/esi_leap/tests/objects/test_contract.py
+++ b/esi_leap/tests/objects/test_contract.py
@@ -18,18 +18,15 @@ from esi_leap.objects import contract
 from esi_leap.tests import base
 
 
-class Offer(object):
-    pass
+start = datetime.datetime(2016, 7, 16, 19, 20, 30)
 
 
-def get_test_contract():
-
-    start = datetime.datetime(2016, 7, 16, 19, 20, 30)
-
+def get_test_contract_1():
     return {
         'id': 27,
-        'uuid': '534653c9-880d-4c2d-6d6d-f4f2a09e384',
-        'project_id': '01d4e6a72f5c408813e02f664cc8c83e',
+        'name': 'c',
+        'uuid': '534653c9-880d-4c2d-6d6d-11111111111',
+        'project_id': 'le55ee',
         'start_time': start + datetime.timedelta(days=5),
         'end_time': start + datetime.timedelta(days=10),
         'status': statuses.CREATED,
@@ -40,9 +37,61 @@ def get_test_contract():
     }
 
 
+def get_test_contract_2():
+
+    return {
+        'id': 28,
+        'name': 'c',
+        'uuid': '534653c9-880d-4c2d-6d6d-22222222222',
+        'project_id': 'le55ee',
+        'start_time': start + datetime.timedelta(days=15),
+        'end_time': start + datetime.timedelta(days=20),
+        'status': statuses.CREATED,
+        'properties': {},
+        'offer_uuid': '534653c9-880d-4c2d-6d6d-f4f2a09e384',
+        'created_at': None,
+        'updated_at': None
+    }
+
+
+def get_test_contract_3():
+
+    return {
+        'id': 29,
+        'name': 'c',
+        'uuid': '534653c9-880d-4c2d-6d6d-33333333333',
+        'project_id': 'le55ee_2',
+        'start_time': start + datetime.timedelta(days=25),
+        'end_time': start + datetime.timedelta(days=30),
+        'status': statuses.CREATED,
+        'properties': {},
+        'offer_uuid': '534653c9-880d-4c2d-6d6d-f4f2a09e384',
+        'created_at': None,
+        'updated_at': None
+    }
+
+
+def get_test_contract_4():
+
+    return {
+        'id': 30,
+        'name': 'c2',
+        'uuid': '534653c9-880d-4c2d-6d6d-44444444444',
+        'project_id': 'le55ee_2',
+        'start_time': start + datetime.timedelta(days=35),
+        'end_time': start + datetime.timedelta(days=40),
+        'status': statuses.CREATED,
+        'properties': {},
+        'offer_uuid': '534653c9-880d-4c2d-6d6d-f4f2a09e384',
+        'created_at': None,
+        'updated_at': None
+    }
+
+
 def get_offer():
 
-    start = datetime.datetime(2016, 7, 16, 19, 20, 30)
+    class Offer(object):
+        pass
 
     o = Offer()
     offer = dict(
@@ -69,33 +118,83 @@ class TestContractObject(base.DBTestCase):
 
     def setUp(self):
         super(TestContractObject, self).setUp()
-        self.fake_contract = get_test_contract()
+        self.fake_contract = get_test_contract_1()
+        self.fake_contract_2 = get_test_contract_2()
+        self.fake_contract_3 = get_test_contract_3()
+        self.fake_contract_4 = get_test_contract_4()
 
-    def test_get(self):
+    def test_get_by_uuid(self):
         contract_uuid = self.fake_contract['uuid']
-        with mock.patch.object(self.db_api, 'contract_get',
-                               autospec=True) as mock_contract_get:
-            mock_contract_get.return_value = self.fake_contract
+        with mock.patch.object(self.db_api, 'contract_get_by_uuid',
+                               autospec=True) as mock_contract_get_by_uuid:
+            mock_contract_get_by_uuid.return_value = self.fake_contract
 
-            c = contract.Contract.get(
-                self.context, contract_uuid)
+            c = contract.Contract.get_by_uuid(
+                contract_uuid, self.context)
 
-            mock_contract_get.assert_called_once_with(
+            mock_contract_get_by_uuid.assert_called_once_with(
                 contract_uuid)
             self.assertEqual(self.context, c._context)
+
+    def test_get_by_name(self):
+        with mock.patch.object(self.db_api, 'contract_get_by_name',
+                               autospec=True) as mock_contract_get_by_name:
+            mock_contract_get_by_name.return_value = \
+                [self.fake_contract, self.fake_contract_2,
+                 self.fake_contract_3]
+
+            c = contract.Contract.get_by_name(
+                'c', self.context)
+
+            mock_contract_get_by_name.assert_called_once_with('c')
+            self.assertEqual(self.context, c[0]._context)
+
+    def test_get(self):
+        with mock.patch.object(self.db_api, 'contract_get_by_name',
+                               autospec=True) as mock_contract_get_by_name:
+            with mock.patch.object(self.db_api, 'contract_get_by_uuid',
+                                   autospec=True) as mock_contract_get_by_uuid:
+
+                mock_contract_get_by_name.return_value = \
+                    [self.fake_contract, self.fake_contract_2,
+                     self.fake_contract_3]
+                mock_contract_get_by_uuid.return_value = None
+
+                c = contract.Contract.get(
+                    'c', self.context)
+
+                mock_contract_get_by_uuid.assert_called_once_with('c')
+                mock_contract_get_by_name.assert_called_once_with('c')
+                assert len(c) == 3
+
+        with mock.patch.object(self.db_api, 'contract_get_by_name',
+                               autospec=True) as mock_contract_get_by_name:
+            with mock.patch.object(self.db_api, 'contract_get_by_uuid',
+                                   autospec=True) as mock_contract_get_by_uuid:
+
+                mock_contract_get_by_uuid.return_value = self.fake_contract
+                c = contract.Contract.get(
+                    self.fake_contract['uuid'], self.context)
+
+                mock_contract_get_by_uuid.assert_called_once_with(
+                    self.fake_contract['uuid']
+                )
+                assert not mock_contract_get_by_name.called
+                assert len(c) == 1
 
     def test_get_all(self):
         with mock.patch.object(
                 self.db_api, 'contract_get_all', autospec=True
         ) as mock_contract_get_all:
-            mock_contract_get_all.return_value = [
-                self.fake_contract]
+            mock_contract_get_all.return_value = \
+                [self.fake_contract, self.fake_contract_2,
+                 self.fake_contract_3, self.fake_contract_4]
 
             contracts = contract.Contract.get_all(
                 self.context, {})
 
             mock_contract_get_all.assert_called_once_with({})
-            self.assertEqual(len(contracts), 1)
+            self.assertEqual(len(contracts), 4)
             self.assertIsInstance(
                 contracts[0], contract.Contract)
             self.assertEqual(self.context, contracts[0]._context)
@@ -105,20 +204,20 @@ class TestContractObject(base.DBTestCase):
             self.context, **self.fake_contract)
         with mock.patch.object(self.db_api, 'contract_create',
                                autospec=True) as mock_contract_create:
-            with mock.patch.object(self.db_api, 'offer_get',
-                                   autospec=True) as mock_offer_get:
+            with mock.patch.object(self.db_api, 'offer_get_by_uuid',
+                                   autospec=True) as mock_offer_get_by_uuid:
                 with mock.patch(
                         'esi_leap.objects.contract.uuidutils.generate_uuid')\
                         as mock_uuid:
-                    mock_offer_get.return_value = get_offer()
-                    mock_contract_create.return_value = get_test_contract()
+                    mock_offer_get_by_uuid.return_value = get_offer()
+                    mock_contract_create.return_value = get_test_contract_1()
                     mock_uuid.return_value = '534653c9-880d-4c2d-6d6d-' \
-                                             'f4f2a09e384'
+                                             '11111111111'
 
                     c.create()
 
                     mock_contract_create.assert_called_once_with(
-                        get_test_contract())
+                        get_test_contract_1())
 
     def test_destroy(self):
         c = contract.Contract(self.context, **self.fake_contract)
@@ -136,7 +235,7 @@ class TestContractObject(base.DBTestCase):
         updated_at = datetime.datetime(2006, 12, 11, 0, 0)
         with mock.patch.object(self.db_api, 'contract_update',
                                autospec=True) as mock_contract_update:
-            updated_contract = get_test_contract()
+            updated_contract = get_test_contract_1()
             updated_contract['status'] = new_status
             updated_contract['updated_at'] = updated_at
             mock_contract_update.return_value = updated_contract
@@ -144,7 +243,7 @@ class TestContractObject(base.DBTestCase):
             c.status = new_status
             c.save(self.context)
 
-            updated_values = get_test_contract()
+            updated_values = get_test_contract_1()
             updated_values['status'] = new_status
             mock_contract_update.assert_called_once_with(
                 c.uuid, updated_values)


### PR DESCRIPTION
Added the 'name' column to offers and contracts. Names
will make object management easier for users as they no
longer need to use cumbersome uuids to manage their objects.