### PR TITLE
Conflict times for offer creation

### DIFF
--- a/esi_leap/common/exception.py
+++ b/esi_leap/common/exception.py
@@ -72,6 +72,13 @@ class OfferNoTimeAvailabilities(ESILeapException):
                 "time range %(start_time)s, %(end_time)s.")
 
 
+class OfferResourceTimeConflict(ESILeapException):
+    msg_fmt = ("Offer on %(resource_type)s %(resource_uuid)s cannot be "
+               "created with a start_time and end_time "
+               "which conflicts with the time range of an existing offer "
+               "on %(resource_type)s %(resource_uuid)s.")
+
+
 class OfferNotAvailable(ESILeapException):
     msg_fmt = _("Offer %(offer_uuid)s does not have status "
                 "'available'. Got offer status '%(status)s'.")

--- a/esi_leap/db/api.py
+++ b/esi_leap/db/api.py
@@ -109,9 +109,14 @@ def offer_get_conflict_times(offer_ref):
     return IMPL.offer_get_conflict_times(offer_ref)
 
 
-def offer_verify_availability(offer_ref, start, end):
-    return IMPL.offer_verify_availability(
+def offer_verify_contract_availability(offer_ref, start, end):
+    return IMPL.offer_verify_contract_availability(
         offer_ref, start, end)
+
+
+def offer_verify_resource_availability(r_type, r_uuid, start, end):
+    return IMPL.offer_verify_resource_availability(
+        r_type, r_uuid, start, end)
 
 
 def offer_create(values):

--- a/esi_leap/objects/contract.py
+++ b/esi_leap/objects/contract.py
@@ -94,9 +94,9 @@ class Contract(base.ESILEAPObject):
             else:
                 updates['end_time'] = q.start_time
 
-        self.dbapi.offer_verify_availability(related_offer,
-                                             updates['start_time'],
-                                             updates['end_time'])
+        self.dbapi.offer_verify_contract_availability(related_offer,
+                                                      updates['start_time'],
+                                                      updates['end_time'])
 
         db_contract = self.dbapi.contract_create(updates)
         self._from_db_object(context, self, db_contract)

--- a/esi_leap/objects/offer.py
+++ b/esi_leap/objects/offer.py
@@ -116,6 +116,11 @@ class Offer(base.ESILEAPObject):
                                  start_time=str(updates['start_time']),
                                  end_time=str(updates['end_time']))
 
+        self.dbapi.offer_verify_resource_availability(updates['resource_type'],
+                                                      updates['resource_uuid'],
+                                                      updates['start_time'],
+                                                      updates['end_time'])
+
         db_offer = self.dbapi.offer_create(updates)
         self._from_db_object(context, self, db_offer)
 

--- a/esi_leap/tests/db/sqlalchemy/test_api.py
+++ b/esi_leap/tests/db/sqlalchemy/test_api.py
@@ -112,7 +112,7 @@ class TestAPI(base.DBTestCase):
         assert len(o) == 1
         assert o[0].to_dict() == offer.to_dict()
 
-    def test_offer_verify_availability(self):
+    def test_offer_verify_contract_availability(self):
         offer = api.offer_create(test_offer_1)
 
         test_contract_1['offer_uuid'] = offer.uuid
@@ -125,93 +125,105 @@ class TestAPI(base.DBTestCase):
 
         start = now + datetime.timedelta(days=35)
         end = now + datetime.timedelta(days=40)
-        api.offer_verify_availability(offer, start, end)
+        api.offer_verify_contract_availability(offer, start, end)
 
         start = now + datetime.timedelta(days=5)
         end = now + datetime.timedelta(days=10)
-        api.offer_verify_availability(offer, start, end)
+        api.offer_verify_contract_availability(offer, start, end)
 
         start = now
         end = now + datetime.timedelta(days=10)
-        api.offer_verify_availability(offer, start, end)
+        api.offer_verify_contract_availability(offer, start, end)
 
         start = now + datetime.timedelta(days=90)
         end = now + datetime.timedelta(days=100)
-        api.offer_verify_availability(offer, start, end)
+        api.offer_verify_contract_availability(offer, start, end)
 
         start = now + datetime.timedelta(days=60)
         end = now + datetime.timedelta(days=100)
-        api.offer_verify_availability(offer, start, end)
+        api.offer_verify_contract_availability(offer, start, end)
 
         start = now + datetime.timedelta(days=30)
         end = now + datetime.timedelta(days=50)
-        api.offer_verify_availability(offer, start, end)
+        api.offer_verify_contract_availability(offer, start, end)
 
         start = now + datetime.timedelta(days=15)
         end = now + datetime.timedelta(days=16)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_availability, offer, start, end)
+                          api.offer_verify_contract_availability,
+                          offer, start, end)
 
         start = now + datetime.timedelta(days=45)
         end = now + datetime.timedelta(days=55)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_availability, offer, start, end)
+                          api.offer_verify_contract_availability,
+                          offer, start, end)
 
         start = now + datetime.timedelta(days=55)
         end = now + datetime.timedelta(days=65)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_availability, offer, start, end)
+                          api.offer_verify_contract_availability,
+                          offer, start, end)
 
         start = now + datetime.timedelta(days=50)
         end = now + datetime.timedelta(days=65)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_availability, offer, start, end)
+                          api.offer_verify_contract_availability,
+                          offer, start, end)
 
         start = now + datetime.timedelta(days=45)
         end = now + datetime.timedelta(days=60)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_availability, offer, start, end)
+                          api.offer_verify_contract_availability,
+                          offer, start, end)
 
         start = now + datetime.timedelta(days=90)
         end = now + datetime.timedelta(days=105)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_availability, offer, start, end)
+                          api.offer_verify_contract_availability,
+                          offer, start, end)
 
         start = now + datetime.timedelta(days=100)
         end = now + datetime.timedelta(days=105)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_availability, offer, start, end)
+                          api.offer_verify_contract_availability,
+                          offer, start, end)
 
         start = now + datetime.timedelta(days=105)
         end = now + datetime.timedelta(days=110)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_availability, offer, start, end)
+                          api.offer_verify_contract_availability,
+                          offer, start, end)
 
         start = now - datetime.timedelta(days=1)
         end = now + datetime.timedelta(days=5)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_availability, offer, start, end)
+                          api.offer_verify_contract_availability,
+                          offer, start, end)
 
         start = now - datetime.timedelta(days=1)
         end = now
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_availability, offer, start, end)
+                          api.offer_verify_contract_availability,
+                          offer, start, end)
 
         start = now - datetime.timedelta(days=10)
         end = now - datetime.timedelta(days=5)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_availability, offer, start, end)
+                          api.offer_verify_contract_availability,
+                          offer, start, end)
 
         start = now + datetime.timedelta(days=45)
         end = now + datetime.timedelta(days=55)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_availability, offer, start, end)
+                          api.offer_verify_contract_availability,
+                          offer, start, end)
 
         test_contract_4['offer_uuid'] = offer.uuid
         api.contract_create(test_contract_4)
         start = now + datetime.timedelta(days=86)
         end = now + datetime.timedelta(days=87)
-        api.offer_verify_availability(offer, start, end)
+        api.offer_verify_contract_availability(offer, start, end)
 
     def test_offer_get_by_uuid(self):
 


### PR DESCRIPTION
Added a check to offer creation to see if an offer
has a time conflict with another offer on the same
resource node. This is needed as having two offers
exist on the same node allows one node to be leased
out to multiple lessees concurrently.