### PR TITLE
Contract creation by name

### DIFF
--- a/esi_leap/api/controllers/v1/offer.py
+++ b/esi_leap/api/controllers/v1/offer.py
@@ -12,6 +12,7 @@
 
 import datetime
 from oslo_policy import policy as oslo_policy
+from oslo_utils import uuidutils
 import pecan
 from pecan import rest
 import wsme
@@ -152,6 +153,19 @@ class OffersController(rest.RestController):
         offer_dict['project_id'] = request.project_id
 
         OffersController._verify_resource_permission(cdict, offer_dict)
+
+        offer_dict['uuid'] = uuidutils.generate_uuid()
+
+        if 'start_time' not in offer_dict:
+            offer_dict['start_time'] = datetime.datetime.now()
+        if 'end_time' not in offer_dict:
+            offer_dict['end_time'] = datetime.datetime.max
+
+        if offer_dict['start_time'] >= offer_dict['end_time']:
+            raise exception.\
+                InvalidTimeRange(resource="an offer",
+                                 start_time=str(offer_dict['start_time']),
+                                 end_time=str(offer_dict['end_time']))
 
         o = offer.Offer(**offer_dict)
         o.create(request)

--- a/esi_leap/db/api.py
+++ b/esi_leap/db/api.py
@@ -109,6 +109,11 @@ def offer_get_conflict_times(offer_ref):
     return IMPL.offer_get_conflict_times(offer_ref)
 
 
+def offer_get_first_availability(offer_uuid, start, end):
+    return IMPL.offer_get_first_availability(
+        offer_uuid, start, end)
+
+
 def offer_verify_contract_availability(offer_ref, start, end):
     return IMPL.offer_verify_contract_availability(
         offer_ref, start, end)

--- a/esi_leap/db/sqlalchemy/api.py
+++ b/esi_leap/db/sqlalchemy/api.py
@@ -168,18 +168,17 @@ def offer_get_conflict_times(offer_ref):
                ).all()
 
 
-def offer_get_first_availability(offer_ref, start):
+def offer_get_first_availability(offer_uuid, start):
     c_query = model_query(models.Contract, get_session())
 
     return c_query.with_entities(
         models.Contract.start_time).\
-        join(models.Offer).\
-        filter(models.Contract.offer_uuid == offer_ref.uuid,
+        filter(models.Contract.offer_uuid == offer_uuid,
                (models.Contract.status == statuses.CREATED) |
                (models.Contract.status == statuses.ACTIVE)
                ).\
         order_by(models.Contract.start_time).\
-        filter(models.Contract.end_time >= start).one_or_none()
+        filter(models.Contract.end_time >= start).first()
 
 
 def offer_verify_contract_availability(offer_ref, start, end):

--- a/esi_leap/objects/offer.py
+++ b/esi_leap/objects/offer.py
@@ -10,9 +10,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import datetime
 
-from esi_leap.common import exception
 from esi_leap.common import statuses
 from esi_leap.db import api as dbapi
 from esi_leap.objects import base
@@ -21,7 +19,6 @@ from esi_leap.objects import fields
 from esi_leap.resource_objects import resource_object_factory as ro_factory
 
 from oslo_config import cfg
-from oslo_utils import uuidutils
 from oslo_versionedobjects import base as versioned_objects_base
 
 CONF = cfg.CONF
@@ -100,21 +97,11 @@ class Offer(base.ESILEAPObject):
 
         return a
 
+    def get_first_availability(self, start):
+        return self.dbapi.offer_get_first_availability(self.uuid, start)
+
     def create(self, context=None):
         updates = self.obj_get_changes()
-
-        updates['uuid'] = uuidutils.generate_uuid()
-
-        if 'start_time' not in updates:
-            updates['start_time'] = datetime.datetime.now()
-        if 'end_time' not in updates:
-            updates['end_time'] = datetime.datetime.max
-
-        if updates['start_time'] >= updates['end_time']:
-            raise exception.\
-                InvalidTimeRange(resource="an offer",
-                                 start_time=str(updates['start_time']),
-                                 end_time=str(updates['end_time']))
 
         self.dbapi.offer_verify_resource_availability(updates['resource_type'],
                                                       updates['resource_uuid'],

--- a/esi_leap/tests/api/base.py
+++ b/esi_leap/tests/api/base.py
@@ -10,15 +10,12 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import datetime
 import mock
 import pecan
 import pecan.testing
 
 from esi_leap.api import app
 import esi_leap.conf
-from esi_leap.objects import contract
-from esi_leap.objects import offer
 from esi_leap.tests import base
 
 
@@ -27,29 +24,6 @@ PATH_PREFIX = '/v1'
 
 
 class APITestCase(base.DBTestCase):
-
-    @staticmethod
-    def create_test_offer(context):
-        o = offer.Offer(
-            resource_type='test_node',
-            resource_uuid='1234567890',
-            start_time=datetime.datetime(2016, 7, 16, 19, 20, 30),
-            end_time=datetime.datetime(2016, 8, 16, 19, 20, 30),
-            project_id="111111111111"
-        )
-        o.create(context)
-        return o
-
-    @staticmethod
-    def create_test_contract(context):
-        c = contract.Contract(
-            start_date=datetime.datetime(2016, 7, 16, 19, 20, 30),
-            end_date=datetime.datetime(2016, 8, 16, 19, 20, 30),
-            offer_uuid='1234567890',
-            project_id="222222222222"
-        )
-        c.create(context)
-        return c
 
     def setUp(self):
         super(APITestCase, self).setUp()

--- a/esi_leap/tests/api/controllers/v1/test_offer.py
+++ b/esi_leap/tests/api/controllers/v1/test_offer.py
@@ -46,6 +46,19 @@ test_node_1 = TestNode('aaa', owner_ctx.project_id)
 test_node_2 = TestNode('bbb', owner_ctx_2.project_id)
 
 
+def create_test_offer(context):
+    o = offer.Offer(
+        resource_type='test_node',
+        resource_uuid='1234567890',
+        uuid='aaaaaaaa',
+        start_time=datetime.datetime(2016, 7, 16, 19, 20, 30),
+        end_time=datetime.datetime(2016, 8, 16, 19, 20, 30),
+        project_id="111111111111"
+    )
+    o.create(context)
+    return o
+
+
 def get_offer_response(o):
     return {
         'resource_type': o.resource_type,
@@ -123,6 +136,7 @@ class TestListOffers(test_api_base.APITestCase):
         self.test_offer = offer.Offer(
             resource_type='test_node',
             resource_uuid='1234567890',
+            uuid='00000',
             start_time=start,
             end_time=end,
             project_id=owner_ctx.project_id
@@ -138,13 +152,15 @@ class TestListOffers(test_api_base.APITestCase):
         data = self.get_json('/offers')
         self.assertEqual(self.test_offer.uuid, data['offers'][0]["uuid"])
 
+    @mock.patch('esi_leap.api.controllers.v1.offer.uuidutils.generate_uuid')
     @mock.patch('esi_leap.objects.offer.Offer.create')
     @mock.patch('esi_leap.api.controllers.v1.offer.' +
                 'OffersController._verify_resource_permission')
     @mock.patch('esi_leap.api.controllers.v1.offer.' +
                 'OffersController._add_offer_availabilities')
-    def test_post(self, mock_aoa, mock_vrp, mock_create):
+    def test_post(self, mock_aoa, mock_vrp, mock_create, mock_generate_uuid):
 
+        mock_generate_uuid.return_value = '11111'
         mock_create.return_value = self.test_offer
         data = create_test_offer_data
         request = self.post_json('/offers', data)

--- a/esi_leap/tests/objects/test_contract.py
+++ b/esi_leap/tests/objects/test_contract.py
@@ -199,25 +199,24 @@ class TestContractObject(base.DBTestCase):
                 contracts[0], contract.Contract)
             self.assertEqual(self.context, contracts[0]._context)
 
-    def test_create(self):
+    @mock.patch('esi_leap.objects.contract.Offer.get',
+                return_value=[get_offer()])
+    def test_create(self, mock_offer_get):
         c = contract.Contract(
             self.context, **self.fake_contract)
         with mock.patch.object(self.db_api, 'contract_create',
                                autospec=True) as mock_contract_create:
             with mock.patch.object(self.db_api, 'offer_get_by_uuid',
-                                   autospec=True) as mock_offer_get_by_uuid:
-                with mock.patch(
-                        'esi_leap.objects.contract.uuidutils.generate_uuid')\
-                        as mock_uuid:
-                    mock_offer_get_by_uuid.return_value = get_offer()
-                    mock_contract_create.return_value = get_test_contract_1()
-                    mock_uuid.return_value = '534653c9-880d-4c2d-6d6d-' \
-                                             '11111111111'
+                                   autospec=True) as mock_offer_get:
+                mock_contract_create.return_value = get_test_contract_1()
+                mock_offer_get.return_value = get_offer()
 
-                    c.create()
+                c.create('534653c9-880d-4c2d-6d6d-f4f2a09e384')
 
-                    mock_contract_create.assert_called_once_with(
-                        get_test_contract_1())
+                mock_contract_create.assert_called_once_with(
+                    get_test_contract_1())
+                mock_offer_get.assert_called_once_with(
+                    '534653c9-880d-4c2d-6d6d-f4f2a09e384')
 
     def test_destroy(self):
         c = contract.Contract(self.context, **self.fake_contract)

--- a/esi_leap/tests/objects/test_offer.py
+++ b/esi_leap/tests/objects/test_offer.py
@@ -223,16 +223,11 @@ class TestOfferObject(base.DBTestCase):
             self.context, **self.fake_offer)
         with mock.patch.object(self.db_api, 'offer_create',
                                autospec=True) as mock_offer_create:
-            with mock.patch(
-                    'esi_leap.objects.offer.uuidutils.generate_uuid') \
-                    as mock_uuid:
-                mock_uuid.return_value = '534653c9-880d-4c2d-6d6d-' \
-                                         '11111111111'
-                mock_offer_create.return_value = get_test_offer()
 
-                o.create(self.context)
-                mock_offer_create.assert_called_once_with(
-                    get_test_offer())
+            mock_offer_create.return_value = get_test_offer()
+
+            o.create(self.context)
+            mock_offer_create.assert_called_once_with(get_test_offer())
 
     def test_destroy(self):
         o = offer.Offer(self.context, **self.fake_offer)


### PR DESCRIPTION
Added the ability to use an offer's name in place
of uuid when creating a contract.