### PR TITLE
Locks on objects

### DIFF
--- a/esi_leap/api/controllers/v1/utils.py
+++ b/esi_leap/api/controllers/v1/utils.py
@@ -1,0 +1,123 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_policy import policy as oslo_policy
+from oslo_utils import uuidutils
+
+from esi_leap.common import exception
+from esi_leap.common import policy
+from esi_leap.objects import contract
+from esi_leap.objects import offer
+from esi_leap.resource_objects import resource_object_factory as ro_factory
+
+
+def get_offer_authorized(uuid_or_name, cdict, status_filter=None):
+    if uuidutils.is_uuid_like(uuid_or_name):
+        o = offer.Offer.get(uuid_or_name)
+        offer_objs = []
+
+        if not status_filter or o.status == status_filter:
+            try:
+                policy.authorize('esi_leap:offer:offer_admin', cdict, cdict)
+                offer_objs.append(o)
+            except oslo_policy.PolicyNotAuthorized:
+                pass
+
+    else:
+        try:
+            policy.authorize('esi_leap:offer:offer_admin', cdict, cdict)
+            offer_objs = offer.Offer.get_all({'name': uuid_or_name,
+                                              'status': status_filter})
+
+        except oslo_policy.PolicyNotAuthorized:
+            offer_objs = offer.Offer.get_all(
+                {'name': uuid_or_name,
+                 'project_id': cdict['project_id'],
+                 'status': status_filter}
+            )
+
+    if len(offer_objs) == 0:
+        raise exception.OfferNotFound(offer_uuid=uuid_or_name)
+    elif len(offer_objs) > 1:
+        raise exception.OfferDuplicateName(name=uuid_or_name)
+
+    return offer_objs[0]
+
+
+def verify_resource_permission(cdict, offer_dict):
+    resource_type = offer_dict.get('resource_type')
+    resource_uuid = offer_dict.get('resource_uuid')
+    resource = ro_factory.ResourceObjectFactory.get_resource_object(
+        resource_type, resource_uuid)
+    if not resource.is_resource_admin(offer_dict['project_id']):
+        policy.authorize('esi_leap:offer:offer_admin', cdict, cdict)
+
+
+def get_offer(uuid_or_name, status_filter=None):
+    if uuidutils.is_uuid_like(uuid_or_name):
+        o = offer.Offer.get(uuid_or_name)
+        if o.status == status_filter:
+            return o
+    else:
+        offer_objs = offer.Offer.get_all({'name': uuid_or_name,
+                                          'status': status_filter})
+
+        if len(offer_objs) > 1:
+            raise exception.OfferDuplicateName(
+                name=uuid_or_name)
+        elif len(offer_objs) == 0:
+            raise exception.OfferNotFound(
+                offer_uuid=uuid_or_name)
+
+        return offer_objs[0]
+
+
+def get_contract_authorized(uuid_or_name, cdict, status_filters=[]):
+
+    if uuidutils.is_uuid_like(uuid_or_name):
+        c = contract.Contract.get(uuid_or_name)
+        contract_objs = []
+        if not status_filters or c.status in status_filters:
+            contract_objs.append(c)
+
+    else:
+        contract_objs = contract.Contract.get_all({'name': uuid_or_name,
+                                                   'status': status_filters})
+
+    permitted = []
+    for c in contract_objs:
+        try:
+            contract_authorize_management(c, cdict)
+            permitted.append(c)
+        except oslo_policy.PolicyNotAuthorized:
+            continue
+
+        if len(permitted) > 1:
+            raise exception.ContractDuplicateName(name=uuid_or_name)
+
+    if len(permitted) == 0:
+        raise exception.ContractNotFound(contract_id=uuid_or_name)
+
+    return permitted[0]
+
+
+def contract_authorize_management(c, cdict):
+
+    if c.project_id != cdict['project_id']:
+        try:
+            policy.authorize('esi_leap:contract:contract_admin',
+                             cdict, cdict)
+        except oslo_policy.PolicyNotAuthorized:
+            o = offer.Offer.get(c.offer_uuid)
+            if o.project_id != cdict['project_id']:
+                policy.authorize('esi_leap:offer:offer_admin',
+                                 cdict, cdict)

--- a/esi_leap/common/utils.py
+++ b/esi_leap/common/utils.py
@@ -1,0 +1,29 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_concurrency import lockutils
+
+_prefix = 'esileap'
+synchronized = lockutils.synchronized_with_prefix(_prefix)
+lock = lockutils.lock_with_prefix(_prefix)
+
+
+def get_resource_lock_name(resource_type, resource_uuid):
+    return resource_type + '-' + resource_uuid
+
+
+def get_offer_lock_name(offer_uuid):
+    return 'offer' + '-' + offer_uuid
+
+
+def get_contract_lock_name(contract_uuid):
+    return 'contract' + '-' + contract_uuid

--- a/esi_leap/db/sqlalchemy/api.py
+++ b/esi_leap/db/sqlalchemy/api.py
@@ -264,8 +264,8 @@ def offer_update(offer_uuid, values):
         end = offer_ref.end_time
     if start >= end:
         raise exception.InvalidTimeRange(resource="an offer",
-                                         start_time=str(values['start_time']),
-                                         end_time=str(values['end_time']))
+                                         start_time=str(start),
+                                         end_time=str(end))
 
     offer_ref.update(values)
     offer_ref.save(s)
@@ -308,11 +308,7 @@ def contract_get_all(filters):
     query = query.filter_by(**filters)
 
     if status:
-        if type(status) == list:
-            query = query.filter((models.Contract.status == status[0]) |
-                                 (models.Contract.status == status[1]))
-        else:
-            query = query.filter_by(status=status)
+        query = query.filter((models.Contract.status.in_(status)))
 
     if start and end:
         query = query.filter((start >= models.Contract.start_time) &
@@ -348,8 +344,8 @@ def contract_update(contract_uuid, values):
         end = contract_ref.end_time
     if start >= end:
         raise exception.InvalidTimeRange(resource="a contract",
-                                         start_time=str(values['start_time']),
-                                         end_time=str(values['end_time']))
+                                         start_time=str(start),
+                                         end_time=str(end))
 
     contract_ref.update(values)
     contract_ref.save(s)

--- a/esi_leap/manager/service.py
+++ b/esi_leap/manager/service.py
@@ -61,7 +61,7 @@ class ManagerService(service.Service):
     def _fulfill_contracts(self):
         LOG.info("Checking for contracts to fulfill")
         contracts = contract.Contract.get_all(
-            self._context, {'status': statuses.CREATED})
+            {'status': statuses.CREATED}, self._context)
         now = timeutils.utcnow()
         for c in contracts:
             if c.start_time <= now and now <= c.end_time:
@@ -71,7 +71,7 @@ class ManagerService(service.Service):
     def _expire_contracts(self):
         LOG.info("Checking for expiring contracts")
         contracts = contract.Contract.get_all(
-            self._context, {'status': [statuses.ACTIVE, statuses.CREATED]})
+            {'status': [statuses.ACTIVE, statuses.CREATED]}, self._context)
         now = timeutils.utcnow()
         for c in contracts:
             if c.end_time <= now:
@@ -80,8 +80,8 @@ class ManagerService(service.Service):
 
     def _expire_offers(self):
         LOG.info("Checking for expiring offers")
-        offers = offer.Offer.get_all(self._context,
-                                     {'status': statuses.AVAILABLE})
+        offers = offer.Offer.get_all({'status': statuses.AVAILABLE},
+                                     self._context)
 
         for o in offers:
             if o.end_time and \

--- a/esi_leap/objects/contract.py
+++ b/esi_leap/objects/contract.py
@@ -12,10 +12,12 @@
 
 from esi_leap.common import exception
 from esi_leap.common import statuses
+from esi_leap.common import utils
 from esi_leap.db import api as dbapi
 from esi_leap.objects import base
 from esi_leap.objects import fields
 from esi_leap.objects.offer import Offer
+
 from oslo_config import cfg
 from oslo_versionedobjects import base as versioned_objects_base
 
@@ -39,50 +41,41 @@ class Contract(base.ESILEAPObject):
     }
 
     @classmethod
-    def get_by_uuid(cls, contract_uuid, context=None):
+    def get(cls, contract_uuid, context=None):
         db_contract = cls.dbapi.contract_get_by_uuid(contract_uuid)
         if db_contract:
             return cls._from_db_object(context, cls(), db_contract)
 
     @classmethod
-    def get_by_name(cls, contract_name, context=None):
-        db_contract = cls.dbapi.contract_get_by_name(contract_name)
-        return cls._from_db_object_list(context, db_contract)
-
-    @classmethod
-    def get(cls, contract_id, context=None):
-
-        c_uuid = cls.get_by_uuid(contract_id, context)
-        if c_uuid:
-            return [c_uuid]
-
-        c_name = cls.get_by_name(contract_id, context)
-
-        return c_name
-
-    @classmethod
-    def get_all(cls, context, filters):
+    def get_all(cls, filters, context=None):
         db_contracts = cls.dbapi.contract_get_all(filters)
         return cls._from_db_object_list(context, db_contracts)
 
     def create(self, context=None):
         updates = self.obj_get_changes()
 
-        related_offer = self.dbapi.offer_get_by_uuid(updates['offer_uuid'])
+        @utils.synchronized(utils.get_offer_lock_name(updates['offer_uuid']),
+                            external=True)
+        def _create_contract():
+            related_offer = self.dbapi.offer_get_by_uuid(updates['offer_uuid'])
 
-        if related_offer.status != statuses.AVAILABLE:
-            raise exception.OfferNotAvailable(offer_uuid=related_offer.uuid,
-                                              status=related_offer.status)
+            if related_offer.status != statuses.AVAILABLE:
+                raise exception.OfferNotAvailable(
+                    offer_uuid=related_offer.uuid,
+                    status=related_offer.status)
 
-        self.dbapi.offer_verify_contract_availability(related_offer,
-                                                      updates['start_time'],
-                                                      updates['end_time'])
+            self.dbapi.offer_verify_contract_availability(
+                related_offer,
+                updates['start_time'],
+                updates['end_time'])
 
-        db_contract = self.dbapi.contract_create(updates)
-        self._from_db_object(context, self, db_contract)
+            db_contract = self.dbapi.contract_create(updates)
+            self._from_db_object(context, self, db_contract)
+
+        _create_contract()
 
     def cancel(self):
-        o = Offer.get_by_uuid(self.offer_uuid)
+        o = Offer.get(self.offer_uuid)
 
         resource = o.resource_object()
         if resource.get_contract_uuid() == self.uuid:
@@ -102,18 +95,25 @@ class Contract(base.ESILEAPObject):
         self._from_db_object(context, self, db_contract)
 
     def fulfill(self, context=None):
-        # fulfill resource
-        o = Offer.get_by_uuid(self.offer_uuid, context)
-        resource = o.resource_object()
-        resource.set_contract(self)
 
-        # activate contract
-        self.status = statuses.ACTIVE
-        self.save(context)
+        @utils.synchronized(utils.get_offer_lock_name(self.offer_uuid),
+                            external=True)
+        def _fulfill_contract():
+
+            o = Offer.get(self.offer_uuid, context)
+
+            resource = o.resource_object()
+            resource.set_contract(self)
+
+            # activate contract
+            self.status = statuses.ACTIVE
+            self.save(context)
+
+        _fulfill_contract()
 
     def expire(self, context=None):
         # unassign resource
-        o = Offer.get_by_uuid(self.offer_uuid, context)
+        o = Offer.get(self.offer_uuid, context)
 
         resource = o.resource_object()
         if resource.get_contract_uuid() == self.uuid:

--- a/esi_leap/tests/api/base.py
+++ b/esi_leap/tests/api/base.py
@@ -13,6 +13,7 @@
 import mock
 import pecan
 import pecan.testing
+import tempfile
 
 from esi_leap.api import app
 import esi_leap.conf
@@ -40,6 +41,8 @@ class APITestCase(base.DBTestCase):
         self.mock_context = self.patch_context.start()
 
         self.mock_context.return_value = self.context
+
+        self.config(lock_path=tempfile.mkdtemp(), group='oslo_concurrency')
 
     # borrowed from Ironic
     def get_json(self, path, expect_errors=False, headers=None,

--- a/esi_leap/tests/api/controllers/v1/test_utils.py
+++ b/esi_leap/tests/api/controllers/v1/test_utils.py
@@ -1,0 +1,453 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import datetime
+import mock
+from oslo_context import context as ctx
+from oslo_policy import policy
+import testtools
+
+from esi_leap.api.controllers.v1 import utils
+from esi_leap.common import statuses
+from esi_leap.objects import contract
+from esi_leap.objects import offer
+from esi_leap.resource_objects.test_node import TestNode
+
+
+admin_ctx = ctx.RequestContext(project_id='adminid',
+                               roles=['admin'])
+
+owner_ctx = ctx.RequestContext(project_id='ownerid',
+                               roles=['owner'])
+owner_ctx_dict = owner_ctx.to_policy_values()
+
+lessee_ctx = ctx.RequestContext(project_id="lesseeid",
+                                roles=['lessee'])
+lessee_ctx_dict = lessee_ctx.to_policy_values()
+
+owner_ctx_2 = ctx.RequestContext(project_id='ownerid2',
+                                 roles=['owner'])
+lessee_ctx_2 = ctx.RequestContext(project_id="lesseeid2",
+                                  roles=['lessee'])
+
+
+start = datetime.datetime(2016, 7, 16)
+start_iso = '2016-07-16T00:00:00'
+
+end = start + datetime.timedelta(days=100)
+end_iso = '2016-10-24T00:00:00'
+
+
+test_node_1 = TestNode('111', owner_ctx.project_id)
+test_node_2 = TestNode('bbb', owner_ctx_2.project_id)
+
+
+def create_test_offer(context):
+    o = offer.Offer(
+        resource_type='test_node',
+        resource_uuid='1234567890',
+        uuid='aaaaaaaa',
+        start_time=datetime.datetime(2016, 7, 16, 19, 20, 30),
+        end_time=datetime.datetime(2016, 8, 16, 19, 20, 30),
+        project_id="111111111111"
+    )
+    o.create(context)
+    return o
+
+
+def create_test_contract(context):
+    c = contract.Contract(
+        uuid='bbbbbbbb',
+        start_date=datetime.datetime(2016, 7, 16, 19, 20, 30),
+        end_date=datetime.datetime(2016, 8, 16, 19, 20, 30),
+        offer_uuid='1234567890',
+        project_id="222222222222"
+    )
+    c.create(context)
+    return c
+
+
+def create_test_contract_data():
+    return {
+        "offer_uuid_or_name": "o",
+        "start_time": "2016-07-16T19:20:30",
+        "end_time": "2016-08-16T19:20:30"
+    }
+
+
+test_offer = offer.Offer(
+    resource_type='test_node',
+    resource_uuid=test_node_1._uuid,
+    name="o",
+    uuid='11111',
+    status=statuses.AVAILABLE,
+    start_time=start,
+    end_time=end,
+    project_id=owner_ctx.project_id
+)
+
+test_offer_2 = offer.Offer(
+    resource_type='test_node',
+    resource_uuid=test_node_1._uuid,
+    name="o",
+    uuid='11111',
+    status=statuses.EXPIRED,
+    start_time=start,
+    end_time=end,
+    project_id=owner_ctx.project_id
+)
+
+test_contract = contract.Contract(
+    offer_uuid="11111",
+    name='c',
+    uuid='zzzzz',
+    project_id=lessee_ctx.project_id,
+    status=statuses.CREATED
+)
+
+test_contract_2 = contract.Contract(
+    offer_uuid="11111",
+    name='c',
+    uuid='yyyyy',
+    project_id=lessee_ctx.project_id,
+    status=statuses.CREATED
+)
+
+test_contract_3 = contract.Contract(
+    offer_uuid="11111",
+    name='c',
+    uuid='xxxxx',
+    project_id=lessee_ctx_2.project_id,
+    status=statuses.CREATED
+)
+
+
+test_contract_4 = contract.Contract(
+    offer_uuid="11111",
+    name='c2',
+    uuid='wwwww',
+    project_id=lessee_ctx_2.project_id,
+    status=statuses.CREATED
+)
+
+
+class TestManagementUtils(testtools.TestCase):
+
+    @mock.patch('esi_leap.api.controllers.v1.utils.offer.Offer.get')
+    @mock.patch('esi_leap.api.controllers.v1.utils.policy.authorize')
+    def test__contract_authorize_management_valid_lessee(self,
+                                                         mock_authorize,
+                                                         mock_get):
+        utils.contract_authorize_management(
+            test_contract, lessee_ctx.to_policy_values()
+        )
+
+        assert not mock_authorize.called
+        assert not mock_get.called
+
+    @mock.patch('esi_leap.api.controllers.v1.utils.offer.Offer.get')
+    @mock.patch('esi_leap.api.controllers.v1.utils.policy.authorize')
+    def test__contract_authorize_management_invalid_lessee(self,
+                                                           mock_authorize,
+                                                           mock_get):
+        mock_get.return_value = test_offer
+        mock_authorize.side_effect = [
+            policy.PolicyNotAuthorized('esi_leap:contract:contract_admin',
+                                       lessee_ctx.to_policy_values(),
+                                       lessee_ctx.to_policy_values()),
+            policy.PolicyNotAuthorized('esi_leap:offer:offer_admin',
+                                       lessee_ctx.to_policy_values(),
+                                       lessee_ctx.to_policy_values())
+        ]
+
+        self.assertRaises(policy.PolicyNotAuthorized,
+                          utils.contract_authorize_management,
+                          test_contract_3, lessee_ctx.to_policy_values())
+
+        mock_authorize.assert_has_calls(
+            [
+                mock.call('esi_leap:contract:contract_admin',
+                          lessee_ctx.to_policy_values(),
+                          lessee_ctx.to_policy_values()),
+                mock.call('esi_leap:offer:offer_admin',
+                          lessee_ctx.to_policy_values(),
+                          lessee_ctx.to_policy_values())
+            ])
+
+        mock_get.assert_called_with(test_contract_3.offer_uuid)
+
+    @mock.patch('esi_leap.api.controllers.v1.utils.offer.Offer.get')
+    @mock.patch('esi_leap.api.controllers.v1.utils.policy.authorize')
+    def test__contract_authorize_management_valid_owner(self,
+                                                        mock_authorize,
+                                                        mock_get):
+        mock_get.return_value = test_offer
+        mock_authorize.side_effect = [
+            policy.PolicyNotAuthorized('esi_leap:contract:contract_admin',
+                                       lessee_ctx.to_policy_values(),
+                                       lessee_ctx.to_policy_values()),
+            None]
+
+        utils.contract_authorize_management(
+            test_contract, owner_ctx.to_policy_values()
+        )
+
+        mock_authorize.assert_called_once_with(
+            'esi_leap:contract:contract_admin',
+            owner_ctx.to_policy_values(),
+            owner_ctx.to_policy_values())
+
+        mock_get.assert_called_with(test_contract.offer_uuid)
+
+    @mock.patch('esi_leap.api.controllers.v1.utils.offer.Offer.get')
+    @mock.patch('esi_leap.api.controllers.v1.utils.policy.authorize')
+    def test__contract_authorize_management_invalid_owner(self,
+                                                          mock_authorize,
+                                                          mock_get):
+        mock_get.return_value = test_offer
+        mock_authorize.side_effect = [
+            policy.PolicyNotAuthorized('esi_leap:contract:contract_admin',
+                                       owner_ctx_2.to_policy_values(),
+                                       owner_ctx_2.to_policy_values()),
+            policy.PolicyNotAuthorized('esi_leap:offer:offer_admin',
+                                       owner_ctx_2.to_policy_values(),
+                                       owner_ctx_2.to_policy_values())
+        ]
+
+        self.assertRaises(policy.PolicyNotAuthorized,
+                          utils.contract_authorize_management,
+                          test_contract_3, owner_ctx_2.to_policy_values())
+
+        mock_authorize.assert_has_calls(
+            [
+                mock.call('esi_leap:contract:contract_admin',
+                          owner_ctx_2.to_policy_values(),
+                          owner_ctx_2.to_policy_values()),
+                mock.call('esi_leap:offer:offer_admin',
+                          owner_ctx_2.to_policy_values(),
+                          owner_ctx_2.to_policy_values())
+            ])
+
+        mock_get.assert_called_with(test_contract_3.offer_uuid)
+
+
+class TestGetObjectUtils(testtools.TestCase):
+
+    @mock.patch('esi_leap.api.controllers.v1.utils.policy.authorize')
+    @mock.patch('esi_leap.api.controllers.v1.utils.uuidutils.is_uuid_like')
+    @mock.patch('esi_leap.api.controllers.v1.utils.offer.Offer.get')
+    def test_get_offer_authorized_uuid(self,
+                                       mock_offer_get,
+                                       mock_is_uuid_like,
+                                       mock_authorize):
+
+        mock_is_uuid_like.return_value = True
+        mock_offer_get.return_value = test_offer
+
+        res = utils.get_offer_authorized(test_offer.uuid,
+                                         owner_ctx.to_policy_values())
+
+        self.assertEqual(res, test_offer)
+
+        mock_is_uuid_like.assert_called_once_with(test_offer.uuid)
+        mock_offer_get.assert_called_once_with(test_offer.uuid)
+
+    @mock.patch('esi_leap.api.controllers.v1.utils.policy.authorize')
+    @mock.patch('esi_leap.api.controllers.v1.utils.uuidutils.is_uuid_like')
+    @mock.patch('esi_leap.api.controllers.v1.utils.offer.Offer.get_all')
+    def test_get_offer_authorized_name_available(self,
+                                                 mock_offer_get_all,
+                                                 mock_is_uuid_like,
+                                                 mock_authorize):
+
+        mock_is_uuid_like.return_value = False
+        mock_offer_get_all.return_value = [test_offer]
+
+        res = utils.get_offer_authorized(test_offer.name,
+                                         owner_ctx.to_policy_values(),
+                                         statuses.AVAILABLE)
+
+        self.assertEqual(res, test_offer)
+
+        mock_is_uuid_like.assert_called_once_with(test_offer.name)
+        mock_offer_get_all.assert_called_once_with(
+            {'name': test_offer.name,
+             'status': statuses.AVAILABLE}
+        )
+        mock_authorize.assert_called_once()
+
+    @mock.patch('esi_leap.api.controllers.v1.utils.uuidutils.is_uuid_like')
+    @mock.patch('esi_leap.api.controllers.v1.utils.offer.Offer.get')
+    def test_get_offer_uuid_available(self,
+                                      mock_offer_get,
+                                      mock_is_uuid_like):
+
+        mock_is_uuid_like.return_value = True
+        mock_offer_get.return_value = test_offer
+
+        res = utils.get_offer(test_offer.uuid, statuses.AVAILABLE)
+
+        self.assertEqual(res, test_offer)
+
+        mock_is_uuid_like.assert_called_once_with(test_offer.uuid)
+        mock_offer_get.assert_called_once_with(test_offer.uuid)
+
+    @mock.patch('esi_leap.api.controllers.v1.utils.uuidutils.is_uuid_like')
+    @mock.patch('esi_leap.api.controllers.v1.utils.offer.Offer.get_all')
+    def test_get_offer_name_available(self,
+                                      mock_offer_get_all,
+                                      mock_is_uuid_like):
+
+        mock_is_uuid_like.return_value = False
+        mock_offer_get_all.return_value = [test_offer]
+
+        res = utils.get_offer(test_offer.name, statuses.AVAILABLE)
+
+        self.assertEqual(res, test_offer)
+
+        mock_is_uuid_like.assert_called_once_with(test_offer.name)
+        mock_offer_get_all.assert_called_once_with(
+            {'name': test_offer.name,
+             'status': statuses.AVAILABLE}
+        )
+
+    @mock.patch('esi_leap.api.controllers.v1.utils.'
+                'contract_authorize_management')
+    @mock.patch('esi_leap.api.controllers.v1.utils.uuidutils.is_uuid_like')
+    @mock.patch('esi_leap.api.controllers.v1.utils.contract.Contract.get')
+    def test_get_contract_authorized_uuid(self,
+                                          mock_contract_get,
+                                          mock_is_uuid_like,
+                                          mock_authorize):
+
+        mock_is_uuid_like.return_value = True
+        mock_contract_get.return_value = test_contract
+
+        res = utils.get_contract_authorized(test_contract.uuid,
+                                            lessee_ctx.to_policy_values())
+
+        self.assertEqual(res, test_contract)
+
+        mock_is_uuid_like.assert_called_once_with(test_contract.uuid)
+        mock_contract_get.assert_called_once_with(test_contract.uuid)
+
+    @mock.patch('esi_leap.api.controllers.v1.utils.'
+                'contract_authorize_management')
+    @mock.patch('esi_leap.api.controllers.v1.utils.uuidutils.is_uuid_like')
+    @mock.patch('esi_leap.api.controllers.v1.utils.contract.Contract.get_all')
+    def test_get_contract_authorized_name(self,
+                                          mock_contract_get_all,
+                                          mock_is_uuid_like,
+                                          mock_authorize):
+
+        mock_is_uuid_like.return_value = False
+        mock_contract_get_all.return_value = [test_contract]
+
+        res = utils.get_contract_authorized(
+            test_contract.name,
+            lessee_ctx.to_policy_values(),
+            [statuses.CREATED, statuses.ACTIVE])
+
+        self.assertEqual(res, test_contract)
+
+        mock_is_uuid_like.assert_called_once_with(test_contract.name)
+        mock_contract_get_all.assert_called_once_with(
+            {'name': test_contract.name,
+             'status': [statuses.CREATED, statuses.ACTIVE]}
+        )
+
+
+class TestOffersControllerStaticMethods(testtools.TestCase):
+
+    @mock.patch.object(test_node_1, 'is_resource_admin',
+                       return_value=True)
+    @mock.patch('esi_leap.api.controllers.v1.utils.policy.authorize')
+    @mock.patch('esi_leap.api.controllers.v1.utils.ro_factory.'
+                'ResourceObjectFactory.get_resource_object',
+                return_value=test_node_1)
+    def test__verify_resource_permission_owner(self,
+                                               mock_gro,
+                                               mock_authorize,
+                                               mock_is_resource_admin):
+
+        utils.verify_resource_permission(
+            owner_ctx.to_policy_values(), test_offer.to_dict())
+
+        mock_gro.assert_called_once_with(
+            test_offer.resource_type,
+            test_offer.resource_uuid)
+        mock_is_resource_admin.assert_called_once_with(test_offer.project_id)
+        assert not mock_authorize.called
+
+    @mock.patch.object(test_node_2, 'is_resource_admin',
+                       return_value=False)
+    @mock.patch('esi_leap.api.controllers.v1.utils.policy.authorize')
+    @mock.patch('esi_leap.api.controllers.v1.utils.ro_factory.'
+                'ResourceObjectFactory.get_resource_object',
+                return_value=test_node_2)
+    def test__verify_resource_permission_admin(self,
+                                               mock_gro,
+                                               mock_authorize,
+                                               mock_is_resource_admin):
+
+        bad_test_offer = offer.Offer(
+            resource_type='test_node',
+            resource_uuid=test_node_2._uuid,
+            project_id=owner_ctx.project_id
+        )
+
+        utils.verify_resource_permission(admin_ctx.to_policy_values(),
+                                         bad_test_offer.to_dict())
+
+        mock_gro.assert_called_once_with(
+            bad_test_offer.resource_type,
+            bad_test_offer.resource_uuid)
+        mock_is_resource_admin.assert_called_once_with(
+            bad_test_offer.project_id)
+        mock_authorize.assert_called_once_with('esi_leap:offer:offer_admin',
+                                               admin_ctx.to_policy_values(),
+                                               admin_ctx.to_policy_values())
+
+    @mock.patch.object(test_node_2, 'is_resource_admin',
+                       return_value=False)
+    @mock.patch('esi_leap.api.controllers.v1.utils.policy.authorize')
+    @mock.patch('esi_leap.api.controllers.v1.utils.ro_factory.'
+                'ResourceObjectFactory.get_resource_object',
+                return_value=test_node_2)
+    def test__verify_resource_permission_invalid_owner(self,
+                                                       mock_gro,
+                                                       mock_authorize,
+                                                       mock_is_resource_admin):
+
+        mock_authorize.side_effect = policy.PolicyNotAuthorized(
+            'esi_leap:offer:offer_admin',
+            owner_ctx.to_dict(), owner_ctx.to_dict())
+
+        bad_test_offer = offer.Offer(
+            resource_type='test_node',
+            resource_uuid=test_node_2._uuid,
+            project_id=owner_ctx.project_id
+        )
+
+        self.assertRaises(policy.PolicyNotAuthorized,
+                          utils.verify_resource_permission,
+                          owner_ctx_2.to_policy_values(),
+                          bad_test_offer.to_dict())
+
+        mock_gro.assert_called_once_with(
+            bad_test_offer.resource_type,
+            bad_test_offer.resource_uuid)
+        mock_is_resource_admin.assert_called_once_with(
+            bad_test_offer.project_id)
+        mock_authorize.assert_called_once_with('esi_leap:offer:offer_admin',
+                                               owner_ctx_2.to_policy_values(),
+                                               owner_ctx_2.to_policy_values())

--- a/esi_leap/tests/base.py
+++ b/esi_leap/tests/base.py
@@ -12,6 +12,8 @@
 
 import fixtures
 
+from oslo_concurrency import lockutils
+from oslo_config import fixture as config
 from oslo_context import context as ctx
 from oslotest import base
 
@@ -39,6 +41,7 @@ class Database(fixtures.Fixture):
 class TestCase(base.BaseTestCase):
 
     def setUp(self):
+        self.config = self.useFixture(config.Config(lockutils.CONF)).config
         super(TestCase, self).setUp()
 
         if not hasattr(self, 'context'):


### PR DESCRIPTION
Adding syncrhonization using the oslo concurrency
lockutils module. This is needed to address race conditions
when creating contracts and offers. This commit prevents
conflicting contracts from being created on an offer,
conflicting offers being created on a resource, and a contract
from being created on an offer being deleted.