### PR TITLE
Bug Fix on offer deletion and manager

### DIFF
--- a/esi_leap/api/controllers/v1/utils.py
+++ b/esi_leap/api/controllers/v1/utils.py
@@ -27,7 +27,9 @@ def get_offer_authorized(uuid_or_name, cdict, status_filter=None):
 
         if not status_filter or o.status == status_filter:
             try:
-                policy.authorize('esi_leap:offer:offer_admin', cdict, cdict)
+                if o.project_id != cdict['project_id']:
+                    policy.authorize('esi_leap:offer:offer_admin',
+                                     cdict, cdict)
                 offer_objs.append(o)
             except oslo_policy.PolicyNotAuthorized:
                 pass
@@ -65,8 +67,11 @@ def verify_resource_permission(cdict, offer_dict):
 def get_offer(uuid_or_name, status_filter=None):
     if uuidutils.is_uuid_like(uuid_or_name):
         o = offer.Offer.get(uuid_or_name)
-        if o.status == status_filter:
+        if not status_filter or o.status == status_filter:
             return o
+        else:
+            raise exception.OfferNotFound(
+                offer_uuid=uuid_or_name)
     else:
         offer_objs = offer.Offer.get_all({'name': uuid_or_name,
                                           'status': status_filter})

--- a/esi_leap/manager/service.py
+++ b/esi_leap/manager/service.py
@@ -61,7 +61,7 @@ class ManagerService(service.Service):
     def _fulfill_contracts(self):
         LOG.info("Checking for contracts to fulfill")
         contracts = contract.Contract.get_all(
-            {'status': statuses.CREATED}, self._context)
+            {'status': [statuses.CREATED]}, self._context)
         now = timeutils.utcnow()
         for c in contracts:
             if c.start_time <= now and now <= c.end_time:


### PR DESCRIPTION
Two bug fixes. One which prevented an owner from
deleting offers by uuid, and one where the manager could
not properly retrieve contracts to fulfill.