### PR TITLE
UUID warning in tests

### DIFF
--- a/esi_leap/tests/api/base.py
+++ b/esi_leap/tests/api/base.py
@@ -74,7 +74,6 @@ class APITestCase(base.DBTestCase):
         all_params.update(params)
         if q:
             all_params.update(query_params)
-        print('GET: %s %r' % (full_path, all_params))
         response = self.app.get(full_path,
                                 params=all_params,
                                 headers=headers,
@@ -82,7 +81,6 @@ class APITestCase(base.DBTestCase):
                                 expect_errors=expect_errors)
         if not expect_errors:
             response = response.json
-        print('GOT:%s' % response)
         return response
 
     # borrowed from Ironic
@@ -124,7 +122,6 @@ class APITestCase(base.DBTestCase):
         """
 
         full_path = path_prefix + path
-        print('%s: %s %s' % (method.upper(), full_path, params))
         response = getattr(self.app, "%s_json" % method)(
             str(full_path),
             params=params,
@@ -133,5 +130,4 @@ class APITestCase(base.DBTestCase):
             extra_environ=extra_environ,
             expect_errors=expect_errors
         )
-        print('GOT:%s' % response)
         return response

--- a/esi_leap/tests/api/controllers/v1/test_contract.py
+++ b/esi_leap/tests/api/controllers/v1/test_contract.py
@@ -14,6 +14,7 @@ import datetime
 import mock
 from oslo_context import context as ctx
 from oslo_policy import policy
+from oslo_utils import uuidutils
 import testtools
 
 from esi_leap.api.controllers.v1.contract import ContractsController
@@ -54,15 +55,17 @@ start_iso = '2016-07-16T00:00:00'
 end = start + datetime.timedelta(days=100)
 end_iso = '2016-10-24T00:00:00'
 
-
 test_node_1 = TestNode('111', owner_ctx.project_id)
+
+o_uuid = uuidutils.generate_uuid()
+c_uuid = uuidutils.generate_uuid()
 
 
 def create_test_offer(context):
     o = offer.Offer(
         resource_type='test_node',
         resource_uuid='1234567890',
-        uuid='aaaaaaaa',
+        uuid=o_uuid,
         start_time=datetime.datetime(2016, 7, 16, 19, 20, 30),
         end_time=datetime.datetime(2016, 8, 16, 19, 20, 30),
         project_id="111111111111"
@@ -73,7 +76,7 @@ def create_test_offer(context):
 
 def create_test_contract(context):
     c = contract.Contract(
-        uuid='bbbbbbbb',
+        uuid=c_uuid,
         start_date=datetime.datetime(2016, 7, 16, 19, 20, 30),
         end_date=datetime.datetime(2016, 8, 16, 19, 20, 30),
         offer_uuid='1234567890',
@@ -95,7 +98,7 @@ test_offer = offer.Offer(
     resource_type='test_node',
     resource_uuid=test_node_1._uuid,
     name="o",
-    uuid='11111',
+    uuid=o_uuid,
     status=statuses.AVAILABLE,
     start_time=start,
     end_time=end,
@@ -103,34 +106,33 @@ test_offer = offer.Offer(
 )
 
 test_contract = contract.Contract(
-    offer_uuid="11111",
+    offer_uuid=o_uuid,
     name='c',
-    uuid='zzzzz',
+    uuid=c_uuid,
     project_id=lessee_ctx.project_id,
     status=statuses.CREATED
 )
 
 test_contract_2 = contract.Contract(
-    offer_uuid="11111",
+    offer_uuid=o_uuid,
     name='c',
-    uuid='yyyyy',
+    uuid=uuidutils.generate_uuid(),
     project_id=lessee_ctx.project_id,
     status=statuses.CREATED
 )
 
 test_contract_3 = contract.Contract(
-    offer_uuid="11111",
+    offer_uuid=o_uuid,
     name='c',
-    uuid='xxxxx',
+    uuid=uuidutils.generate_uuid(),
     project_id=lessee_ctx_2.project_id,
     status=statuses.CREATED
 )
 
-
 test_contract_4 = contract.Contract(
-    offer_uuid="11111",
+    offer_uuid=o_uuid,
     name='c2',
-    uuid='wwwww',
+    uuid=uuidutils.generate_uuid(),
     project_id=lessee_ctx_2.project_id,
     status=statuses.CREATED
 )
@@ -149,7 +151,7 @@ class TestContractsControllerAdmin(test_api_base.APITestCase):
         self.test_contract = contract.Contract(
             start_date=datetime.datetime(2016, 7, 16, 19, 20, 30),
             end_date=datetime.datetime(2016, 8, 16, 19, 20, 30),
-            uuid='1111111111',
+            uuid=c_uuid,
             offer_uuid=o.uuid,
             project_id=lessee_ctx.project_id
         )
@@ -171,7 +173,7 @@ class TestContractsControllerAdmin(test_api_base.APITestCase):
     @mock.patch('esi_leap.objects.contract.Contract.create')
     def test_post(self, mock_create, mock_offer_get, mock_generate_uuid):
 
-        mock_generate_uuid.return_value = '22222'
+        mock_generate_uuid.return_value = c_uuid
         mock_offer_get.return_value = test_offer
 
         data = create_test_contract_data()
@@ -180,8 +182,8 @@ class TestContractsControllerAdmin(test_api_base.APITestCase):
 
         data.pop('offer_uuid_or_name')
         data['project_id'] = lessee_ctx.project_id
-        data['uuid'] = '22222'
-        data['offer_uuid'] = '11111'
+        data['uuid'] = c_uuid
+        data['offer_uuid'] = o_uuid
         self.assertEqual(request.json, data)
         # FIXME: post returns incorrect status code
         # self.assertEqual(http_client.CREATED, request.status_int)

--- a/esi_leap/tests/api/controllers/v1/test_offer.py
+++ b/esi_leap/tests/api/controllers/v1/test_offer.py
@@ -12,6 +12,7 @@
 import datetime
 import mock
 from oslo_context import context as ctx
+from oslo_utils import uuidutils
 import testtools
 
 from esi_leap.api.controllers.v1.offer import OffersController
@@ -40,16 +41,17 @@ start_iso = '2016-07-16T00:00:00'
 end = start + datetime.timedelta(days=100)
 end_iso = '2016-10-24T00:00:00'
 
-
 test_node_1 = TestNode('aaa', owner_ctx.project_id)
 test_node_2 = TestNode('bbb', owner_ctx_2.project_id)
+
+o_uuid = uuidutils.generate_uuid()
 
 
 def create_test_offer(context):
     o = offer.Offer(
         resource_type='test_node',
         resource_uuid='1234567890',
-        uuid='aaaaaaaa',
+        uuid=o_uuid,
         start_time=datetime.datetime(2016, 7, 16, 19, 20, 30),
         end_time=datetime.datetime(2016, 8, 16, 19, 20, 30),
         project_id="111111111111"
@@ -84,7 +86,7 @@ test_offer = offer.Offer(
     resource_type='test_node',
     resource_uuid=test_node_1._uuid,
     name="o",
-    uuid='11111',
+    uuid=o_uuid,
     status=statuses.AVAILABLE,
     start_time=start,
     end_time=end,
@@ -97,7 +99,7 @@ test_offer_2 = offer.Offer(
     start_time=start,
     status=statuses.CANCELLED,
     name="o",
-    uuid='22222',
+    uuid=uuidutils.generate_uuid(),
     end_time=end,
     project_id=owner_ctx.project_id
 )
@@ -107,7 +109,7 @@ test_offer_3 = offer.Offer(
     resource_type='test_node',
     resource_uuid=test_node_2._uuid,
     name="o",
-    uuid='33333',
+    uuid=uuidutils.generate_uuid(),
     status=statuses.AVAILABLE,
     start_time=start,
     end_time=end,
@@ -119,7 +121,7 @@ test_offer_4 = offer.Offer(
     resource_type='test_node',
     resource_uuid=test_node_2._uuid,
     name="o2",
-    uuid='44444',
+    uuid=uuidutils.generate_uuid(),
     status=statuses.AVAILABLE,
     start_time=start,
     end_time=end,
@@ -135,7 +137,7 @@ class TestListOffers(test_api_base.APITestCase):
         self.test_offer = offer.Offer(
             resource_type='test_node',
             resource_uuid='1234567890',
-            uuid='00000',
+            uuid=o_uuid,
             start_time=start,
             end_time=end,
             project_id=owner_ctx.project_id
@@ -159,7 +161,7 @@ class TestListOffers(test_api_base.APITestCase):
                 'OffersController._add_offer_availabilities')
     def test_post(self, mock_aoa, mock_vrp, mock_create, mock_generate_uuid):
 
-        mock_generate_uuid.return_value = '11111'
+        mock_generate_uuid.return_value = o_uuid
         mock_create.return_value = self.test_offer
         data = create_test_offer_data
         request = self.post_json('/offers', data)

--- a/esi_leap/tests/api/controllers/v1/test_utils.py
+++ b/esi_leap/tests/api/controllers/v1/test_utils.py
@@ -14,6 +14,8 @@ import datetime
 import mock
 from oslo_context import context as ctx
 from oslo_policy import policy
+from oslo_utils import uuidutils
+
 import testtools
 
 from esi_leap.api.controllers.v1 import utils
@@ -46,49 +48,17 @@ start_iso = '2016-07-16T00:00:00'
 end = start + datetime.timedelta(days=100)
 end_iso = '2016-10-24T00:00:00'
 
-
 test_node_1 = TestNode('111', owner_ctx.project_id)
 test_node_2 = TestNode('bbb', owner_ctx_2.project_id)
 
-
-def create_test_offer(context):
-    o = offer.Offer(
-        resource_type='test_node',
-        resource_uuid='1234567890',
-        uuid='aaaaaaaa',
-        start_time=datetime.datetime(2016, 7, 16, 19, 20, 30),
-        end_time=datetime.datetime(2016, 8, 16, 19, 20, 30),
-        project_id="111111111111"
-    )
-    o.create(context)
-    return o
-
-
-def create_test_contract(context):
-    c = contract.Contract(
-        uuid='bbbbbbbb',
-        start_date=datetime.datetime(2016, 7, 16, 19, 20, 30),
-        end_date=datetime.datetime(2016, 8, 16, 19, 20, 30),
-        offer_uuid='1234567890',
-        project_id="222222222222"
-    )
-    c.create(context)
-    return c
-
-
-def create_test_contract_data():
-    return {
-        "offer_uuid_or_name": "o",
-        "start_time": "2016-07-16T19:20:30",
-        "end_time": "2016-08-16T19:20:30"
-    }
+o_uuid = uuidutils.generate_uuid()
 
 
 test_offer = offer.Offer(
     resource_type='test_node',
     resource_uuid=test_node_1._uuid,
     name="o",
-    uuid='11111',
+    uuid=o_uuid,
     status=statuses.AVAILABLE,
     start_time=start,
     end_time=end,
@@ -99,7 +69,7 @@ test_offer_2 = offer.Offer(
     resource_type='test_node',
     resource_uuid=test_node_1._uuid,
     name="o",
-    uuid='11111',
+    uuid=uuidutils.generate_uuid(),
     status=statuses.EXPIRED,
     start_time=start,
     end_time=end,
@@ -107,34 +77,33 @@ test_offer_2 = offer.Offer(
 )
 
 test_contract = contract.Contract(
-    offer_uuid="11111",
+    offer_uuid=o_uuid,
     name='c',
-    uuid='zzzzz',
+    uuid=uuidutils.generate_uuid(),
     project_id=lessee_ctx.project_id,
     status=statuses.CREATED
 )
 
 test_contract_2 = contract.Contract(
-    offer_uuid="11111",
+    offer_uuid=o_uuid,
     name='c',
-    uuid='yyyyy',
+    uuid=uuidutils.generate_uuid(),
     project_id=lessee_ctx.project_id,
     status=statuses.CREATED
 )
 
 test_contract_3 = contract.Contract(
-    offer_uuid="11111",
+    offer_uuid=o_uuid,
     name='c',
-    uuid='xxxxx',
+    uuid=uuidutils.generate_uuid(),
     project_id=lessee_ctx_2.project_id,
     status=statuses.CREATED
 )
 
-
 test_contract_4 = contract.Contract(
-    offer_uuid="11111",
+    offer_uuid=o_uuid,
     name='c2',
-    uuid='wwwww',
+    uuid=uuidutils.generate_uuid(),
     project_id=lessee_ctx_2.project_id,
     status=statuses.CREATED
 )

--- a/esi_leap/tests/manager/test_service.py
+++ b/esi_leap/tests/manager/test_service.py
@@ -13,6 +13,7 @@
 import datetime
 import mock
 from oslo_context import context as ctx
+from oslo_utils import uuidutils
 
 from esi_leap.common import statuses
 from esi_leap.manager.service import ManagerService
@@ -25,11 +26,13 @@ lessee_ctx = ctx.RequestContext(project_id="lesseeid",
 owner_ctx = ctx.RequestContext(project_id='ownerid',
                                roles=['owner'])
 
+o_uuid = uuidutils.generate_uuid()
+
 test_offer = offer.Offer(
     resource_type='test_node',
     resource_uuid='abc',
     name="o",
-    uuid='11111',
+    uuid=o_uuid,
     status=statuses.AVAILABLE,
     start_time=datetime.datetime(3000, 7, 16),
     end_time=datetime.datetime(4000, 7, 16),
@@ -37,9 +40,9 @@ test_offer = offer.Offer(
 )
 
 test_contract = contract.Contract(
-    offer_uuid="11111",
+    offer_uuid=o_uuid,
     name='c',
-    uuid='zzzzz',
+    uuid=uuidutils.generate_uuid(),
     project_id=lessee_ctx.project_id,
     status=statuses.CREATED,
     start_time=datetime.datetime(3000, 7, 16),

--- a/esi_leap/tests/objects/test_contract.py
+++ b/esi_leap/tests/objects/test_contract.py
@@ -12,6 +12,7 @@
 
 import datetime
 import mock
+from oslo_utils import uuidutils
 import tempfile
 import threading
 
@@ -22,12 +23,18 @@ from esi_leap.tests import base
 
 start = datetime.datetime(2016, 7, 16, 19, 20, 30)
 
+o_uuid = uuidutils.generate_uuid()
+c_uuid = uuidutils.generate_uuid()
+c_uuid_2 = uuidutils.generate_uuid()
+c_uuid_3 = uuidutils.generate_uuid()
+c_uuid_4 = uuidutils.generate_uuid()
+
 
 def get_test_contract_1():
     return {
         'id': 27,
         'name': 'c',
-        'uuid': '534653c9-880d-4c2d-6d6d-11111111111',
+        'uuid': c_uuid,
         'project_id': 'le55ee',
         'start_time': start + datetime.timedelta(days=5),
         'end_time': start + datetime.timedelta(days=10),
@@ -35,7 +42,7 @@ def get_test_contract_1():
         'expire_time': start + datetime.timedelta(days=10),
         'status': statuses.CREATED,
         'properties': {},
-        'offer_uuid': '534653c9-880d-4c2d-6d6d-f4f2a09e384',
+        'offer_uuid': o_uuid,
         'created_at': None,
         'updated_at': None
     }
@@ -46,7 +53,7 @@ def get_test_contract_2():
     return {
         'id': 28,
         'name': 'c',
-        'uuid': '534653c9-880d-4c2d-6d6d-22222222222',
+        'uuid': c_uuid_2,
         'project_id': 'le55ee',
         'start_time': start + datetime.timedelta(days=15),
         'end_time': start + datetime.timedelta(days=20),
@@ -54,7 +61,7 @@ def get_test_contract_2():
         'expire_time': start + datetime.timedelta(days=20),
         'status': statuses.CREATED,
         'properties': {},
-        'offer_uuid': '534653c9-880d-4c2d-6d6d-f4f2a09e384',
+        'offer_uuid': o_uuid,
         'created_at': None,
         'updated_at': None
     }
@@ -65,7 +72,7 @@ def get_test_contract_3():
     return {
         'id': 29,
         'name': 'c',
-        'uuid': '534653c9-880d-4c2d-6d6d-33333333333',
+        'uuid': c_uuid_3,
         'project_id': 'le55ee_2',
         'start_time': start + datetime.timedelta(days=25),
         'end_time': start + datetime.timedelta(days=30),
@@ -73,7 +80,7 @@ def get_test_contract_3():
         'expire_time': start + datetime.timedelta(days=30),
         'status': statuses.CREATED,
         'properties': {},
-        'offer_uuid': '534653c9-880d-4c2d-6d6d-f4f2a09e384',
+        'offer_uuid': o_uuid,
         'created_at': None,
         'updated_at': None
     }
@@ -84,7 +91,7 @@ def get_test_contract_4():
     return {
         'id': 30,
         'name': 'c2',
-        'uuid': '534653c9-880d-4c2d-6d6d-44444444444',
+        'uuid': c_uuid_4,
         'project_id': 'le55ee_2',
         'start_time': start + datetime.timedelta(days=35),
         'end_time': start + datetime.timedelta(days=40),
@@ -92,7 +99,7 @@ def get_test_contract_4():
         'expire_time': start + datetime.timedelta(days=40),
         'status': statuses.CREATED,
         'properties': {},
-        'offer_uuid': '534653c9-880d-4c2d-6d6d-f4f2a09e384',
+        'offer_uuid': o_uuid,
         'created_at': None,
         'updated_at': None
     }
@@ -106,7 +113,7 @@ def get_offer():
     o = Offer()
     offer = dict(
         id=27,
-        uuid='534653c9-880d-4c2d-6d6d-f4f2a09e384',
+        uuid=o_uuid,
         project_id='01d4e6a72f5c408813e02f664cc8c83e',
         resource_type='dummy_node',
         resource_uuid='1718',

--- a/esi_leap/tests/objects/test_offer.py
+++ b/esi_leap/tests/objects/test_offer.py
@@ -12,6 +12,7 @@
 
 import datetime
 import mock
+from oslo_utils import uuidutils
 import tempfile
 import threading
 
@@ -21,13 +22,17 @@ from esi_leap.tests import base
 
 start = datetime.datetime(2016, 7, 16, 19, 20, 30)
 
+o_uuid = uuidutils.generate_uuid()
+o_uuid_2 = uuidutils.generate_uuid()
+o_uuid_3 = uuidutils.generate_uuid()
+
 
 def get_test_offer():
 
     return {
         'id': 27,
         'name': "o",
-        'uuid': '534653c9-880d-4c2d-6d6d-11111111111',
+        'uuid': o_uuid,
         'project_id': '0wn5r',
         'resource_type': 'dummy_node',
         'resource_uuid': '1718',
@@ -45,7 +50,7 @@ def get_test_offer_2():
     return {
         'id': 28,
         'name': "o",
-        'uuid': '534653c9-880d-4c2d-6d6d-2222222222',
+        'uuid': o_uuid_2,
         'project_id': '0wn5r',
         'resource_type': 'dummy_node',
         'resource_uuid': '1718',
@@ -63,7 +68,7 @@ def get_test_offer_3():
     return {
         'id': 29,
         'name': "o",
-        'uuid': '534653c9-880d-4c2d-6d6d-3333333333',
+        'uuid': o_uuid_3,
         'project_id': '0wn5r2',
         'resource_type': 'dummy_node',
         'resource_uuid': '1718',


### PR DESCRIPTION
Changed the uuid's of offer and contract objects
created in different test cases to use valid uuids
to correct a warning that would pop up when testing.