### PR TITLE
Bugfix on Offer create

### DIFF
--- a/esi_leap/api/controllers/v1/offer.py
+++ b/esi_leap/api/controllers/v1/offer.py
@@ -161,7 +161,7 @@ class OffersController(rest.RestController):
                                  end_time=str(offer_dict['end_time']))
 
         o = offer.Offer(**offer_dict)
-        o.create(request)
+        o.create()
         o = OffersController._add_offer_availabilities(o)
         return Offer(**o)
 

--- a/esi_leap/tests/api/controllers/v1/test_offer.py
+++ b/esi_leap/tests/api/controllers/v1/test_offer.py
@@ -168,6 +168,8 @@ class TestListOffers(test_api_base.APITestCase):
         data['project_id'] = owner_ctx.project_id
         self.assertEqual(1, mock_create.call_count)
         self.assertEqual(request.json, {})
+
+        mock_create.assert_called_once_with()
         # FIXME: post returns incorrect status code
         # self.assertEqual(http_client.CREATED, request.status_int)
 


### PR DESCRIPTION
Fixed a bug where an extra context parameter
was being passed into the offer create call in
the offer api controller.