### PR TITLE
Rename contract with lease

### DIFF
--- a/docs/esi-leap-api-ref.md
+++ b/docs/esi-leap-api-ref.md
@@ -66,29 +66,29 @@ curl -X POST -sH "X-Auth-Token: $token" http://localhost:7777/v1/offers  -H 'Con
 ##### DELETE
 * The /v1/offers/\<uuid> endpoint supports DELETE requests for offer cancellation.
 * Offers will have their "status" set to 'cancelled'.
-* All contracts on this offer will also have their "status" set to 'cancelled'.
+* All leases on this offer will also have their "status" set to 'cancelled'.
 * Returns null on success.
 
 
-## Contract API
+## Lease API
 
-The contract api endpoint can be reached at /v1/contracts
+The lease api endpoint can be reached at /v1/leases
 
 
 ##### GET
-* The /v1/contracts/\<uuid_or_name> endpoint is used to retrieve the contract with the given uuid. The response type is 'application/json'.
-* The /v1/contracts endpoint is used to retrieve a list of contracts. This url supports several url variables for retrieving offers filtered by given values. The response type is 'application/json'.
-  * project_id: Returns all contracts with given project_id.
+* The /v1/leases/\<uuid_or_name> endpoint is used to retrieve the lease with the given uuid. The response type is 'application/json'.
+* The /v1/leases endpoint is used to retrieve a list of leases. This url supports several url variables for retrieving offers filtered by given values. The response type is 'application/json'.
+  * project_id: Returns all leases with given project_id.
     * This value will default to the project_id of the request.
   * status: Returns all offers with given status. 
-    * This value will default to returning contracts with status 'open'.
-    * This value can be set to 'any' to return contracts without filtering by status.
-  * start_time and end_time: Passing in values for the start_time and end_time variables will return all contracts with a start_time and end_time which completely span the given values. These two url variables must be used together. Passing in only one will throw an error. 
-  * owner: Returns all contracts which are related to offers with project_id 'owner'.
-  * view: Setting view to 'all' will return all contracts in the database. This value can be used in combination with other filters.
+    * This value will default to returning leases with status 'open'.
+    * This value can be set to 'any' to return leases without filtering by status.
+  * start_time and end_time: Passing in values for the start_time and end_time variables will return all leases with a start_time and end_time which completely span the given values. These two url variables must be used together. Passing in only one will throw an error. 
+  * owner: Returns all leases which are related to offers with project_id 'owner'.
+  * view: Setting view to 'all' will return all leases in the database. This value can be used in combination with other filters.
 
 ##### POST
-* The /v1/contracts endpoint supports POST requests for contract creation with values passed through the body.
+* The /v1/leases endpoint supports POST requests for lease creation with values passed through the body.
   * start_time:
     * A datetime string.
     * This field is optional. Not setting it will default start_time to the time when the request was sent.
@@ -102,11 +102,11 @@ The contract api endpoint can be reached at /v1/contracts
     * A string.
     * This field is required.
 * 'status' and 'uuid' are read only. 
-* The response to a POST request will be the newly created contract. The response type is 'application/json'.
+* The response to a POST request will be the newly created lease. The response type is 'application/json'.
 
 An example curl request is shown below.
 ```
-curl -X POST -sH "X-Auth-Token: $token" http://localhost:7777/v1/contracts  -H 'Content-Type: application/json' -d '{
+curl -X POST -sH "X-Auth-Token: $token" http://localhost:7777/v1/leases  -H 'Content-Type: application/json' -d '{
   "start_time": "2020-04-07 05:45:02",
   "end_time": "2020-04-09 05:45:02",
   "name": "c1",
@@ -117,7 +117,7 @@ curl -X POST -sH "X-Auth-Token: $token" http://localhost:7777/v1/contracts  -H '
 ```
 
 ##### DELETE
-* The /v1/contracts/\<uuid> endpoint supports DELETE requests for contract cancellation.
-* Contracts will have their "status" set to 'cancelled'.
-* Cancelling a contract does not affect any other contracts. The related offer will have its availabilities updated to reflect the newly freed time range.
+* The /v1/leases/\<uuid> endpoint supports DELETE requests for lease cancellation.
+* Leases will have their "status" set to 'cancelled'.
+* Cancelling a lease does not affect any other leases. The related offer will have its availabilities updated to reflect the newly freed time range.
 * Returns null on success.

--- a/docs/esi-leap-policy.md
+++ b/docs/esi-leap-policy.md
@@ -10,13 +10,13 @@ By default, the is_admin policy is given to any openstack user with the role 'ad
   * offers can be created with any resource_uuid.
 * DELETE: an admin can cancel offers on behalf of any user.
 
-##### Contract
-* GET: an admin can view any contract with the /v1/contracts/\<uuid> endpoint. The admin has access to all GET filters.
+##### Lease
+* GET: an admin can view any lease with the /v1/leases/\<uuid> endpoint. The admin has access to all GET filters.
   * 'owner' can be set to any value
   * 'project_id' can be set to any value
   * 'view' variable to 'all'
-* POST: an admin can post contracts.
-* DELETE: an admin can cancel any contract with the /v1/contracts/\<uuid> endpoint.
+* POST: an admin can post leases.
+* DELETE: an admin can cancel any lease with the /v1/leases/\<uuid> endpoint.
 
 ### is_owner
 By default, the is_owner policy is given to any openstack user with the role 'owner' or 'esi_leap_owner'.
@@ -29,14 +29,14 @@ By default, the is_owner policy is given to any openstack user with the role 'ow
   * The resource corresponding to resource_uuid must have project_owner_id = the user's project_id.
 * DELETE: an owner can cancel any offer they own. IE, the offer's project_id = user's project_id and the resource's project_owner_id = user's project_id.
 
-##### Contract
-* GET: an owner can view any contract which is related to an offer owned by the the owner or any contract owned by the owner. The owner has restricted access to the GET filters.
+##### Lease
+* GET: an owner can view any lease which is related to an offer owned by the the owner or any lease owned by the owner. The owner has restricted access to the GET filters.
   * 'owner' must be set to the user's project_id
-    * The default behavior of GET is to retrieve contracts owned. Not using this variable will return all contracts owned, and because an owner may not create contracts, will thus be an empty list.
+    * The default behavior of GET is to retrieve leases owned. Not using this variable will return all leases owned, and because an owner may not create leases, will thus be an empty list.
   * 'project_id' can be set to any value if used with the 'owner' variable. If used without the 'owner' variable, project_id must equal user's project_id.
   * 'view' variable is not allowed to be set.
-* POST: an owner cannot post contracts.
-* DELETE: an owner can cancel any contract tied to an offer which is owned by the user.
+* POST: an owner cannot post leases.
+* DELETE: an owner can cancel any lease tied to an offer which is owned by the user.
 
 
 ### is_lessee
@@ -49,14 +49,14 @@ By default, the is_lessee policy is given to any openstack user with the role 'l
 * POST: a lessee cannot create an offer.
 * DELETE: a lessee cannot delete an offer.
 
-##### Contract
-* GET: a lessee can view any contract which is related to an offer owned by the the lessee or any contract owned by the lessee. The lessee has restricted access to the GET filters.
+##### Lease
+* GET: a lessee can view any lease which is related to an offer owned by the the lessee or any lease owned by the lessee. The lessee has restricted access to the GET filters.
   * 'owner' must be set to the user's project_id
-    * The default behavior of GET is to retrieve contracts owned. Not using this variable will return all contracts owned by the lessee.
+    * The default behavior of GET is to retrieve leases owned. Not using this variable will return all leases owned by the lessee.
   * 'project_id' can be set to any value if used with the 'owner' variable. If used without the 'owner' variable, project_id must equal user's project_id.
   * 'view' variable is not allowed to be set.
-* POST: a lessee can create contracts.
-* DELETE: a lessee can cancel any contract they own.
+* POST: a lessee can create leases.
+* DELETE: a lessee can cancel any lease they own.
 
 
 The default policies are listed below.
@@ -73,31 +73,31 @@ default_policies = [
                        description='Lessee API access'),
 ]
 
-contract_policies = [
+lease_policies = [
     policy.DocumentedRuleDefault(
-        'esi_leap:contract:contract_admin',
+        'esi_leap:lease:lease_admin',
         'rule:is_admin',
-        'Complete permissions over contracts',
-        [{'path': '/contracts', 'method': 'POST'},
-         {'path': '/contracts', 'method': 'GET'},
-         {'path': '/contracts/{contract_ident}', 'method': 'GET'},
-         {'path': '/contracts/{contract_ident}', 'method': 'DELETE'}]),
+        'Complete permissions over leases',
+        [{'path': '/leases', 'method': 'POST'},
+         {'path': '/leases', 'method': 'GET'},
+         {'path': '/leases/{lease_ident}', 'method': 'GET'},
+         {'path': '/leases/{lease_ident}', 'method': 'DELETE'}]),
     policy.DocumentedRuleDefault(
-        'esi_leap:contract:create',
+        'esi_leap:lease:create',
         'rule:is_admin or rule:is_lessee',
-        'Create contract',
-        [{'path': '/contracts', 'method': 'POST'}]),
+        'Create lease',
+        [{'path': '/leases', 'method': 'POST'}]),
     policy.DocumentedRuleDefault(
-        'esi_leap:contract:get',
+        'esi_leap:lease:get',
         'rule:is_admin or rule:is_lessee or rule:is_owner',
-        'Retrieve all contracts owned by project_id',
-        [{'path': '/contracts', 'method': 'GET'},
-         {'path': '/contracts/{contract_ident}', 'method': 'GET'}]),
+        'Retrieve all leases owned by project_id',
+        [{'path': '/leases', 'method': 'GET'},
+         {'path': '/leases/{lease_ident}', 'method': 'GET'}]),
     policy.DocumentedRuleDefault(
-        'esi_leap:contract:delete',
+        'esi_leap:lease:delete',
         'rule:is_admin or rule:is_owner or rule:is_lessee',
-        'Delete contract',
-        [{'path': '/contracts/{contract_ident}', 'method': 'DELETE'}]),
+        'Delete lease',
+        [{'path': '/leases/{lease_ident}', 'method': 'DELETE'}]),
 ]
 
 offer_policies = [

--- a/docs/esi-leap-reporting.md
+++ b/docs/esi-leap-reporting.md
@@ -5,7 +5,7 @@ of a resource over time.
 
 To generate a csv file with data on all lessees' usage on different nodes:
 ```
-openstack lease contract list --all --long -f csv > report.csv
+openstack esi lease list --all --long -f csv > report.csv
 ```
 
 The Esi-Leap api allows users to retrieve data based on certain parameters. 
@@ -15,19 +15,19 @@ projects type ``openstack project list`` and from there grab the desired project
 
 
 ```
-openstack lease contract list --project-id <project_id> --all --long -f csv > report.csv
+openstack esi lease list --project-id <project_id> --all --long -f csv > report.csv
 ```
 
 To generate a report based on usage of a particular owner's resources, run the command:
 
 ```
-openstack lease contract list --owner <project_id> --all --long -f csv > report.csv
+openstack esi lease list --owner <project_id> --all --long -f csv > report.csv
 ```
 
 To generate a report based on usage over a particular date range, run the command:
 
 ```
-opensack lease contract list --time-range <datetime string> <datetime string> --all --long -f csv > report.csv
+opensack esi lease list --time-range <datetime string> <datetime string> --all --long -f csv > report.csv
 ```
 
 These different arguments can be combined together for report generation.

--- a/docs/esi-leap-requirements.md
+++ b/docs/esi-leap-requirements.md
@@ -1,7 +1,7 @@
 # ESI Leap Requirements
 
 ## Overview
-ESI Leap is a leasing service for bare metal. Ironic nodes owners can offer up their nodes to other users, while lesees can view offers and create a contract for available nodes.
+ESI Leap is a leasing service for bare metal. Ironic nodes owners can offer up their nodes to other users, while lesees can view offers and create a lease for available nodes.
 
 ## Definitions
 
@@ -93,8 +93,8 @@ An offer response has the following fields:
 * "created_at", "updated_at", and "id" are only used in the schema and cannot be read or set.
 
 
-### Contract
-Users can choose available nodes offered up and make contracts to lease nodes. A contract example is shown below:
+### Lease
+Users can choose available nodes offered up and make leases to lease nodes. A lease example is shown below:
 ```
     {
         'id': 27,
@@ -112,23 +112,23 @@ Users can choose available nodes offered up and make contracts to lease nodes. A
         'updated_at': None
     }
 ```
-The contract data model is designed to support the following basic APIs:
-* Get a contract by contract_uuid.
-* Get contract(s) with filters: [project_id, status, start_time, end_time, offer_uuid, owner].
-* List an offer's relevant contracts.
-* Create a new contract with given values.
-* Update a contract's fields. Such as update the status to 'active' or 'expired', etc.
-* Delete a contract by contract_uuid.
+The lease data model is designed to support the following basic APIs:
+* Get a lease by lease_uuid.
+* Get lease(s) with filters: [project_id, status, start_time, end_time, offer_uuid, owner].
+* List an offer's relevant leases.
+* Create a new lease with given values.
+* Update a lease's fields. Such as update the status to 'active' or 'expired', etc.
+* Delete a lease by lease_uuid.
 
-The lifecycle of a contract is
-* 'created' on contract creation.
-* 'active' once a contract's start_time has passed and its end_time has not yet passed.
-* 'expired' once a contracts's end_time has passed.
-* 'cancelled' if a contract is prematurely deleted.
+The lifecycle of a lease is
+* 'created' on lease creation.
+* 'active' once a lease's start_time has passed and its end_time has not yet passed.
+* 'expired' once a leases's end_time has passed.
+* 'cancelled' if a lease is prematurely deleted.
 
-The contract api endpoint can be reached at /v1/contracts
+The lease api endpoint can be reached at /v1/leases
 
-An example contract response is shown below.
+An example lease response is shown below.
 
 ```
 {
@@ -145,37 +145,37 @@ An example contract response is shown below.
 }
 ```
 
-A contract response has the following fields:
-* "uuid" is the primary key for a contract entry.
-* "name" is an identifier the user may set for a contract on creation. Can be used for offer management instead of 'uuid'. Does not have to be unique.
-* "project_id" is the project_id of the owner of the contract and the that is leasing the offer.
+A lease response has the following fields:
+* "uuid" is the primary key for a lease entry.
+* "name" is an identifier the user may set for a lease on creation. Can be used for offer management instead of 'uuid'. Does not have to be unique.
+* "project_id" is the project_id of the owner of the lease and the that is leasing the offer.
 * "start_time" is a datetime representing the time in which the offer is being leased.
-* "fulfill_time" is a datetime representing the time in which the contract is set to active and the user gains access to the node.
+* "fulfill_time" is a datetime representing the time in which the lease is set to active and the user gains access to the node.
 * "end_time" is a datetime representing the time in which the offer is no longer being leased.
 * "expire_time" is a datetime representing the time in which the lessee no longer has access to the resource.
-* "status" is the status of the contract. There are three valid statuses for a contract.
-  * open: a contract is set. This is the state of a contract on creation.
-  * fulfilled: a user has leased the offer. When a contract's end_time has passed, it's status is set to "fulfilled".
-  * cancelled: a contract is no longer valid. A contract is set to cancelled when it is manually revoked by a user before its end_time has passed.
-* "properties" is the baremetal properties of a contract.
-* "offer_uuid" is the uuid of the offer which the contract is leased against.
+* "status" is the status of the lease. There are three valid statuses for a lease.
+  * open: a lease is set. This is the state of a lease on creation.
+  * fulfilled: a user has leased the offer. When a lease's end_time has passed, it's status is set to "fulfilled".
+  * cancelled: a lease is no longer valid. A lease is set to cancelled when it is manually revoked by a user before its end_time has passed.
+* "properties" is the baremetal properties of a lease.
+* "offer_uuid" is the uuid of the offer which the lease is leased against.
 * "created_at", "updated_at", and "id" are only used in the schema and cannot be read or set.
 
 
 
 ### Manager Service
-An ESI Leap manager has periodic jobs to manage offers and contracts. 
+An ESI Leap manager has periodic jobs to manage offers and leases. 
 * expire offers: out-of-date offers, i.e, the current timestamp > offer's end_time, will be updated with an 'EXPIRED' status.
-* fulfill contracts: if a contract's start_time <= the current timestamp and is not expired, the manager service will fulfill the resources in the contracts and update the status of the contracts to 'active'. 
-* expire contracts: same as 'expire offers', ESI Leap will expire contracts based on timestamp.
-* update offers: after the manager fulfills and expires contracts, it will update the relevant offers' status. The offers in a fulfilled contract should be unavailable to others. Likewise, when a contract expires, offers in the contract should be updated and be available again. 
+* fulfill leases: if a lease's start_time <= the current timestamp and is not expired, the manager service will fulfill the resources in the leases and update the status of the leases to 'active'. 
+* expire leases: same as 'expire offers', ESI Leap will expire leases based on timestamp.
+* update offers: after the manager fulfills and expires leases, it will update the relevant offers' status. The offers in a fulfilled lease should be unavailable to others. Likewise, when a lease expires, offers in the lease should be updated and be available again. 
 
 ## Reporting API
-ESI Leap admin queries this API to learn about the usage of nodes given a period. The admin enters a date range to get all contracts' information within that range. The results could be like this:
+ESI Leap admin queries this API to learn about the usage of nodes given a period. The admin enters a date range to get all leases' information within that range. The results could be like this:
 ```
     [
         {
-        'contract_uuid':'634653c9-880d-4c2d-6d6d-f4f2a09e384',
+        'lease_uuid':'634653c9-880d-4c2d-6d6d-f4f2a09e384',
         'project_id': '01d4e6a72f5c408813e02f664cc8c83e',
         'offer_uuid': '534653c9-880d-4c2d-6d6d-f4f2a09e384',
         'resource_uuid': '1718',
@@ -189,9 +189,9 @@ ESI Leap admin queries this API to learn about the usage of nodes given a period
         'updated_at': None
         },
         {
-        'contract_uuid':...,
+        'lease_uuid':...,
         ...
         }
     ]
 ```
-With the contracts and nodes information, admin can inform owners about the status of the node and who leases their nodes during a date range.
+With the leases and nodes information, admin can inform owners about the status of the node and who leases their nodes during a date range.

--- a/esi_leap/api/controllers/v1/root.py
+++ b/esi_leap/api/controllers/v1/root.py
@@ -14,13 +14,13 @@ from oslo_serialization import jsonutils
 import pecan
 from pecan import rest
 
-from esi_leap.api.controllers.v1 import contract
+from esi_leap.api.controllers.v1 import lease
 from esi_leap.api.controllers.v1 import offer
 
 
 class Controller(rest.RestController):
 
-    contracts = contract.ContractsController()
+    leases = lease.LeasesController()
     offers = offer.OffersController()
 
     @pecan.expose(content_type='application/json')

--- a/esi_leap/common/exception.py
+++ b/esi_leap/common/exception.py
@@ -37,21 +37,21 @@ class ESILeapException(Exception):
         super(ESILeapException, self).__init__(message)
 
 
-class ContractNoPermission(ESILeapException):
+class LeaseNoPermission(ESILeapException):
     msg_fmt = _("You do not have permissions on "
-                "contract %(contract_uuid)s.")
+                "lease %(lease_uuid)s.")
 
 
-class ContractDuplicateName(ESILeapException):
-    msg_fmt = _("Duplicate contracts with name %(name)s.")
+class LeaseDuplicateName(ESILeapException):
+    msg_fmt = _("Duplicate leases with name %(name)s.")
 
 
-class ContractNotFound(ESILeapException):
-    msg_fmt = _("Contract with name or uuid %(contract_id)s not found.")
+class LeaseNotFound(ESILeapException):
+    msg_fmt = _("Lease with name or uuid %(lease_id)s not found.")
 
 
-class ContractNoOfferUUID(ESILeapException):
-    msg_fmt = _("Cannot create contract without parameter offer_uuid.")
+class LeaseNoOfferUUID(ESILeapException):
+    msg_fmt = _("Cannot create lease without parameter offer_uuid.")
 
 
 class OfferNoPermission(ESILeapException):

--- a/esi_leap/common/policy.py
+++ b/esi_leap/common/policy.py
@@ -31,31 +31,31 @@ default_policies = [
                        description='Lessee API access'),
 ]
 
-contract_policies = [
+lease_policies = [
     policy.DocumentedRuleDefault(
-        'esi_leap:contract:contract_admin',
+        'esi_leap:lease:lease_admin',
         'rule:is_admin',
-        'Complete permissions over contracts',
-        [{'path': '/contracts', 'method': 'POST'},
-         {'path': '/contracts', 'method': 'GET'},
-         {'path': '/contracts/{contract_ident}', 'method': 'GET'},
-         {'path': '/contracts/{contract_ident}', 'method': 'DELETE'}]),
+        'Complete permissions over leases',
+        [{'path': '/leases', 'method': 'POST'},
+         {'path': '/leases', 'method': 'GET'},
+         {'path': '/leases/{lease_ident}', 'method': 'GET'},
+         {'path': '/leases/{lease_ident}', 'method': 'DELETE'}]),
     policy.DocumentedRuleDefault(
-        'esi_leap:contract:create',
+        'esi_leap:lease:create',
         'rule:is_admin or rule:is_lessee',
-        'Create contract',
-        [{'path': '/contracts', 'method': 'POST'}]),
+        'Create lease',
+        [{'path': '/leases', 'method': 'POST'}]),
     policy.DocumentedRuleDefault(
-        'esi_leap:contract:get',
+        'esi_leap:lease:get',
         'rule:is_admin or rule:is_lessee or rule:is_owner',
-        'Retrieve all contracts owned by project_id',
-        [{'path': '/contracts', 'method': 'GET'},
-         {'path': '/contracts/{contract_ident}', 'method': 'GET'}]),
+        'Retrieve all leases owned by project_id',
+        [{'path': '/leases', 'method': 'GET'},
+         {'path': '/leases/{lease_ident}', 'method': 'GET'}]),
     policy.DocumentedRuleDefault(
-        'esi_leap:contract:delete',
+        'esi_leap:lease:delete',
         'rule:is_admin or rule:is_owner or rule:is_lessee',
-        'Delete contract',
-        [{'path': '/contracts/{contract_ident}', 'method': 'DELETE'}]),
+        'Delete lease',
+        [{'path': '/leases/{lease_ident}', 'method': 'DELETE'}]),
 ]
 
 offer_policies = [
@@ -89,7 +89,7 @@ offer_policies = [
 def list_rules():
     policies = itertools.chain(
         default_policies,
-        contract_policies,
+        lease_policies,
         offer_policies,
     )
     return policies

--- a/esi_leap/common/utils.py
+++ b/esi_leap/common/utils.py
@@ -25,5 +25,5 @@ def get_offer_lock_name(offer_uuid):
     return 'offer' + '-' + offer_uuid
 
 
-def get_contract_lock_name(contract_uuid):
-    return 'contract' + '-' + contract_uuid
+def get_lease_lock_name(lease_uuid):
+    return 'lease' + '-' + lease_uuid

--- a/esi_leap/db/api.py
+++ b/esi_leap/db/api.py
@@ -97,8 +97,8 @@ def offer_get_first_availability(offer_uuid, start, end):
         offer_uuid, start, end)
 
 
-def offer_verify_contract_availability(offer_ref, start, end):
-    return IMPL.offer_verify_contract_availability(
+def offer_verify_lease_availability(offer_ref, start, end):
+    return IMPL.offer_verify_lease_availability(
         offer_ref, start, end)
 
 
@@ -119,29 +119,29 @@ def offer_destroy(offer_uuid):
     return IMPL.offer_destroy(offer_uuid)
 
 
-# Contract
+# Lease
 @to_dict
-def contract_get_by_uuid(contract_uuid):
-    return IMPL.contract_get(contract_uuid)
-
-
-@to_dict
-def contract_get_by_name(contract_name):
-    return IMPL.contract_get(contract_name)
+def lease_get_by_uuid(lease_uuid):
+    return IMPL.lease_get(lease_uuid)
 
 
 @to_dict
-def contract_get_all():
-    return IMPL.contract_get_all()
+def lease_get_by_name(lease_name):
+    return IMPL.lease_get(lease_name)
 
 
-def contract_create(values):
-    return IMPL.contract_create(values)
+@to_dict
+def lease_get_all():
+    return IMPL.lease_get_all()
 
 
-def contract_update(contract_uuid, values):
-    return IMPL.contract_update(contract_uuid, values)
+def lease_create(values):
+    return IMPL.lease_create(values)
 
 
-def contract_destroy(contract_uuid):
-    return IMPL.contract_destroy(contract_uuid)
+def lease_update(lease_uuid, values):
+    return IMPL.lease_update(lease_uuid, values)
+
+
+def lease_destroy(lease_uuid):
+    return IMPL.lease_destroy(lease_uuid)

--- a/esi_leap/db/sqlalchemy/models.py
+++ b/esi_leap/db/sqlalchemy/models.py
@@ -58,14 +58,14 @@ class Offer(Base):
     properties = Column(db_types.JsonEncodedDict, nullable=True)
 
 
-class Contract(Base):
-    """Represents an accepted contract."""
+class Lease(Base):
+    """Represents an accepted lease."""
 
-    __tablename__ = 'contracts'
+    __tablename__ = 'leases'
     __table_args__ = (
-        Index('contract_uuid_idx', 'uuid'),
-        Index('contract_project_id_idx', 'project_id'),
-        Index('contract_status_idx', 'status'),
+        Index('lease_uuid_idx', 'uuid'),
+        Index('lease_project_id_idx', 'project_id'),
+        Index('lease_status_idx', 'status'),
     )
 
     id = Column(Integer, primary_key=True, nullable=False, autoincrement=True)

--- a/esi_leap/objects/__init__.py
+++ b/esi_leap/objects/__init__.py
@@ -1,3 +1,3 @@
 def register_all():
-    __import__('esi_leap.objects.contract')
+    __import__('esi_leap.objects.lease')
     __import__('esi_leap.objects.offer')

--- a/esi_leap/resource_objects/dummy_node.py
+++ b/esi_leap/resource_objects/dummy_node.py
@@ -25,10 +25,10 @@ class DummyNode(object):
         self._uuid = uuid
         self._path = DUMMY_NODE_DIR + "/" + uuid
 
-    def get_contract_uuid(self):
+    def get_lease_uuid(self):
         with open(self._path) as node_file:
             node_dict = json.load(node_file)
-        return node_dict.get("contract_uuid", None)
+        return node_dict.get("lease_uuid", None)
 
     def get_project_id(self):
         with open(self._path) as node_file:
@@ -40,18 +40,18 @@ class DummyNode(object):
             node_dict = json.load(node_file)
         return node_dict.get("server_config", None)
 
-    def set_contract(self, contract):
+    def set_lease(self, lease):
         with open(self._path) as node_file:
             node_dict = json.load(node_file)
-        node_dict["contract_uuid"] = contract.uuid
-        node_dict["project_id"] = contract.project_id
+        node_dict["lease_uuid"] = lease.uuid
+        node_dict["project_id"] = lease.project_id
         with open(self._path, 'w') as node_file:
             json.dump(node_dict, node_file)
 
-    def expire_contract(self, contract):
+    def expire_lease(self, lease):
         with open(self._path) as node_file:
             node_dict = json.load(node_file)
-        node_dict.pop("contract_uuid", None)
+        node_dict.pop("lease_uuid", None)
         node_dict.pop("project_id", None)
         with open(self._path, 'w') as node_file:
             json.dump(node_dict, node_file)

--- a/esi_leap/resource_objects/ironic_node.py
+++ b/esi_leap/resource_objects/ironic_node.py
@@ -43,9 +43,9 @@ class IronicNode(object):
     def __init__(self, uuid):
         self._uuid = uuid
 
-    def get_contract_uuid(self):
+    def get_lease_uuid(self):
         node = get_ironic_client().node.get(self._uuid)
-        return node.properties.get('contract_uuid', None)
+        return node.properties.get('lease_uuid', None)
 
     def get_project_id(self):
         node = get_ironic_client().node.get(self._uuid)
@@ -54,32 +54,32 @@ class IronicNode(object):
     def get_node_config(self):
         node = get_ironic_client().node.get(self._uuid)
         config = node.properties
-        config.pop('contract_uuid', None)
+        config.pop('lease_uuid', None)
         return config
 
-    def set_contract(self, contract):
+    def set_lease(self, lease):
         patches = []
         patches.append({
             "op": "add",
-            "path": "/properties/contract_uuid",
-            "value": contract.uuid,
+            "path": "/properties/lease_uuid",
+            "value": lease.uuid,
         })
         patches.append({
             "op": "add",
             "path": "/lessee",
-            "value": contract.project_id,
+            "value": lease.project_id,
         })
         if len(patches) > 0:
             get_ironic_client().node.update(self._uuid, patches)
 
-    def expire_contract(self, contract):
+    def expire_lease(self, lease):
         patches = []
-        if self.get_contract_uuid() != contract.uuid:
+        if self.get_lease_uuid() != lease.uuid:
             return
-        if self.get_contract_uuid():
+        if self.get_lease_uuid():
             patches.append({
                 "op": "remove",
-                "path": "/properties/contract_uuid",
+                "path": "/properties/lease_uuid",
             })
         if self.get_project_id():
             patches.append({

--- a/esi_leap/resource_objects/test_node.py
+++ b/esi_leap/resource_objects/test_node.py
@@ -17,7 +17,7 @@ class TestNode(object):
         self._uuid = uuid
         self._project_id = project_id
 
-    def get_contract_uuid(self):
+    def get_lease_uuid(self):
         return '12345'
 
     def get_project_id(self):
@@ -26,10 +26,10 @@ class TestNode(object):
     def get_node_config(self):
         return {}
 
-    def set_contract(self, contract):
+    def set_lease(self, lease):
         return
 
-    def expire_contract(self, contract):
+    def expire_lease(self, lease):
         return
 
     def is_resource_admin(self, project_id):

--- a/esi_leap/tests/api/controllers/v1/test_lease.py
+++ b/esi_leap/tests/api/controllers/v1/test_lease.py
@@ -17,11 +17,11 @@ from oslo_policy import policy
 from oslo_utils import uuidutils
 import testtools
 
-from esi_leap.api.controllers.v1.contract import ContractsController
+from esi_leap.api.controllers.v1.lease import LeasesController
 from esi_leap.common import exception
 from esi_leap.common import statuses
-from esi_leap.objects import contract
-from esi_leap.objects import offer
+from esi_leap.objects import lease as lease_obj
+from esi_leap.objects import offer as offer_obj
 from esi_leap.resource_objects.test_node import TestNode
 from esi_leap.tests.api import base as test_api_base
 
@@ -57,36 +57,36 @@ end_iso = '2016-10-24T00:00:00'
 
 test_node_1 = TestNode('111', owner_ctx.project_id)
 
-o_uuid = uuidutils.generate_uuid()
-c_uuid = uuidutils.generate_uuid()
+offer_uuid = uuidutils.generate_uuid()
+lease_uuid = uuidutils.generate_uuid()
 
 
 def create_test_offer(context):
-    o = offer.Offer(
+    offer = offer_obj.Offer(
         resource_type='test_node',
         resource_uuid='1234567890',
-        uuid=o_uuid,
+        uuid=offer_uuid,
         start_time=datetime.datetime(2016, 7, 16, 19, 20, 30),
         end_time=datetime.datetime(2016, 8, 16, 19, 20, 30),
         project_id="111111111111"
     )
-    o.create(context)
-    return o
+    offer.create(context)
+    return offer
 
 
-def create_test_contract(context):
-    c = contract.Contract(
-        uuid=c_uuid,
+def create_test_lease(context):
+    lease = lease_obj.Lease(
+        uuid=lease_uuid,
         start_date=datetime.datetime(2016, 7, 16, 19, 20, 30),
         end_date=datetime.datetime(2016, 8, 16, 19, 20, 30),
         offer_uuid='1234567890',
         project_id="222222222222"
     )
-    c.create(context)
-    return c
+    lease.create(context)
+    return lease
 
 
-def create_test_contract_data():
+def create_test_lease_data():
     return {
         "offer_uuid_or_name": "o",
         "start_time": "2016-07-16T19:20:30",
@@ -94,43 +94,43 @@ def create_test_contract_data():
     }
 
 
-test_offer = offer.Offer(
+test_offer = offer_obj.Offer(
     resource_type='test_node',
     resource_uuid=test_node_1._uuid,
     name="o",
-    uuid=o_uuid,
+    uuid=offer_uuid,
     status=statuses.AVAILABLE,
     start_time=start,
     end_time=end,
     project_id=owner_ctx.project_id
 )
 
-test_contract = contract.Contract(
-    offer_uuid=o_uuid,
+test_lease = lease_obj.Lease(
+    offer_uuid=offer_uuid,
     name='c',
-    uuid=c_uuid,
+    uuid=lease_uuid,
     project_id=lessee_ctx.project_id,
     status=statuses.CREATED
 )
 
-test_contract_2 = contract.Contract(
-    offer_uuid=o_uuid,
+test_lease_2 = lease_obj.Lease(
+    offer_uuid=offer_uuid,
     name='c',
     uuid=uuidutils.generate_uuid(),
     project_id=lessee_ctx.project_id,
     status=statuses.CREATED
 )
 
-test_contract_3 = contract.Contract(
-    offer_uuid=o_uuid,
+test_lease_3 = lease_obj.Lease(
+    offer_uuid=offer_uuid,
     name='c',
     uuid=uuidutils.generate_uuid(),
     project_id=lessee_ctx_2.project_id,
     status=statuses.CREATED
 )
 
-test_contract_4 = contract.Contract(
-    offer_uuid=o_uuid,
+test_lease_4 = lease_obj.Lease(
+    offer_uuid=offer_uuid,
     name='c2',
     uuid=uuidutils.generate_uuid(),
     project_id=lessee_ctx_2.project_id,
@@ -138,52 +138,52 @@ test_contract_4 = contract.Contract(
 )
 
 
-class TestContractsControllerAdmin(test_api_base.APITestCase):
+class TestLeasesControllerAdmin(test_api_base.APITestCase):
 
     def setUp(self):
 
         self.context = lessee_ctx
 
-        super(TestContractsControllerAdmin, self).setUp()
+        super(TestLeasesControllerAdmin, self).setUp()
 
         o = create_test_offer(self.context)
 
-        self.test_contract = contract.Contract(
+        self.test_lease = lease_obj.Lease(
             start_date=datetime.datetime(2016, 7, 16, 19, 20, 30),
             end_date=datetime.datetime(2016, 8, 16, 19, 20, 30),
-            uuid=c_uuid,
+            uuid=lease_uuid,
             offer_uuid=o.uuid,
             project_id=lessee_ctx.project_id
         )
 
     def test_empty(self):
-        data = self.get_json('/contracts')
-        self.assertEqual([], data['contracts'])
+        data = self.get_json('/leases')
+        self.assertEqual([], data['leases'])
 
-    @mock.patch('esi_leap.objects.contract.Contract.get_all')
+    @mock.patch('esi_leap.objects.lease.Lease.get_all')
     def test_one(self, mock_ga):
 
-        mock_ga.return_value = [self.test_contract]
-        data = self.get_json('/contracts')
-        self.assertEqual(self.test_contract.uuid,
-                         data['contracts'][0]["uuid"])
+        mock_ga.return_value = [self.test_lease]
+        data = self.get_json('/leases')
+        self.assertEqual(self.test_lease.uuid,
+                         data['leases'][0]["uuid"])
 
-    @mock.patch('esi_leap.api.controllers.v1.contract.uuidutils.generate_uuid')
-    @mock.patch('esi_leap.api.controllers.v1.contract.utils.get_offer')
-    @mock.patch('esi_leap.objects.contract.Contract.create')
+    @mock.patch('esi_leap.api.controllers.v1.lease.uuidutils.generate_uuid')
+    @mock.patch('esi_leap.api.controllers.v1.lease.utils.get_offer')
+    @mock.patch('esi_leap.objects.lease.Lease.create')
     def test_post(self, mock_create, mock_offer_get, mock_generate_uuid):
 
-        mock_generate_uuid.return_value = c_uuid
+        mock_generate_uuid.return_value = lease_uuid
         mock_offer_get.return_value = test_offer
 
-        data = create_test_contract_data()
-        request = self.post_json('/contracts', data)
+        data = create_test_lease_data()
+        request = self.post_json('/leases', data)
         self.assertEqual(1, mock_create.call_count)
 
         data.pop('offer_uuid_or_name')
         data['project_id'] = lessee_ctx.project_id
-        data['uuid'] = c_uuid
-        data['offer_uuid'] = o_uuid
+        data['uuid'] = lease_uuid
+        data['offer_uuid'] = offer_uuid
         self.assertEqual(request.json, data)
         # FIXME: post returns incorrect status code
         # self.assertEqual(http_client.CREATED, request.status_int)
@@ -192,9 +192,9 @@ class TestContractsControllerAdmin(test_api_base.APITestCase):
         mock_offer_get.assert_called_once_with('o', statuses.AVAILABLE)
 
 
-class TestContractControllersGetAllFilters(testtools.TestCase):
+class TestLeaseControllersGetAllFilters(testtools.TestCase):
 
-    def test_contract_get_all_no_view_no_projectid_no_owner(self):
+    def test_lease_get_all_no_view_no_projectid_no_owner(self):
 
         expected_filters = {
             'status': ['random'],
@@ -203,33 +203,33 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
 
         # admin
         expected_filters['project_id'] = admin_ctx_dict['project_id']
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             admin_ctx_dict,
             status='random', offer_uuid='offeruuid')
         self.assertEqual(expected_filters, filters)
 
         # owner
         expected_filters['project_id'] = owner_ctx.project_id
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             owner_ctx_dict,
             status='random', offer_uuid='offeruuid')
         self.assertEqual(expected_filters, filters)
 
         # lessee
         expected_filters['project_id'] = lessee_ctx.project_id
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             lessee_ctx_dict,
             status='random', offer_uuid='offeruuid')
         self.assertEqual(expected_filters, filters)
 
         # random
         self.assertRaises(policy.PolicyNotAuthorized,
-                          ContractsController.
-                          _contract_get_all_authorize_filters,
+                          LeasesController.
+                          _lease_get_all_authorize_filters,
                           random_ctx_dict,
                           status='random', offer_uuid='offeruuid')
 
-    def test_contract_get_all_no_view_project_no_owner(self):
+    def test_lease_get_all_no_view_project_no_owner(self):
 
         expected_filters = {
             'status': ['random']
@@ -237,14 +237,14 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
 
         # admin
         expected_filters['project_id'] = admin_ctx_dict['project_id']
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             admin_ctx_dict,
             project_id=admin_ctx_dict['project_id'],
             status='random')
         self.assertEqual(expected_filters, filters)
 
         expected_filters['project_id'] = random_ctx.project_id
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             admin_ctx_dict,
             project_id=random_ctx.project_id,
             status='random')
@@ -252,43 +252,43 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
 
         # lessee
         expected_filters['project_id'] = lessee_ctx.project_id
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             lessee_ctx_dict,
             project_id=lessee_ctx.project_id,
             status='random')
         self.assertEqual(expected_filters, filters)
 
         self.assertRaises(policy.PolicyNotAuthorized,
-                          ContractsController.
-                          _contract_get_all_authorize_filters,
+                          LeasesController.
+                          _lease_get_all_authorize_filters,
                           lessee_ctx_dict,
                           project_id=random_ctx.project_id,
                           status='random')
 
         # owner
         expected_filters['project_id'] = owner_ctx.project_id
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             owner_ctx_dict,
             project_id=owner_ctx.project_id,
             status='random')
         self.assertEqual(expected_filters, filters)
 
         self.assertRaises(policy.PolicyNotAuthorized,
-                          ContractsController.
-                          _contract_get_all_authorize_filters,
+                          LeasesController.
+                          _lease_get_all_authorize_filters,
                           lessee_ctx_dict,
                           project_id=random_ctx.project_id,
                           status='random')
 
         # random
         self.assertRaises(policy.PolicyNotAuthorized,
-                          ContractsController.
-                          _contract_get_all_authorize_filters,
+                          LeasesController.
+                          _lease_get_all_authorize_filters,
                           random_ctx_dict,
                           project_id=random_ctx.project_id,
                           status='random')
 
-    def test_contract_get_all_no_view_any_projectid_owner(self):
+    def test_lease_get_all_no_view_any_projectid_owner(self):
 
         expected_filters = {
             'status': ['random']
@@ -296,14 +296,14 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
 
         # admin
         expected_filters['owner'] = admin_ctx_dict['project_id']
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             admin_ctx_dict,
             owner=admin_ctx_dict['project_id'],
             status='random')
         self.assertEqual(expected_filters, filters)
 
         expected_filters['owner'] = random_ctx.project_id
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             admin_ctx_dict,
             owner=random_ctx.project_id,
             status='random')
@@ -311,22 +311,22 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
 
         # lessee
         expected_filters['owner'] = lessee_ctx.project_id
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             lessee_ctx_dict,
             owner=lessee_ctx.project_id,
             status='random')
         self.assertEqual(expected_filters, filters)
 
         self.assertRaises(policy.PolicyNotAuthorized,
-                          ContractsController.
-                          _contract_get_all_authorize_filters,
+                          LeasesController.
+                          _lease_get_all_authorize_filters,
                           lessee_ctx_dict,
                           owner=random_ctx.project_id,
                           status='random')
 
         expected_filters['owner'] = lessee_ctx.project_id
         expected_filters['project_id'] = random_ctx.project_id
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             lessee_ctx_dict,
             owner=lessee_ctx.project_id, project_id=random_ctx.project_id,
             status='random')
@@ -335,22 +335,22 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
 
         # owner
         expected_filters['owner'] = owner_ctx.project_id
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             owner_ctx_dict,
             owner=owner_ctx.project_id,
             status='random')
         self.assertEqual(expected_filters, filters)
 
         self.assertRaises(policy.PolicyNotAuthorized,
-                          ContractsController.
-                          _contract_get_all_authorize_filters,
+                          LeasesController.
+                          _lease_get_all_authorize_filters,
                           lessee_ctx_dict,
                           owner=random_ctx.project_id,
                           status='random')
 
         expected_filters['owner'] = owner_ctx_dict['project_id']
         expected_filters['project_id'] = random_ctx.project_id
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             owner_ctx_dict,
             owner=owner_ctx.project_id, project_id=random_ctx.project_id,
             status='random')
@@ -358,20 +358,20 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
 
         # random
         self.assertRaises(policy.PolicyNotAuthorized,
-                          ContractsController.
-                          _contract_get_all_authorize_filters,
+                          LeasesController.
+                          _lease_get_all_authorize_filters,
                           random_ctx_dict,
                           owner=random_ctx.project_id,
                           status='random')
 
-    def test_contract_get_all_all_view(self):
+    def test_lease_get_all_all_view(self):
 
         expected_filters = {
             'status': ['random']
         }
 
         # admin
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             admin_ctx_dict,
             view='all',
             status='random')
@@ -379,27 +379,27 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
 
         # not admin
         self.assertRaises(policy.PolicyNotAuthorized,
-                          ContractsController.
-                          _contract_get_all_authorize_filters,
+                          LeasesController.
+                          _lease_get_all_authorize_filters,
                           lessee_ctx_dict,
                           view='all',
                           status='random')
 
         self.assertRaises(policy.PolicyNotAuthorized,
-                          ContractsController.
-                          _contract_get_all_authorize_filters,
+                          LeasesController.
+                          _lease_get_all_authorize_filters,
                           owner_ctx_dict,
                           view='all',
                           status='random')
 
         self.assertRaises(policy.PolicyNotAuthorized,
-                          ContractsController.
-                          _contract_get_all_authorize_filters,
+                          LeasesController.
+                          _lease_get_all_authorize_filters,
                           random_ctx_dict,
                           view='all',
                           status='random')
 
-    def test_contract_get_all_all_view_times(self):
+    def test_lease_get_all_all_view_times(self):
 
         start = datetime.datetime(2016, 7, 16, 19, 20, 30)
         end = datetime.datetime(2020, 7, 16, 19, 20, 30)
@@ -411,24 +411,24 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
         }
 
         # admin
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             admin_ctx_dict,
             view='all', start_time=start, end_time=end, status='random')
         self.assertEqual(expected_filters, filters)
 
         self.assertRaises(exception.InvalidTimeAPICommand,
-                          ContractsController.
-                          _contract_get_all_authorize_filters,
+                          LeasesController.
+                          _lease_get_all_authorize_filters,
                           admin_ctx_dict,
                           view='all', start_time=start, status='random')
 
         self.assertRaises(exception.InvalidTimeAPICommand,
-                          ContractsController.
-                          _contract_get_all_authorize_filters,
+                          LeasesController.
+                          _lease_get_all_authorize_filters,
                           admin_ctx_dict,
                           view='all', end_time=end, status='random')
 
-    def test_contract_get_all_status(self):
+    def test_lease_get_all_status(self):
 
         expected_filters = {
             'project_id': 'adminid',
@@ -436,11 +436,11 @@ class TestContractControllersGetAllFilters(testtools.TestCase):
         }
 
         # admin
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             admin_ctx_dict)
         self.assertEqual(expected_filters, filters)
 
         del(expected_filters['status'])
-        filters = ContractsController._contract_get_all_authorize_filters(
+        filters = LeasesController._lease_get_all_authorize_filters(
             admin_ctx_dict, status='any')
         self.assertEqual(expected_filters, filters)

--- a/esi_leap/tests/db/sqlalchemy/test_api.py
+++ b/esi_leap/tests/db/sqlalchemy/test_api.py
@@ -67,48 +67,48 @@ test_offer_4 = dict(
     status=statuses.AVAILABLE,
 )
 
-test_contract_1 = dict(
+test_lease_1 = dict(
     uuid='11111',
     project_id='1e5533',
-    name='c1',
+    name='l1',
     start_time=now + datetime.timedelta(days=10),
     end_time=now + datetime.timedelta(days=20),
     status=statuses.CREATED,
 )
 
-test_contract_2 = dict(
+test_lease_2 = dict(
     uuid='22222',
     project_id='1e5533',
-    name='c1',
+    name='l1',
     start_time=now + datetime.timedelta(days=20),
     end_time=now + datetime.timedelta(days=30),
     status=statuses.CREATED,
 )
 
-test_contract_3 = dict(
+test_lease_3 = dict(
     uuid='33333',
     project_id='1e5533_2',
-    name='c1',
+    name='l1',
     start_time=now + datetime.timedelta(days=50),
     end_time=now + datetime.timedelta(days=60),
     status=statuses.ACTIVE,
 )
 
-test_contract_4 = dict(
+test_lease_4 = dict(
     uuid='44444',
     project_id='1e5533_2',
-    name='c2',
+    name='l2',
     start_time=now + datetime.timedelta(days=85),
     end_time=now + datetime.timedelta(days=90),
     properties={},
     status=statuses.CANCELLED,
 )
 
-test_contract_5 = dict(
+test_lease_5 = dict(
     project_id='1e5533',
     start_time=now + datetime.timedelta(days=90),
     end_time=now + datetime.timedelta(days=100),
-    uuid='contract_5',
+    uuid='lease_5',
     properties={},
 )
 
@@ -121,124 +121,124 @@ class TestAPI(base.DBTestCase):
         assert len(o) == 1
         assert o[0].to_dict() == offer.to_dict()
 
-    def test_offer_verify_contract_availability(self):
+    def test_offer_verify_lease_availability(self):
         offer = api.offer_create(test_offer_1)
 
-        test_contract_1['offer_uuid'] = offer.uuid
-        test_contract_2['offer_uuid'] = offer.uuid
-        test_contract_3['offer_uuid'] = offer.uuid
+        test_lease_1['offer_uuid'] = offer.uuid
+        test_lease_2['offer_uuid'] = offer.uuid
+        test_lease_3['offer_uuid'] = offer.uuid
 
-        api.contract_create(test_contract_1)
-        api.contract_create(test_contract_2)
-        api.contract_create(test_contract_3)
+        api.lease_create(test_lease_1)
+        api.lease_create(test_lease_2)
+        api.lease_create(test_lease_3)
 
         start = now + datetime.timedelta(days=35)
         end = now + datetime.timedelta(days=40)
-        api.offer_verify_contract_availability(offer, start, end)
+        api.offer_verify_lease_availability(offer, start, end)
 
         start = now + datetime.timedelta(days=5)
         end = now + datetime.timedelta(days=10)
-        api.offer_verify_contract_availability(offer, start, end)
+        api.offer_verify_lease_availability(offer, start, end)
 
         start = now
         end = now + datetime.timedelta(days=10)
-        api.offer_verify_contract_availability(offer, start, end)
+        api.offer_verify_lease_availability(offer, start, end)
 
         start = now + datetime.timedelta(days=90)
         end = now + datetime.timedelta(days=100)
-        api.offer_verify_contract_availability(offer, start, end)
+        api.offer_verify_lease_availability(offer, start, end)
 
         start = now + datetime.timedelta(days=60)
         end = now + datetime.timedelta(days=100)
-        api.offer_verify_contract_availability(offer, start, end)
+        api.offer_verify_lease_availability(offer, start, end)
 
         start = now + datetime.timedelta(days=30)
         end = now + datetime.timedelta(days=50)
-        api.offer_verify_contract_availability(offer, start, end)
+        api.offer_verify_lease_availability(offer, start, end)
 
         start = now + datetime.timedelta(days=15)
         end = now + datetime.timedelta(days=16)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_contract_availability,
+                          api.offer_verify_lease_availability,
                           offer, start, end)
 
         start = now + datetime.timedelta(days=45)
         end = now + datetime.timedelta(days=55)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_contract_availability,
+                          api.offer_verify_lease_availability,
                           offer, start, end)
 
         start = now + datetime.timedelta(days=55)
         end = now + datetime.timedelta(days=65)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_contract_availability,
+                          api.offer_verify_lease_availability,
                           offer, start, end)
 
         start = now + datetime.timedelta(days=50)
         end = now + datetime.timedelta(days=65)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_contract_availability,
+                          api.offer_verify_lease_availability,
                           offer, start, end)
 
         start = now + datetime.timedelta(days=45)
         end = now + datetime.timedelta(days=60)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_contract_availability,
+                          api.offer_verify_lease_availability,
                           offer, start, end)
 
         start = now + datetime.timedelta(days=90)
         end = now + datetime.timedelta(days=105)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_contract_availability,
+                          api.offer_verify_lease_availability,
                           offer, start, end)
 
         start = now + datetime.timedelta(days=100)
         end = now + datetime.timedelta(days=105)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_contract_availability,
+                          api.offer_verify_lease_availability,
                           offer, start, end)
 
         start = now + datetime.timedelta(days=105)
         end = now + datetime.timedelta(days=110)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_contract_availability,
+                          api.offer_verify_lease_availability,
                           offer, start, end)
 
         start = now - datetime.timedelta(days=1)
         end = now + datetime.timedelta(days=5)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_contract_availability,
+                          api.offer_verify_lease_availability,
                           offer, start, end)
 
         start = now - datetime.timedelta(days=1)
         end = now
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_contract_availability,
+                          api.offer_verify_lease_availability,
                           offer, start, end)
 
         start = now - datetime.timedelta(days=10)
         end = now - datetime.timedelta(days=5)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_contract_availability,
+                          api.offer_verify_lease_availability,
                           offer, start, end)
 
         start = now + datetime.timedelta(days=45)
         end = now + datetime.timedelta(days=55)
         self.assertRaises(e.OfferNoTimeAvailabilities,
-                          api.offer_verify_contract_availability,
+                          api.offer_verify_lease_availability,
                           offer, start, end)
 
-        test_contract_4['offer_uuid'] = offer.uuid
-        api.contract_create(test_contract_4)
+        test_lease_4['offer_uuid'] = offer.uuid
+        api.lease_create(test_lease_4)
         start = now + datetime.timedelta(days=86)
         end = now + datetime.timedelta(days=87)
-        api.offer_verify_contract_availability(offer, start, end)
+        api.offer_verify_lease_availability(offer, start, end)
 
     def test_offer_get_conflict_times(self):
         o1 = api.offer_create(test_offer_1)
         self.assertEqual(api.offer_get_conflict_times(o1), [])
-        test_contract_3['offer_uuid'] = o1.uuid
-        api.contract_create(test_contract_3)
+        test_lease_3['offer_uuid'] = o1.uuid
+        api.lease_create(test_lease_3)
         self.assertEqual(api.offer_get_conflict_times(o1),
                          [(now + datetime.timedelta(days=50),
                           now + datetime.timedelta(days=60))])
@@ -247,8 +247,8 @@ class TestAPI(base.DBTestCase):
         o1 = api.offer_create(test_offer_1)
         self.assertEqual(api.offer_get_first_availability
                          (o1.uuid, o1.start_time,), None)
-        test_contract_3['offer_uuid'] = o1.uuid
-        api.contract_create(test_contract_3)
+        test_lease_3['offer_uuid'] = o1.uuid
+        api.lease_create(test_lease_3)
         self.assertEqual(api.offer_get_first_availability
                          (o1.uuid, o1.start_time), (now + datetime
                                                     .timedelta(days=50),))
@@ -329,88 +329,88 @@ class TestAPI(base.DBTestCase):
         self.assertEqual((o1.to_dict(), o2.to_dict()),
                          (res[0].to_dict(), res[1].to_dict()))
 
-    def test_contract_get_by_uuid(self):
+    def test_lease_get_by_uuid(self):
         o1 = api.offer_create(test_offer_2)
-        test_contract_4['offer_uuid'] = o1.uuid
-        c1 = api.contract_create(test_contract_4)
-        res = api.contract_get_by_uuid(c1.uuid)
-        self.assertEqual(c1.uuid, res.uuid)
+        test_lease_4['offer_uuid'] = o1.uuid
+        l1 = api.lease_create(test_lease_4)
+        res = api.lease_get_by_uuid(l1.uuid)
+        self.assertEqual(l1.uuid, res.uuid)
 
-    def test_contract_get_by_uuid_not_found(self):
-        assert api.contract_get_by_uuid('some_uuid') is None
+    def test_lease_get_by_uuid_not_found(self):
+        assert api.lease_get_by_uuid('some_uuid') is None
 
-    def test_contract_get_by_name(self):
+    def test_lease_get_by_name(self):
         o1 = api.offer_create(test_offer_1)
         o2 = api.offer_create(test_offer_2)
         o3 = api.offer_create(test_offer_3)
         o4 = api.offer_create(test_offer_4)
-        test_contract_1['offer_uuid'] = o1.uuid
-        test_contract_2['offer_uuid'] = o2.uuid
-        test_contract_3['offer_uuid'] = o3.uuid
-        test_contract_4['offer_uuid'] = o4.uuid
-        c1 = api.contract_create(test_contract_1)
-        c2 = api.contract_create(test_contract_2)
-        c3 = api.contract_create(test_contract_3)
-        api.contract_create(test_contract_4)
-        res = api.contract_get_by_name('c1')
+        test_lease_1['offer_uuid'] = o1.uuid
+        test_lease_2['offer_uuid'] = o2.uuid
+        test_lease_3['offer_uuid'] = o3.uuid
+        test_lease_4['offer_uuid'] = o4.uuid
+        l1 = api.lease_create(test_lease_1)
+        l2 = api.lease_create(test_lease_2)
+        l3 = api.lease_create(test_lease_3)
+        api.lease_create(test_lease_4)
+        res = api.lease_get_by_name('l1')
         assert len(res) == 3
-        self.assertEqual(c1.uuid, res[0].uuid)
-        self.assertEqual(c1.project_id, res[0].project_id)
+        self.assertEqual(l1.uuid, res[0].uuid)
+        self.assertEqual(l1.project_id, res[0].project_id)
 
-        self.assertEqual(c2.uuid, res[1].uuid)
-        self.assertEqual(c2.project_id, res[1].project_id)
+        self.assertEqual(l2.uuid, res[1].uuid)
+        self.assertEqual(l2.project_id, res[1].project_id)
 
-        self.assertEqual(c3.uuid, res[2].uuid)
-        self.assertEqual(c3.project_id, res[2].project_id)
+        self.assertEqual(l3.uuid, res[2].uuid)
+        self.assertEqual(l3.project_id, res[2].project_id)
 
-    def test_contract_get_by_name_not_found(self):
-        self.assertEqual(api.contract_get_by_name('some_name'), [])
+    def test_lease_get_by_name_not_found(self):
+        self.assertEqual(api.lease_get_by_name('some_name'), [])
 
-    def test_contract_get_all(self):
+    def test_lease_get_all(self):
         o1 = api.offer_create(test_offer_2)
-        test_contract_4['offer_uuid'] = o1.uuid
+        test_lease_4['offer_uuid'] = o1.uuid
         o2 = api.offer_create(test_offer_3)
-        test_contract_5['offer_uuid'] = o2.uuid
-        c1 = api.contract_create(test_contract_4)
-        c2 = api.contract_create(test_contract_5)
-        res = api.contract_get_all({})
-        self.assertEqual((c1.to_dict(), c2.to_dict()),
+        test_lease_5['offer_uuid'] = o2.uuid
+        l1 = api.lease_create(test_lease_4)
+        l2 = api.lease_create(test_lease_5)
+        res = api.lease_get_all({})
+        self.assertEqual((l1.to_dict(), l2.to_dict()),
                          (res[0].to_dict(), res[1].to_dict()))
 
-    def test_contract_create(db):
+    def test_lease_create(db):
         o1 = api.offer_create(test_offer_2)
-        test_contract_4['offer_uuid'] = o1.uuid
-        c1 = api.contract_create(test_contract_4)
-        c2 = api.contract_get_all({}).all()
-        assert len(c2) == 1
-        assert c2[0].to_dict() == c1.to_dict()
+        test_lease_4['offer_uuid'] = o1.uuid
+        l1 = api.lease_create(test_lease_4)
+        l2 = api.lease_get_all({}).all()
+        assert len(l2) == 1
+        assert l2[0].to_dict() == l1.to_dict()
 
-    def test_contract_update(self):
+    def test_lease_update(self):
         o1 = api.offer_create(test_offer_2)
-        test_contract_4['offer_uuid'] = o1.uuid
-        c1 = api.contract_create(test_contract_4)
-        values = {'start_time': test_contract_5['start_time'],
-                  'end_time': test_contract_5['end_time']}
-        api.contract_update(c1.uuid, values)
-        c1 = api.contract_get_by_uuid(c1.uuid)
-        self.assertEqual(test_contract_5['start_time'], c1.start_time)
-        self.assertEqual(test_contract_5['end_time'], c1.end_time)
+        test_lease_4['offer_uuid'] = o1.uuid
+        l1 = api.lease_create(test_lease_4)
+        values = {'start_time': test_lease_5['start_time'],
+                  'end_time': test_lease_5['end_time']}
+        api.lease_update(l1.uuid, values)
+        l1 = api.lease_get_by_uuid(l1.uuid)
+        self.assertEqual(test_lease_5['start_time'], l1.start_time)
+        self.assertEqual(test_lease_5['end_time'], l1.end_time)
 
-    def test_contract_update_invalid_time(self):
+    def test_lease_update_invalid_time(self):
         o1 = api.offer_create(test_offer_3)
-        test_contract_4['offer_uuid'] = o1.uuid
-        c1 = api.contract_create(test_contract_4)
+        test_lease_4['offer_uuid'] = o1.uuid
+        l1 = api.lease_create(test_lease_4)
         values = {'start_time': now + datetime.timedelta(days=101),
                   'end_time': now}
-        self.assertRaises(e.InvalidTimeRange, api.contract_update,
-                          c1.uuid, values)
+        self.assertRaises(e.InvalidTimeRange, api.lease_update,
+                          l1.uuid, values)
 
-    def test_contract_destroy(self):
+    def test_lease_destroy(self):
         o1 = api.offer_create(test_offer_2)
-        test_contract_4['offer_uuid'] = o1.uuid
-        c1 = api.contract_create(test_contract_4)
-        api.contract_destroy(c1.uuid)
-        self.assertEqual(api.contract_get_by_uuid('contract_4'), None)
+        test_lease_4['offer_uuid'] = o1.uuid
+        l1 = api.lease_create(test_lease_4)
+        api.lease_destroy(l1.uuid)
+        self.assertEqual(api.lease_get_by_uuid('lease_4'), None)
 
-    def test_contract_destroy_not_found(self):
-        self.assertEqual(api.contract_get_by_uuid('contract_4'), None)
+    def test_lease_destroy_not_found(self):
+        self.assertEqual(api.lease_get_by_uuid('lease_4'), None)

--- a/esi_leap/tests/manager/test_service.py
+++ b/esi_leap/tests/manager/test_service.py
@@ -17,7 +17,7 @@ from oslo_utils import uuidutils
 
 from esi_leap.common import statuses
 from esi_leap.manager.service import ManagerService
-from esi_leap.objects import contract
+from esi_leap.objects import lease
 from esi_leap.objects import offer
 
 
@@ -39,7 +39,7 @@ test_offer = offer.Offer(
     project_id=owner_ctx.project_id
 )
 
-test_contract = contract.Contract(
+test_lease = lease.Lease(
     offer_uuid=o_uuid,
     name='c',
     uuid=uuidutils.generate_uuid(),
@@ -52,15 +52,15 @@ test_contract = contract.Contract(
 
 @mock.patch('esi_leap.manager.service.timeutils.utcnow')
 @mock.patch('esi_leap.manager.service.LOG.info')
-@mock.patch('esi_leap.manager.service.contract.Contract.get_all')
-def test__fulfill_contracts(mock_ga, mock_log, mock_utcnow):
-    mock_ga.return_value = [test_contract]
+@mock.patch('esi_leap.manager.service.lease.Lease.get_all')
+def test__fulfill_leases(mock_ga, mock_log, mock_utcnow):
+    mock_ga.return_value = [test_lease]
     mock_utcnow.return_value = datetime.datetime(3500, 7, 16)
 
     s = ManagerService()
 
-    with mock.patch.object(test_contract, 'fulfill') as mock_fulfill:
-        s._fulfill_contracts()
+    with mock.patch.object(test_lease, 'fulfill') as mock_fulfill:
+        s._fulfill_leases()
 
         mock_fulfill.assert_called_once()
 
@@ -70,15 +70,15 @@ def test__fulfill_contracts(mock_ga, mock_log, mock_utcnow):
 
 @mock.patch('esi_leap.manager.service.timeutils.utcnow')
 @mock.patch('esi_leap.manager.service.LOG.info')
-@mock.patch('esi_leap.manager.service.contract.Contract.get_all')
-def test__expire_contracts(mock_ga, mock_log, mock_utcnow):
-    mock_ga.return_value = [test_contract]
+@mock.patch('esi_leap.manager.service.lease.Lease.get_all')
+def test__expire_leases(mock_ga, mock_log, mock_utcnow):
+    mock_ga.return_value = [test_lease]
     mock_utcnow.return_value = datetime.datetime(3500, 7, 16)
 
     s = ManagerService()
 
-    with mock.patch.object(test_contract, 'expire') as mock_expire:
-        s._expire_contracts()
+    with mock.patch.object(test_lease, 'expire') as mock_expire:
+        s._expire_leases()
 
         mock_expire.assert_called_once()
 

--- a/esi_leap/tests/objects/test_offer.py
+++ b/esi_leap/tests/objects/test_offer.py
@@ -98,11 +98,11 @@ class TestOfferObject(base.DBTestCase):
                                autospec=True) as mock_offer_get_by_uuid:
             mock_offer_get_by_uuid.return_value = self.fake_offer
 
-            c = offer.Offer.get(offer_uuid, self.context)
+            o = offer.Offer.get(offer_uuid, self.context)
 
             mock_offer_get_by_uuid.assert_called_once_with(
                 offer_uuid)
-            self.assertEqual(self.context, c._context)
+            self.assertEqual(self.context, o._context)
 
     def test_get_all(self):
         with mock.patch.object(

--- a/esi_leap/tests/resource_objects/test_dummy_node.py
+++ b/esi_leap/tests/resource_objects/test_dummy_node.py
@@ -24,7 +24,7 @@ def get_test_dummy_node_1():
     return {
         "project_owner_id": "123456",
         "project_id": "654321",
-        "contract_uuid": "001",
+        "lease_uuid": "001",
         "server_config": {
             "new attribute XYZ": "new attribute XYZ",
             "cpu_type": "Intel Xeon",
@@ -50,7 +50,7 @@ def get_test_dummy_node_2():
     }
 
 
-class FakeContract(object):
+class FakeLease(object):
     def __init__(self):
         self.uuid = '001'
         self.project_id = '654321'
@@ -70,11 +70,11 @@ class TestDummyNode(base.TestCase):
         self.fake_read_data_1 = json.dumps(get_test_dummy_node_1())
         self.fake_read_data_2 = json.dumps(get_test_dummy_node_2())
 
-    def test_get_contract_uuid(self):
+    def test_get_lease_uuid(self):
         mock_open = mock.mock_open(read_data=self.fake_read_data_1)
         with mock.patch('builtins.open', mock_open) as mock_file_open:
-            contract_uuid = self.fake_dummy_node.get_contract_uuid()
-            self.assertEqual(contract_uuid, '001')
+            lease_uuid = self.fake_dummy_node.get_lease_uuid()
+            self.assertEqual(lease_uuid, '001')
             mock_file_open.assert_called_once()
 
     def test_get_project_id(self):
@@ -91,18 +91,18 @@ class TestDummyNode(base.TestCase):
             self.assertEqual(config, get_test_dummy_node_1()['server_config'])
             mock_file_open.assert_called_once()
 
-    def test_set_contract(self):
+    def test_set_lease(self):
         mock_open = mock.mock_open(read_data=self.fake_read_data_2)
         with mock.patch('builtins.open', mock_open) as mock_file_open:
-            fake_contract = FakeContract()
-            self.fake_dummy_node.set_contract(fake_contract)
+            fake_lease = FakeLease()
+            self.fake_dummy_node.set_lease(fake_lease)
             self.assertEqual(mock_file_open.call_count, 2)
 
-    def test_expire_contract(self):
+    def test_expire_lease(self):
         mock_open = mock.mock_open(read_data=self.fake_read_data_1)
         with mock.patch('builtins.open', mock_open) as mock_file_open:
-            fake_contract = FakeContract()
-            self.fake_dummy_node.expire_contract(fake_contract)
+            fake_lease = FakeLease()
+            self.fake_dummy_node.expire_lease(fake_lease)
             self.assertEqual(mock_file_open.call_count, 2)
 
     def test_is_resource_admin(self):

--- a/esi_leap/tests/resource_objects/test_test_node.py
+++ b/esi_leap/tests/resource_objects/test_test_node.py
@@ -17,7 +17,7 @@ from esi_leap.tests import base
 start = datetime.datetime(2016, 7, 16, 19, 20, 30)
 
 
-def get_test_contract():
+def get_test_lease():
     return {
         'id': 12345,
         'name': 'c',
@@ -43,9 +43,9 @@ class TestTestNode(base.TestCase):
         self.fake_admin_project_id_1 = '123'
         self.fake_admin_project_id_2 = '123456'
 
-    def test_get_contract_uuid(self):
-        contract_uuid = self.fake_test_node.get_contract_uuid()
-        self.assertEqual(contract_uuid, '12345')
+    def test_get_lease_uuid(self):
+        lease_uuid = self.fake_test_node.get_lease_uuid()
+        self.assertEqual(lease_uuid, '12345')
 
     def test_get_project_id(self):
         project_id = self.fake_test_node.get_project_id()
@@ -55,17 +55,17 @@ class TestTestNode(base.TestCase):
         config = self.fake_test_node.get_node_config()
         self.assertEqual(config, {})
 
-    def test_set_contract(self):
-        fake_contract = get_test_contract()
+    def test_set_lease(self):
+        fake_lease = get_test_lease()
         self.assertEqual(
-            self.fake_test_node.set_contract(
-                fake_contract), None)
+            self.fake_test_node.set_lease(
+                fake_lease), None)
 
-    def test_expire_contract(self):
-        fake_contract = get_test_contract()
+    def test_expire_lease(self):
+        fake_lease = get_test_lease()
         self.assertEqual(
-            self.fake_test_node.expire_contract(
-                fake_contract), None)
+            self.fake_test_node.expire_lease(
+                fake_lease), None)
 
     def test_is_resource_admin(self):
         res1 = self.fake_test_node.is_resource_admin(


### PR DESCRIPTION
This change replaces 'contract' terminology with 'lease'.