### PR TITLE
Update default lease get all to include owned leases

### DIFF
--- a/esi_leap/db/sqlalchemy/api.py
+++ b/esi_leap/db/sqlalchemy/api.py
@@ -261,6 +261,7 @@ def lease_get_all(filters):
     start = filters.pop('start_time', None)
     end = filters.pop('end_time', None)
     status = filters.pop('status', None)
+    project_or_owner_id = filters.pop('project_or_owner_id', None)
 
     query = query.filter_by(**filters)
 
@@ -270,6 +271,11 @@ def lease_get_all(filters):
     if start and end:
         query = query.filter((start >= models.Lease.start_time) &
                              (end <= models.Lease.end_time))
+
+    if project_or_owner_id:
+        query = query.filter(
+            (project_or_owner_id == models.Lease.project_id) |
+            (project_or_owner_id == models.Lease.owner_id))
 
     return query
 

--- a/esi_leap/tests/api/controllers/v1/test_lease.py
+++ b/esi_leap/tests/api/controllers/v1/test_lease.py
@@ -126,21 +126,21 @@ class TestLeaseControllersGetAllFilters(testtools.TestCase):
         }
 
         # admin
-        expected_filters['project_id'] = self.admin_ctx.project_id
+        expected_filters['project_or_owner_id'] = self.admin_ctx.project_id
         filters = LeasesController._lease_get_all_authorize_filters(
             self.admin_ctx.to_policy_values(),
             status='random', offer_uuid='offeruuid')
         self.assertEqual(expected_filters, filters)
 
         # owner
-        expected_filters['project_id'] = self.owner_ctx.project_id
+        expected_filters['project_or_owner_id'] = self.owner_ctx.project_id
         filters = LeasesController._lease_get_all_authorize_filters(
             self.owner_ctx.to_policy_values(),
             status='random', offer_uuid='offeruuid')
         self.assertEqual(expected_filters, filters)
 
         # lessee
-        expected_filters['project_id'] = self.lessee_ctx.project_id
+        expected_filters['project_or_owner_id'] = self.lessee_ctx.project_id
         filters = LeasesController._lease_get_all_authorize_filters(
             self.lessee_ctx.to_policy_values(),
             status='random', offer_uuid='offeruuid')
@@ -205,44 +205,44 @@ class TestLeaseControllersGetAllFilters(testtools.TestCase):
         }
 
         # admin
-        expected_filters['owner'] = self.admin_ctx.project_id
+        expected_filters['owner_id'] = self.admin_ctx.project_id
         filters = LeasesController._lease_get_all_authorize_filters(
             self.admin_ctx.to_policy_values(),
-            owner=self.admin_ctx.project_id,
+            owner_id=self.admin_ctx.project_id,
             status='random')
         self.assertEqual(expected_filters, filters)
 
         # lessee
-        expected_filters['owner'] = self.lessee_ctx.project_id
+        expected_filters['owner_id'] = self.lessee_ctx.project_id
         filters = LeasesController._lease_get_all_authorize_filters(
             self.lessee_ctx.to_policy_values(),
-            owner=self.lessee_ctx.project_id,
+            owner_id=self.lessee_ctx.project_id,
             status='random')
         self.assertEqual(expected_filters, filters)
 
-        expected_filters['owner'] = self.lessee_ctx.project_id
+        expected_filters['owner_id'] = self.lessee_ctx.project_id
         expected_filters['project_id'] = self.random_ctx.project_id
         filters = LeasesController._lease_get_all_authorize_filters(
             self.lessee_ctx.to_policy_values(),
-            owner=self.lessee_ctx.project_id,
+            owner_id=self.lessee_ctx.project_id,
             project_id=self.random_ctx.project_id,
             status='random')
         self.assertEqual(expected_filters, filters)
         del expected_filters['project_id']
 
         # owner
-        expected_filters['owner'] = self.owner_ctx.project_id
+        expected_filters['owner_id'] = self.owner_ctx.project_id
         filters = LeasesController._lease_get_all_authorize_filters(
             self.owner_ctx.to_policy_values(),
-            owner=self.owner_ctx.project_id,
+            owner_id=self.owner_ctx.project_id,
             status='random')
         self.assertEqual(expected_filters, filters)
 
-        expected_filters['owner'] = self.owner_ctx.project_id
+        expected_filters['owner_id'] = self.owner_ctx.project_id
         expected_filters['project_id'] = self.random_ctx.project_id
         filters = LeasesController._lease_get_all_authorize_filters(
             self.owner_ctx.to_policy_values(),
-            owner=self.owner_ctx.project_id,
+            owner_id=self.owner_ctx.project_id,
             project_id=self.random_ctx.project_id,
             status='random')
         self.assertEqual(expected_filters, filters)
@@ -252,7 +252,7 @@ class TestLeaseControllersGetAllFilters(testtools.TestCase):
                           LeasesController.
                           _lease_get_all_authorize_filters,
                           self.random_ctx.to_policy_values(),
-                          owner=self.random_ctx.project_id,
+                          owner_id=self.random_ctx.project_id,
                           status='random')
 
     def test_lease_get_all_all_view(self):
@@ -322,7 +322,7 @@ class TestLeaseControllersGetAllFilters(testtools.TestCase):
     def test_lease_get_all_status(self):
 
         expected_filters = {
-            'project_id': 'adminid',
+            'project_or_owner_id': 'adminid',
             'status': ['created', 'active']
         }
 


### PR DESCRIPTION
Previously, getting all leases defaulted to only showing the user
leases that they were lessees for. This change adds leases that
the user is the owner for.