### PR TITLE
Add lessee_id to offers

### DIFF
--- a/esi_leap/common/keystone.py
+++ b/esi_leap/common/keystone.py
@@ -1,0 +1,43 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from keystoneauth1 import loading as ks_loading
+from keystoneclient import client as keystone_client
+
+import esi_leap.conf
+
+
+CONF = esi_leap.conf.CONF
+_cached_keystone_client = None
+
+
+def get_keystone_client():
+    global _cached_keystone_client
+    if _cached_keystone_client is not None:
+        return _cached_keystone_client
+
+    auth_plugin = ks_loading.load_auth_from_conf_options(CONF, 'keystone')
+    sess = ks_loading.load_session_from_conf_options(CONF, 'keystone',
+                                                     auth=auth_plugin)
+    cli = keystone_client.Client(session=sess)
+    _cached_keystone_client = cli
+
+    return cli
+
+
+def get_parent_project_id_tree(project_id):
+    project = get_keystone_client().projects.get(project_id)
+    project_ids = [project.id]
+    while project.parent_id is not None:
+        project = get_keystone_client().projects.get(project.parent_id)
+        project_ids.append(project.id)
+    return project_ids

--- a/esi_leap/conf/__init__.py
+++ b/esi_leap/conf/__init__.py
@@ -14,6 +14,7 @@
 from esi_leap.conf import api
 from esi_leap.conf import dummy_node
 from esi_leap.conf import ironic
+from esi_leap.conf import keystone
 from esi_leap.conf import netconf
 from esi_leap.conf import pecan
 from oslo_config import cfg
@@ -25,5 +26,6 @@ CONF.register_group(cfg.OptGroup(name='database'))
 api.register_opts(CONF)
 dummy_node.register_opts(CONF)
 ironic.register_opts(CONF)
+keystone.register_opts(CONF)
 netconf.register_opts(CONF)
 pecan.register_opts(CONF)

--- a/esi_leap/conf/keystone.py
+++ b/esi_leap/conf/keystone.py
@@ -1,0 +1,60 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import copy
+
+from keystoneauth1 import loading
+from oslo_config import cfg
+
+
+opts = []
+keystone_group = cfg.OptGroup(
+    'keystone',
+    title='Keystone Options')
+
+
+def register_opts(conf):
+    conf.register_opts(opts, group=keystone_group)
+    loading.register_session_conf_options(conf, keystone_group)
+    loading.register_auth_conf_options(conf, keystone_group)
+    loading.register_adapter_conf_options(conf, keystone_group)
+    conf.set_default('valid_interfaces', ['internal', 'public'],
+                     group=keystone_group)
+    conf.set_default('service_type', 'identity', group=keystone_group)
+
+
+def list_opts():
+    def add_options(opts, opts_to_add):
+        for new_opt in opts_to_add:
+            for opt in opts:
+                if opt.name == new_opt.name:
+                    break
+            else:
+                opts.append(new_opt)
+
+    opts_copy = copy.deepcopy(opts)
+    opts_copy.insert(0, loading.get_auth_common_conf_options()[0])
+
+    plugins = ['password', 'v2password', 'v3password']
+    for name in plugins:
+        plugin = loading.get_plugin_loader(name)
+        add_options(opts_copy, loading.get_auth_plugin_conf_options(plugin))
+    add_options(opts_copy, loading.get_session_conf_options())
+
+    adapter_opts = loading.get_adapter_conf_options(
+        include_deprecated=False)
+    # adding defaults for valid interfaces
+    cfg.set_defaults(adapter_opts, service_type='identity',
+                     valid_interfaces=['internal', 'public'])
+    add_options(opts_copy, adapter_opts)
+    opts_copy.sort(key=lambda x: x.name)
+    return opts_copy

--- a/esi_leap/conf/opts.py
+++ b/esi_leap/conf/opts.py
@@ -17,6 +17,7 @@ _opts = [
     ('api', esi_leap.conf.api.opts),
     ('dummy_node', esi_leap.conf.dummy_node.opts),
     ('ironic', esi_leap.conf.ironic.list_opts()),
+    ('keystone', esi_leap.conf.keystone.list_opts()),
     ('pecan', esi_leap.conf.pecan.opts),
 ]
 

--- a/esi_leap/db/sqlalchemy/models.py
+++ b/esi_leap/db/sqlalchemy/models.py
@@ -50,6 +50,7 @@ class Offer(Base):
     uuid = Column(String(36), nullable=False, unique=True)
     name = Column(String(35), nullable=True, unique=False)
     project_id = Column(String(255), nullable=False)
+    lessee_id = Column(String(255), nullable=True)
     resource_type = Column(String(36), nullable=False)
     resource_uuid = Column(String(36), nullable=False)
     start_time = Column(DateTime)

--- a/esi_leap/objects/offer.py
+++ b/esi_leap/objects/offer.py
@@ -34,6 +34,7 @@ class Offer(base.ESILEAPObject):
         'name': fields.StringField(nullable=True),
         'uuid': fields.UUIDField(),
         'project_id': fields.StringField(),
+        'lessee_id': fields.StringField(nullable=True),
         'resource_type': fields.StringField(),
         'resource_uuid': fields.StringField(),
         'start_time': fields.DateTimeField(nullable=True),

--- a/esi_leap/tests/objects/test_offer.py
+++ b/esi_leap/tests/objects/test_offer.py
@@ -33,6 +33,7 @@ class TestOfferObject(base.DBTestCase):
             'name': "o",
             'uuid': uuidutils.generate_uuid(),
             'project_id': '0wn5r',
+            'lessee_id': None,
             'resource_type': 'dummy_node',
             'resource_uuid': '1718',
             'start_time': start,


### PR DESCRIPTION
If an offer has a lessee_id, then it can only be claimed by the
project matching that lessee_id or subprojects of that project.