### PR TITLE
Add owner change to leasing system

### DIFF
--- a/esi_leap/api/controllers/v1/lease.py
+++ b/esi_leap/api/controllers/v1/lease.py
@@ -106,16 +106,18 @@ class LeasesController(rest.RestController):
         if 'resource_type' not in lease_dict:
             lease_dict['resource_type'] = CONF.api.default_resource_type
 
-        utils.check_resource_admin(cdict,
-                                   lease_dict.get('resource_type'),
-                                   lease_dict.get('resource_uuid'),
-                                   request.project_id)
-
         if 'start_time' not in lease_dict:
             lease_dict['start_time'] = datetime.datetime.now()
 
         if 'end_time' not in lease_dict:
             lease_dict['end_time'] = datetime.datetime.max
+
+        utils.check_resource_admin(cdict,
+                                   lease_dict.get('resource_type'),
+                                   lease_dict.get('resource_uuid'),
+                                   request.project_id,
+                                   lease_dict.get('start_time'),
+                                   lease_dict.get('end_time'))
 
         lease = lease_obj.Lease(**lease_dict)
         lease.create(request)

--- a/esi_leap/api/controllers/v1/offer.py
+++ b/esi_leap/api/controllers/v1/offer.py
@@ -171,11 +171,6 @@ class OffersController(rest.RestController):
         if 'resource_type' not in offer_dict:
             offer_dict['resource_type'] = CONF.api.default_resource_type
 
-        utils.check_resource_admin(cdict,
-                                   offer_dict.get('resource_type'),
-                                   offer_dict.get('resource_uuid'),
-                                   offer_dict.get('project_id'))
-
         if 'start_time' not in offer_dict:
             offer_dict['start_time'] = datetime.datetime.now()
         if 'end_time' not in offer_dict:
@@ -186,6 +181,13 @@ class OffersController(rest.RestController):
                 InvalidTimeRange(resource="an offer",
                                  start_time=str(offer_dict['start_time']),
                                  end_time=str(offer_dict['end_time']))
+
+        utils.check_resource_admin(cdict,
+                                   offer_dict.get('resource_type'),
+                                   offer_dict.get('resource_uuid'),
+                                   offer_dict.get('project_id'),
+                                   offer_dict.get('start_time'),
+                                   offer_dict.get('end_time'))
 
         o = offer_obj.Offer(**offer_dict)
         o.create()

--- a/esi_leap/api/controllers/v1/owner_change.py
+++ b/esi_leap/api/controllers/v1/owner_change.py
@@ -1,0 +1,188 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import datetime
+import http.client as http_client
+from oslo_policy import policy as oslo_policy
+from oslo_utils import uuidutils
+import pecan
+from pecan import rest
+import wsme
+from wsme import types as wtypes
+import wsmeext.pecan as wsme_pecan
+
+from esi_leap.api.controllers import base
+from esi_leap.api.controllers import types
+from esi_leap.common import exception
+from esi_leap.common import policy
+from esi_leap.common import statuses
+import esi_leap.conf
+from esi_leap.objects import owner_change as owner_change_obj
+
+CONF = esi_leap.conf.CONF
+
+
+class OwnerChange(base.ESILEAPBase):
+
+    uuid = wsme.wsattr(wtypes.text, readonly=True)
+    from_owner_id = wsme.wsattr(wtypes.text, mandatory=True)
+    to_owner_id = wsme.wsattr(wtypes.text, mandatory=True)
+    resource_type = wsme.wsattr(wtypes.text)
+    resource_uuid = wsme.wsattr(wtypes.text, mandatory=True)
+    start_time = wsme.wsattr(datetime.datetime)
+    end_time = wsme.wsattr(datetime.datetime)
+    status = wsme.wsattr(wtypes.text, readonly=True)
+    fulfill_time = wsme.wsattr(datetime.datetime, readonly=True)
+    expire_time = wsme.wsattr(datetime.datetime, readonly=True)
+
+    def __init__(self, **kwargs):
+        self.fields = owner_change_obj.OwnerChange.fields
+        for field in self.fields:
+            setattr(self, field, kwargs.get(field, wtypes.Unset))
+
+
+class OwnerChangeCollection(types.Collection):
+    owner_changes = [OwnerChange]
+
+    def __init__(self, **kwargs):
+        self._type = 'owner_changes'
+
+
+class OwnerChangesController(rest.RestController):
+
+    @wsme_pecan.wsexpose(OwnerChange, wtypes.text)
+    def get_one(self, owner_change_uuid):
+        request = pecan.request.context
+        cdict = request.to_policy_values()
+
+        policy.authorize('esi_leap:owner_change:get', cdict, cdict)
+
+        oc = owner_change_obj.OwnerChange.get(owner_change_uuid)
+        if oc is None:
+            raise exception.OwnerChangeNotFound(
+                owner_change_uuid=owner_change_uuid)
+
+        if cdict['project_id'] not in (oc.from_owner_id, oc.to_owner_id):
+            policy.authorize('esi_leap:owner_change:owner_change_admin',
+                             cdict, cdict)
+
+        return OwnerChange(**oc.to_dict())
+
+    @wsme_pecan.wsexpose(OwnerChangeCollection, wtypes.text, wtypes.text,
+                         wtypes.text, wtypes.text,
+                         datetime.datetime, datetime.datetime,
+                         wtypes.text)
+    def get_all(self, from_owner_id=None, to_owner_id=None,
+                resource_type=None, resource_uuid=None,
+                start_time=None, end_time=None,
+                status=None):
+        request = pecan.request.context
+
+        cdict = request.to_policy_values()
+        policy.authorize('esi_leap:owner_change:get', cdict, cdict)
+
+        if (start_time and end_time is None) or\
+           (end_time and start_time is None):
+            raise exception.InvalidTimeAPICommand(resource='an owner change',
+                                                  start_time=str(start_time),
+                                                  end_time=str(end_time))
+
+        if start_time and end_time and\
+           end_time <= start_time:
+            raise exception.InvalidTimeAPICommand(resource='an owner change',
+                                                  start_time=str(start_time),
+                                                  end_time=str(end_time))
+
+        if status is None:
+            status = [statuses.CREATED, statuses.ACTIVE]
+        elif status == 'any':
+            status = None
+
+        try:
+            policy.authorize('esi_leap:owner_change:owner_change_admin',
+                             cdict, cdict)
+            from_or_to_owner_id = None
+        except oslo_policy.PolicyNotAuthorized:
+            from_or_to_owner_id = cdict['project_id']
+
+        possible_filters = {
+            'from_or_to_owner_id': from_or_to_owner_id,
+            'from_owner_id': from_owner_id,
+            'to_owner_id': to_owner_id,
+            'resource_type': resource_type,
+            'resource_uuid': resource_uuid,
+            'status': status,
+            'start_time': start_time,
+            'end_time': end_time,
+        }
+
+        filters = {}
+        for k, v in possible_filters.items():
+            if v is not None:
+                filters[k] = v
+
+        oc_collection = OwnerChangeCollection()
+        ocs = owner_change_obj.OwnerChange.get_all(filters, request)
+        oc_collection.owner_changes = [
+            OwnerChange(**oc.to_dict()) for oc in ocs]
+
+        return oc_collection
+
+    @wsme_pecan.wsexpose(OwnerChange, body=OwnerChange,
+                         status_code=http_client.CREATED)
+    def post(self, new_owner_change):
+        request = pecan.request.context
+        cdict = request.to_policy_values()
+        policy.authorize('esi_leap:owner_change:create', cdict, cdict)
+
+        owner_change_dict = new_owner_change.to_dict()
+        owner_change_dict['uuid'] = uuidutils.generate_uuid()
+
+        if owner_change_dict['from_owner_id'] == \
+           owner_change_dict['to_owner_id']:
+            raise exception.OwnerChangeSameFromAndToOwner()
+
+        if 'resource_type' not in owner_change_dict:
+            owner_change_dict['resource_type'] = CONF.api.default_resource_type
+
+        if 'start_time' not in owner_change_dict:
+            owner_change_dict['start_time'] = datetime.datetime.now()
+        if 'end_time' not in owner_change_dict:
+            owner_change_dict['end_time'] = datetime.datetime.max
+
+        if owner_change_dict['start_time'] >= owner_change_dict['end_time']:
+            raise exception.\
+                InvalidTimeRange(
+                    resource="an owner change",
+                    start_time=str(owner_change_dict['start_time']),
+                    end_time=str(owner_change_dict['end_time']))
+
+        oc = owner_change_obj.OwnerChange(**owner_change_dict)
+        oc.create()
+        return OwnerChange(**oc.to_dict())
+
+    @wsme_pecan.wsexpose(OwnerChange, wtypes.text)
+    def delete(self, owner_change_uuid):
+        request = pecan.request.context
+        cdict = request.to_policy_values()
+        policy.authorize('esi_leap:owner_change:delete', cdict, cdict)
+
+        oc = owner_change_obj.OwnerChange.get(owner_change_uuid)
+        if oc is None:
+            raise exception.OwnerChangeNotFound(
+                owner_change_uuid=owner_change_uuid)
+
+        if cdict['project_id'] not in (oc.from_owner_id, oc.to_owner_id):
+            policy.authorize('esi_leap:owner_change:owner_change_admin',
+                             cdict, cdict)
+
+        oc.cancel()

--- a/esi_leap/api/controllers/v1/root.py
+++ b/esi_leap/api/controllers/v1/root.py
@@ -16,12 +16,14 @@ from pecan import rest
 
 from esi_leap.api.controllers.v1 import lease
 from esi_leap.api.controllers.v1 import offer
+from esi_leap.api.controllers.v1 import owner_change
 
 
 class Controller(rest.RestController):
 
     leases = lease.LeasesController()
     offers = offer.OffersController()
+    owner_changes = owner_change.OwnerChangesController()
 
     @pecan.expose(content_type='application/json')
     def index(self):

--- a/esi_leap/api/controllers/v1/utils.py
+++ b/esi_leap/api/controllers/v1/utils.py
@@ -56,10 +56,11 @@ def get_offer_authorized(uuid_or_name, cdict, status_filter=None):
     return offer_objs[0]
 
 
-def check_resource_admin(cdict, resource_type, resource_uuid, project_id):
+def check_resource_admin(cdict, resource_type, resource_uuid, project_id,
+                         start_time, end_time):
     resource = ro_factory.ResourceObjectFactory.get_resource_object(
         resource_type, resource_uuid)
-    if not resource.is_resource_admin(project_id):
+    if not resource.check_admin(project_id, start_time, end_time):
         policy.authorize('esi_leap:offer:offer_admin', cdict, cdict)
 
 

--- a/esi_leap/common/exception.py
+++ b/esi_leap/common/exception.py
@@ -77,13 +77,22 @@ class OfferNotAvailable(ESILeapException):
                 "'available'. Got offer status '%(status)s'.")
 
 
+class OwnerChangeNotFound(ESILeapException):
+    msg_fmt = _(
+        "Ownership change with uuid %(owner_change_uuid)s not found.")
+
+
+class OwnerChangeSameFromAndToOwner(ESILeapException):
+    msg_fmt = _(
+        "Ownership change must have different from_ and to_ owners.")
+
+
 class ProjectNoPermission(ESILeapException):
     msg_fmt = _("You do not have permissions on project %(project_id)s.")
 
 
 class ResourceTimeConflict(ESILeapException):
-    msg_fmt = ("Conflict with existing offer or lease "
-               "on %(resource_type)s %(resource_uuid)s.")
+    msg_fmt = ("Time conflict for %(resource_type)s %(resource_uuid)s.")
 
 
 class ResourceNoPermission(ESILeapException):

--- a/esi_leap/common/policy.py
+++ b/esi_leap/common/policy.py
@@ -90,12 +90,40 @@ offer_policies = [
         [{'path': '/offers/{offer_ident}/claim', 'method': 'POST'}]),
 ]
 
+owner_change_policies = [
+    policy.DocumentedRuleDefault(
+        'esi_leap:owner_change:owner_change_admin',
+        'rule:is_admin',
+        'Complete permissions over owner changes',
+        [{'path': '/owner_changes', 'method': 'POST'},
+         {'path': '/owner_changes', 'method': 'GET'},
+         {'path': '/owner_changes/{owner_change_ident}', 'method': 'GET'},
+         {'path': '/owner_changes/{owner_change_ident}', 'method': 'DELETE'}]),
+    policy.DocumentedRuleDefault(
+        'esi_leap:owner_change:create',
+        'rule:is_admin',
+        'Create owner change',
+        [{'path': '/owner_changes', 'method': 'POST'}]),
+    policy.DocumentedRuleDefault(
+        'esi_leap:owner_change:get',
+        'rule:is_admin or rule:is_owner',
+        'Retrieve owner change',
+        [{'path': '/owner_changes', 'method': 'GET'},
+         {'path': '/owner_changes/{owner_change_ident}', 'method': 'GET'}]),
+    policy.DocumentedRuleDefault(
+        'esi_leap:owner_change:delete',
+        'rule:is_admin',
+        'Delete owner change',
+        [{'path': '/owner_changes/{owner_change_ident}', 'method': 'DELETE'}]),
+]
+
 
 def list_rules():
     policies = itertools.chain(
         default_policies,
         lease_policies,
         offer_policies,
+        owner_change_policies,
     )
     return policies
 

--- a/esi_leap/db/api.py
+++ b/esi_leap/db/api.py
@@ -146,3 +146,12 @@ def lease_destroy(lease_uuid):
 def resource_verify_availability(r_type, r_uuid, start, end):
     return IMPL.resource_verify_availability(
         r_type, r_uuid, start, end)
+
+
+def resource_check_admin(resource_type, resource_uuid,
+                         start_time, end_time,
+                         default_admin_project_id, project_id):
+    return IMPL.resource_check_admin(
+        resource_type, resource_uuid,
+        start_time, end_time,
+        default_admin_project_id, project_id)

--- a/esi_leap/db/sqlalchemy/models.py
+++ b/esi_leap/db/sqlalchemy/models.py
@@ -91,3 +91,26 @@ class Lease(Base):
         backref=orm.backref('offers'),
         foreign_keys=offer_uuid,
         primaryjoin=offer_uuid == Offer.uuid)
+
+
+class OwnerChange(Base):
+    """Represents an ownership change."""
+
+    __tablename__ = 'owner_changes'
+    __table_args__ = (
+        Index('oc_uuid_idx', 'uuid'),
+        Index('oc_from_owner_id_idx', 'from_owner_id'),
+        Index('oc_to_owner_id_idx', 'to_owner_id'),
+    )
+
+    id = Column(Integer, primary_key=True, nullable=False, autoincrement=True)
+    uuid = Column(String(36), nullable=False, unique=True)
+    from_owner_id = Column(String(255), nullable=False)
+    to_owner_id = Column(String(255), nullable=False)
+    resource_type = Column(String(36), nullable=False)
+    resource_uuid = Column(String(36), nullable=False)
+    start_time = Column(DateTime)
+    end_time = Column(DateTime)
+    fulfill_time = Column(DateTime)
+    expire_time = Column(DateTime)
+    status = Column(String(15), nullable=False, default=statuses.CREATED)

--- a/esi_leap/objects/__init__.py
+++ b/esi_leap/objects/__init__.py
@@ -1,3 +1,4 @@
 def register_all():
     __import__('esi_leap.objects.lease')
     __import__('esi_leap.objects.offer')
+    __import__('esi_leap.objects.owner_change')

--- a/esi_leap/objects/owner_change.py
+++ b/esi_leap/objects/owner_change.py
@@ -1,0 +1,186 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import datetime
+from oslo_config import cfg
+from oslo_log import log as logging
+from oslo_versionedobjects import base as versioned_objects_base
+
+from esi_leap.common import exception
+from esi_leap.common import statuses
+from esi_leap.common import utils
+from esi_leap.db import api as dbapi
+from esi_leap.objects import base
+from esi_leap.objects import fields
+from esi_leap.objects import lease as lease_obj
+from esi_leap.objects import offer as offer_obj
+from esi_leap.resource_objects import resource_object_factory as ro_factory
+
+
+CONF = cfg.CONF
+LOG = logging.getLogger(__name__)
+
+
+@versioned_objects_base.VersionedObjectRegistry.register
+class OwnerChange(base.ESILEAPObject):
+    dbapi = dbapi.get_instance()
+
+    fields = {
+        'id': fields.IntegerField(),
+        'uuid': fields.UUIDField(),
+        'from_owner_id': fields.StringField(),
+        'to_owner_id': fields.StringField(),
+        'resource_type': fields.StringField(),
+        'resource_uuid': fields.StringField(),
+        'start_time': fields.DateTimeField(nullable=True),
+        'end_time': fields.DateTimeField(nullable=True),
+        'fulfill_time': fields.DateTimeField(nullable=True),
+        'expire_time': fields.DateTimeField(nullable=True),
+        'status': fields.StringField(),
+    }
+
+    @classmethod
+    def get(cls, owner_change_uuid, context=None):
+        db_owner_change = cls.dbapi.owner_change_get_by_uuid(owner_change_uuid)
+        if db_owner_change:
+            return cls._from_db_object(context, cls(), db_owner_change)
+
+    @classmethod
+    def get_all(cls, filters, context=None):
+        db_owner_changes = cls.dbapi.owner_change_get_all(filters)
+        return cls._from_db_object_list(context, db_owner_changes)
+
+    def create(self, context=None):
+        updates = self.obj_get_changes()
+
+        @utils.synchronized(
+            utils.get_resource_lock_name(
+                updates['resource_type'], updates['resource_uuid']),
+            external=True)
+        def _create_owner_change():
+
+            if updates['start_time'] >= updates['end_time']:
+                raise exception.InvalidTimeRange(
+                    resource='owner_change',
+                    start_time=str(updates['start_time']),
+                    end_time=str(updates['end_time'])
+                )
+
+            ro = ro_factory.ResourceObjectFactory.get_resource_object(
+                updates['resource_type'], updates['resource_uuid'])
+            ro.verify_availability(updates['start_time'],
+                                   updates['end_time'],
+                                   is_owner_change=True)
+
+            db_owner_change = self.dbapi.owner_change_create(updates)
+            self._from_db_object(context, self, db_owner_change)
+
+        _create_owner_change()
+
+    def fulfill(self, context=None):
+        @utils.synchronized(utils.get_resource_lock_name(self.resource_type,
+                                                         self.resource_uuid),
+                            external=True)
+        def _fulfill_owner_change():
+            LOG.info("Setting owner of %s %s from %s to %s",
+                     self.resource_type, self.resource_uuid,
+                     self.from_owner_id, self.to_owner_id)
+
+            resource = self.resource_object()
+            resource.set_owner(self.to_owner_id)
+
+            # activate owner change
+            self.status = statuses.ACTIVE
+            self.fulfill_time = datetime.datetime.now()
+            self.save(context)
+
+        _fulfill_owner_change()
+
+    def cancel(self):
+        offers_to_cancel = self.offers()
+        for offer in offers_to_cancel:
+            offer.cancel()
+        leases_to_cancel = self.leases()
+        for lease in leases_to_cancel:
+            lease.cancel()
+
+        @utils.synchronized(utils.get_resource_lock_name(self.resource_type,
+                                                         self.resource_uuid))
+        def _cancel_owner_change():
+            LOG.info("Setting owner of %s %s back to %s",
+                     self.resource_type, self.resource_uuid,
+                     self.from_owner_id)
+
+            resource = self.resource_object()
+            resource.set_owner(self.from_owner_id)
+
+            self.status = statuses.CANCELLED
+            self.expire_time = datetime.datetime.now()
+            self.save(None)
+
+        _cancel_owner_change()
+
+    def expire(self, context=None):
+        offers_to_cancel = self.offers()
+        for offer in offers_to_cancel:
+            offer.cancel()
+        leases_to_cancel = self.leases()
+        for lease in leases_to_cancel:
+            lease.cancel()
+
+        @utils.synchronized(utils.get_resource_lock_name(self.resource_type,
+                                                         self.resource_uuid))
+        def _expire_owner_change():
+            LOG.info("Setting owner of %s %s from %s back to %s",
+                     self.resource_type, self.resource_uuid,
+                     self.to_owner_id, self.from_owner_id)
+
+            resource = self.resource_object()
+            resource.set_owner(self.from_owner_id)
+
+            self.status = statuses.EXPIRED
+            self.expire_time = datetime.datetime.now()
+            self.save(context)
+
+        _expire_owner_change()
+
+    def destroy(self):
+        self.dbapi.owner_change_destroy(self.uuid)
+        self.obj_reset_changes()
+
+    def save(self, context=None):
+        updates = self.obj_get_changes()
+        db_owner_change = self.dbapi.owner_change_update(
+            self.uuid, updates)
+        self._from_db_object(context, self, db_owner_change)
+
+    def offers(self):
+        return offer_obj.Offer.get_all({
+            'project_id': self.to_owner_id,
+            'start_time': self.start_time,
+            'end_time': self.end_time,
+            'time_filter_type': 'within',
+            'status': statuses.AVAILABLE
+        })
+
+    def leases(self):
+        return lease_obj.Lease.get_all({
+            'owner_id': self.to_owner_id,
+            'start_time': self.start_time,
+            'end_time': self.end_time,
+            'time_filter_type': 'within',
+            'status': [statuses.CREATED, statuses.ACTIVE]
+        })
+
+    def resource_object(self):
+        return ro_factory.ResourceObjectFactory.get_resource_object(
+            self.resource_type, self.resource_uuid)

--- a/esi_leap/resource_objects/base.py
+++ b/esi_leap/resource_objects/base.py
@@ -57,14 +57,33 @@ class ResourceObjectInterface(object, metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def is_resource_admin(self, project_id):
-        """Check if project_id can administrate the node
+    def set_owner(self, owner_id):
+        """Set the owner of the node
 
         """
 
-    def verify_availability(self, start_time, end_time):
+    @abc.abstractmethod
+    def resource_admin_project_id(self):
+        """Return project_id of resource admin
+
+        """
+
+    def verify_availability(self, start_time, end_time,
+                            is_owner_change=False):
         self.dbapi.resource_verify_availability(
             self.resource_type,
             self.get_resource_uuid(),
             start_time,
-            end_time)
+            end_time,
+            is_owner_change=is_owner_change
+        )
+
+    def check_admin(self, project_id, start_time, end_time):
+        return self.dbapi.resource_check_admin(
+            self.resource_type,
+            self.get_resource_uuid(),
+            start_time,
+            end_time,
+            self.resource_admin_project_id(),
+            project_id
+        )

--- a/esi_leap/resource_objects/dummy_node.py
+++ b/esi_leap/resource_objects/dummy_node.py
@@ -62,8 +62,14 @@ class DummyNode(base.ResourceObjectInterface):
         with open(self._path, 'w') as node_file:
             json.dump(node_dict, node_file)
 
-    def is_resource_admin(self, project_id):
+    def set_owner(self, owner_id):
         with open(self._path) as node_file:
             node_dict = json.load(node_file)
-        project_owner_id = node_dict.get("project_owner_id", None)
-        return (project_owner_id == project_id)
+        node_dict["project_owner_id"] = owner_id
+        with open(self._path, 'w') as node_file:
+            json.dump(node_dict, node_file)
+
+    def resource_admin_project_id(self):
+        with open(self._path) as node_file:
+            node_dict = json.load(node_file)
+        return node_dict.get("project_owner_id", None)

--- a/esi_leap/resource_objects/ironic_node.py
+++ b/esi_leap/resource_objects/ironic_node.py
@@ -75,8 +75,7 @@ class IronicNode(base.ResourceObjectInterface):
             "path": "/lessee",
             "value": lease.project_id,
         })
-        if len(patches) > 0:
-            get_ironic_client().node.update(self._uuid, patches)
+        get_ironic_client().node.update(self._uuid, patches)
 
     def expire_lease(self, lease):
         patches = []
@@ -98,7 +97,14 @@ class IronicNode(base.ResourceObjectInterface):
         if state == "active":
             get_ironic_client().node.set_provision_state(self._uuid, "deleted")
 
-    def is_resource_admin(self, project_id):
+    def set_owner(self, owner_id):
+        patches = [{
+            "op": "add",
+            "path": "/owner",
+            "value": owner_id,
+        }]
+        get_ironic_client().node.update(self._uuid, patches)
+
+    def resource_admin_project_id(self):
         node = get_ironic_client().node.get(self._uuid)
-        project_owner_id = node.owner
-        return (project_owner_id == project_id)
+        return node.owner

--- a/esi_leap/resource_objects/test_node.py
+++ b/esi_leap/resource_objects/test_node.py
@@ -39,5 +39,8 @@ class TestNode(base.ResourceObjectInterface):
     def expire_lease(self, lease):
         return
 
-    def is_resource_admin(self, project_id):
-        return project_id == self._project_id
+    def set_owner(self, owner_id):
+        return
+
+    def resource_admin_project_id(self):
+        return self._project_id

--- a/esi_leap/tests/api/base.py
+++ b/esi_leap/tests/api/base.py
@@ -103,6 +103,24 @@ class APITestCase(base.DBTestCase):
                                   status=status, method="post")
 
     # borrowed from Ironic
+    def delete_json(self, path, expect_errors=False, headers=None,
+                    extra_environ=None, status=None):
+        """Sends simulated HTTP POST request to Pecan test app.
+
+        :param path: url path of target service
+        :param expect_errors: Boolean value; whether an error is expected based
+                              on request
+        :param headers: a dictionary of headers to send along with the request
+        :param extra_environ: a dictionary of environ variables to send along
+                              with the request
+        :param status: expected status code of response
+        """
+        return self._request_json(path=path, params={},
+                                  expect_errors=expect_errors,
+                                  headers=headers, extra_environ=extra_environ,
+                                  status=status, method="delete")
+
+    # borrowed from Ironic
     def _request_json(self, path, params, expect_errors=False, headers=None,
                       method="post", extra_environ=None, status=None,
                       path_prefix=PATH_PREFIX):

--- a/esi_leap/tests/api/controllers/v1/test_lease.py
+++ b/esi_leap/tests/api/controllers/v1/test_lease.py
@@ -69,9 +69,12 @@ class TestLeasesController(test_api_base.APITestCase):
         data['uuid'] = self.test_lease.uuid
 
         mock_generate_uuid.assert_called_once()
-        mock_cra.assert_called_once_with(self.context.to_policy_values(),
-                                         'test_node', '1234567890',
-                                         self.context.project_id)
+        mock_cra.assert_called_once_with(
+            self.context.to_policy_values(),
+            'test_node', '1234567890',
+            self.context.project_id,
+            datetime.datetime(2016, 7, 16, 19, 20, 30),
+            datetime.datetime(2016, 8, 16, 19, 20, 30))
         mock_create.assert_called_once()
         self.assertEqual(data, request.json)
         self.assertEqual(http_client.CREATED, request.status_int)
@@ -96,9 +99,12 @@ class TestLeasesController(test_api_base.APITestCase):
         data['resource_type'] = 'ironic_node'
 
         mock_generate_uuid.assert_called_once()
-        mock_cra.assert_called_once_with(self.context.to_policy_values(),
-                                         'ironic_node', '1234567890',
-                                         self.context.project_id)
+        mock_cra.assert_called_once_with(
+            self.context.to_policy_values(),
+            'ironic_node', '1234567890',
+            self.context.project_id,
+            datetime.datetime(2016, 7, 16, 19, 20, 30),
+            datetime.datetime(2016, 8, 16, 19, 20, 30))
         mock_create.assert_called_once()
         self.assertEqual(data, request.json)
         self.assertEqual(http_client.CREATED, request.status_int)

--- a/esi_leap/tests/api/controllers/v1/test_offer.py
+++ b/esi_leap/tests/api/controllers/v1/test_offer.py
@@ -108,10 +108,13 @@ class TestOffersController(test_api_base.APITestCase):
         data['uuid'] = self.test_offer.uuid
         data['status'] = statuses.AVAILABLE
 
-        mock_cra.assert_called_once_with(self.context.to_policy_values(),
-                                         self.test_offer.resource_type,
-                                         self.test_offer.resource_uuid,
-                                         self.context.project_id)
+        mock_cra.assert_called_once_with(
+            self.context.to_policy_values(),
+            self.test_offer.resource_type,
+            self.test_offer.resource_uuid,
+            self.context.project_id,
+            datetime.datetime(2016, 7, 16, 0, 0, 0),
+            datetime.datetime(2016, 10, 24, 0, 0, 0))
         mock_create.assert_called_once()
         mock_aoa.assert_called_once()
         self.assertEqual(data, request.json)
@@ -141,10 +144,13 @@ class TestOffersController(test_api_base.APITestCase):
         data['status'] = statuses.AVAILABLE
         data['resource_type'] = 'ironic_node'
 
-        mock_cra.assert_called_once_with(self.context.to_policy_values(),
-                                         'ironic_node',
-                                         self.test_offer_drt.resource_uuid,
-                                         self.context.project_id)
+        mock_cra.assert_called_once_with(
+            self.context.to_policy_values(),
+            'ironic_node',
+            self.test_offer_drt.resource_uuid,
+            self.context.project_id,
+            datetime.datetime(2016, 7, 16, 0, 0, 0),
+            datetime.datetime(2016, 10, 24, 0, 0, 0))
         mock_create.assert_called_once()
         mock_aoa.assert_called_once()
         self.assertEqual(data, request.json)

--- a/esi_leap/tests/api/controllers/v1/test_owner_change.py
+++ b/esi_leap/tests/api/controllers/v1/test_owner_change.py
@@ -1,0 +1,443 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import datetime
+import http.client as http_client
+import mock
+from oslo_policy import policy as oslo_policy
+from oslo_utils import uuidutils
+
+from esi_leap.common import statuses
+from esi_leap.objects import owner_change
+from esi_leap.tests.api import base as test_api_base
+
+
+TIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
+
+
+def _get_owner_change_response(o):
+    return {
+        'resource_type': o.resource_type,
+        'resource_uuid': o.resource_uuid,
+        'start_time': o.start_time.strftime(TIME_FORMAT),
+        'end_time': o.end_time.strftime(TIME_FORMAT),
+        'status': o.status,
+        'uuid': o.uuid,
+        'from_owner_id': o.from_owner_id,
+        'to_owner_id': o.to_owner_id
+    }
+
+
+class TestOwnerChangesController(test_api_base.APITestCase):
+
+    def setUp(self):
+        super(TestOwnerChangesController, self).setUp()
+
+        now = datetime.datetime(2016, 7, 16)
+        self.test_oc = owner_change.OwnerChange(
+            resource_type='ironic_node',
+            resource_uuid=uuidutils.generate_uuid(),
+            uuid=uuidutils.generate_uuid(),
+            status=statuses.CREATED,
+            start_time=now,
+            end_time=now + datetime.timedelta(days=30),
+            from_owner_id=self.context.project_id,
+            to_owner_id='fake-project-id',
+        )
+        self.test_oc2 = owner_change.OwnerChange(
+            resource_type='ironic_node',
+            resource_uuid=uuidutils.generate_uuid(),
+            uuid=uuidutils.generate_uuid(),
+            status=statuses.CREATED,
+            start_time=now,
+            end_time=now + datetime.timedelta(days=30),
+            from_owner_id='another-fake-project-id',
+            to_owner_id='fake-project-id',
+        )
+
+    def test_empty(self):
+        data = self.get_json('/owner_changes')
+        self.assertEqual([], data['owner_changes'])
+
+    def test_one(self):
+        self.test_oc.create(self.context)
+        data = self.get_json('/owner_changes')
+        self.assertEqual(self.test_oc.uuid,
+                         data['owner_changes'][0]["uuid"])
+
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.get_all')
+    @mock.patch('esi_leap.common.policy.authorize')
+    def test_get_all(self, mock_authorize, mock_get_all):
+        mock_get_all.return_value = [self.test_oc, self.test_oc2]
+
+        expected_filters = {'status': [statuses.CREATED, statuses.ACTIVE]}
+        expected_resp = {
+            'owner_changes': [_get_owner_change_response(self.test_oc),
+                              _get_owner_change_response(self.test_oc2)]}
+
+        response = self.get_json('/owner_changes')
+
+        assert mock_authorize.call_count == 2
+        mock_authorize.assert_any_call(
+            'esi_leap:owner_change:get',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_authorize.assert_any_call(
+            'esi_leap:owner_change:owner_change_admin',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_get_all.assert_called_once_with(expected_filters, self.context)
+        self.assertEqual(expected_resp, response)
+
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.get_all')
+    @mock.patch('esi_leap.common.policy.authorize')
+    def test_get_all_any_status(self, mock_authorize, mock_get_all):
+        mock_get_all.return_value = [self.test_oc, self.test_oc2]
+
+        expected_filters = {}
+        expected_resp = {
+            'owner_changes': [_get_owner_change_response(self.test_oc),
+                              _get_owner_change_response(self.test_oc2)]}
+
+        response = self.get_json('/owner_changes?status=any')
+
+        assert mock_authorize.call_count == 2
+        mock_authorize.assert_any_call(
+            'esi_leap:owner_change:get',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_authorize.assert_any_call(
+            'esi_leap:owner_change:owner_change_admin',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_get_all.assert_called_once_with(expected_filters, self.context)
+        self.assertEqual(expected_resp, response)
+
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.get_all')
+    @mock.patch('esi_leap.common.policy.authorize')
+    def test_get_all_non_admin(self, mock_authorize, mock_get_all):
+        mock_get_all.return_value = [self.test_oc, self.test_oc2]
+        mock_authorize.side_effect = [
+            None,
+            oslo_policy.PolicyNotAuthorized('esi_leap:offer:offer_admin',
+                                            self.context.to_policy_values(),
+                                            self.context.to_policy_values())
+        ]
+
+        expected_filters = {'status': [statuses.CREATED, statuses.ACTIVE],
+                            'from_or_to_owner_id': self.context.project_id}
+        expected_resp = {
+            'owner_changes': [_get_owner_change_response(self.test_oc),
+                              _get_owner_change_response(self.test_oc2)]}
+
+        response = self.get_json('/owner_changes')
+
+        assert mock_authorize.call_count == 2
+        mock_authorize.assert_any_call(
+            'esi_leap:owner_change:get',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_authorize.assert_any_call(
+            'esi_leap:owner_change:owner_change_admin',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_get_all.assert_called_once_with(expected_filters, self.context)
+        self.assertEqual(expected_resp, response)
+
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.get_all')
+    @mock.patch('esi_leap.common.policy.authorize')
+    def test_get_all_valid_time(self, mock_authorize, mock_get_all):
+        mock_get_all.return_value = [self.test_oc, self.test_oc2]
+
+        expected_filters = {
+            'status': [statuses.CREATED, statuses.ACTIVE],
+            'start_time': self.test_oc.start_time,
+            'end_time': self.test_oc.end_time
+        }
+        expected_resp = {
+            'owner_changes': [_get_owner_change_response(self.test_oc),
+                              _get_owner_change_response(self.test_oc2)]}
+
+        response = self.get_json(
+            '/owner_changes?start_time=' +
+            self.test_oc.start_time.strftime(TIME_FORMAT) +
+            "&end_time=" +
+            self.test_oc.end_time.strftime(TIME_FORMAT))
+
+        assert mock_authorize.call_count == 2
+        mock_authorize.assert_any_call(
+            'esi_leap:owner_change:get',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_authorize.assert_any_call(
+            'esi_leap:owner_change:owner_change_admin',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_get_all.assert_called_once_with(expected_filters, self.context)
+        self.assertEqual(expected_resp, response)
+
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.get_all')
+    @mock.patch('esi_leap.common.policy.authorize')
+    def test_get_all_invalid_time(self, mock_authorize, mock_get_all):
+        mock_get_all.return_value = [self.test_oc, self.test_oc2]
+
+        response = self.get_json('/owner_changes?start_time=' +
+                                 self.test_oc.end_time.strftime(TIME_FORMAT) +
+                                 "&end_time=" +
+                                 self.test_oc.start_time.strftime(TIME_FORMAT),
+                                 expect_errors=True)
+
+        mock_authorize.assert_called_once_with(
+            'esi_leap:owner_change:get',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_get_all.assert_not_called
+        self.assertEqual(http_client.INTERNAL_SERVER_ERROR,
+                         response.status_int)
+
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.get')
+    @mock.patch('esi_leap.common.policy.authorize')
+    def test_get(self, mock_authorize, mock_get):
+        mock_get.return_value = self.test_oc
+
+        response = self.get_json('/owner_changes/' + self.test_oc.uuid)
+
+        mock_authorize.assert_called_once_with(
+            'esi_leap:owner_change:get',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_get.assert_called_once_with(self.test_oc.uuid)
+        self.assertEqual(_get_owner_change_response(self.test_oc),
+                         response)
+
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.get')
+    @mock.patch('esi_leap.common.policy.authorize')
+    def test_get_not_to_or_from_owner(self, mock_authorize, mock_get):
+        mock_get.return_value = self.test_oc2
+
+        response = self.get_json('/owner_changes/' + self.test_oc2.uuid)
+
+        assert mock_authorize.call_count == 2
+        mock_authorize.assert_any_call(
+            'esi_leap:owner_change:get',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_authorize.assert_any_call(
+            'esi_leap:owner_change:owner_change_admin',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_get.assert_called_once_with(self.test_oc2.uuid)
+        self.assertEqual(_get_owner_change_response(self.test_oc2),
+                         response)
+
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.get')
+    @mock.patch('esi_leap.common.policy.authorize')
+    def test_get_not_exist(self, mock_authorize, mock_get):
+        mock_get.return_value = None
+
+        response = self.get_json('/owner_changes/non-existent-uuid',
+                                 expect_errors=True)
+
+        mock_authorize.assert_called_once_with(
+            'esi_leap:owner_change:get',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_get.assert_called_once_with('non-existent-uuid')
+        self.assertEqual(http_client.INTERNAL_SERVER_ERROR,
+                         response.status_int)
+
+    @mock.patch('oslo_utils.uuidutils.generate_uuid')
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.create')
+    @mock.patch('esi_leap.common.policy.authorize')
+    def test_post(self, mock_authorize, mock_create, mock_generate_uuid):
+        mock_generate_uuid.return_value = self.test_oc.uuid
+        mock_create.return_value = self.test_oc
+
+        data = {
+            "resource_type": self.test_oc.resource_type,
+            "resource_uuid": self.test_oc.resource_uuid,
+            "start_time": self.test_oc.start_time.strftime(TIME_FORMAT),
+            "end_time": self.test_oc.end_time.strftime(TIME_FORMAT),
+            "from_owner_id": self.test_oc.from_owner_id,
+            "to_owner_id": self.test_oc.to_owner_id,
+        }
+
+        response = self.post_json('/owner_changes', data)
+
+        data['uuid'] = self.test_oc.uuid
+
+        mock_authorize.assert_called_once_with(
+            'esi_leap:owner_change:create',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_create.assert_called_once
+        self.assertEqual(data, response.json)
+        self.assertEqual(http_client.CREATED, response.status_int)
+
+    @mock.patch('oslo_utils.uuidutils.generate_uuid')
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.create')
+    @mock.patch('esi_leap.common.policy.authorize')
+    def test_post_default_resource_type(self, mock_authorize, mock_create,
+                                        mock_generate_uuid):
+        mock_generate_uuid.return_value = self.test_oc.uuid
+        mock_create.return_value = self.test_oc
+
+        data = {
+            "resource_uuid": self.test_oc.resource_uuid,
+            "start_time": self.test_oc.start_time.strftime(TIME_FORMAT),
+            "end_time": self.test_oc.end_time.strftime(TIME_FORMAT),
+            "from_owner_id": self.test_oc.from_owner_id,
+            "to_owner_id": self.test_oc.to_owner_id,
+        }
+
+        response = self.post_json('/owner_changes', data)
+
+        data['uuid'] = self.test_oc.uuid
+        data['resource_type'] = 'ironic_node'
+
+        mock_authorize.assert_called_once_with(
+            'esi_leap:owner_change:create',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_create.assert_called_once
+        self.assertEqual(data, response.json)
+        self.assertEqual(http_client.CREATED, response.status_int)
+
+    @mock.patch('oslo_utils.uuidutils.generate_uuid')
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.create')
+    @mock.patch('esi_leap.common.policy.authorize')
+    def test_post_invalid_time(self, mock_authorize, mock_create,
+                               mock_generate_uuid):
+        mock_generate_uuid.return_value = self.test_oc.uuid
+        mock_create.return_value = self.test_oc
+
+        data = {
+            "resource_type": self.test_oc.resource_type,
+            "resource_uuid": self.test_oc.resource_uuid,
+            "start_time": self.test_oc.end_time.strftime(TIME_FORMAT),
+            "end_time": self.test_oc.start_time.strftime(TIME_FORMAT),
+            "from_owner_id": self.test_oc.from_owner_id,
+            "to_owner_id": self.test_oc.to_owner_id,
+        }
+
+        response = self.post_json('/owner_changes', data, expect_errors=True)
+
+        mock_authorize.assert_called_once_with(
+            'esi_leap:owner_change:create',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_create.assert_not_called
+        self.assertEqual(http_client.INTERNAL_SERVER_ERROR,
+                         response.status_int)
+
+    @mock.patch('oslo_utils.uuidutils.generate_uuid')
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.create')
+    @mock.patch('esi_leap.common.policy.authorize')
+    def test_post_same_from_and_to_owner(self, mock_authorize, mock_create,
+                                         mock_generate_uuid):
+        mock_generate_uuid.return_value = self.test_oc.uuid
+        mock_create.return_value = self.test_oc
+
+        data = {
+            "resource_type": self.test_oc.resource_type,
+            "resource_uuid": self.test_oc.resource_uuid,
+            "start_time": self.test_oc.end_time.strftime(TIME_FORMAT),
+            "end_time": self.test_oc.start_time.strftime(TIME_FORMAT),
+            "from_owner_id": self.test_oc.from_owner_id,
+            "to_owner_id": self.test_oc.from_owner_id,
+        }
+
+        response = self.post_json('/owner_changes', data, expect_errors=True)
+
+        mock_authorize.assert_called_once_with(
+            'esi_leap:owner_change:create',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_create.assert_not_called
+        self.assertEqual(http_client.INTERNAL_SERVER_ERROR,
+                         response.status_int)
+
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.cancel')
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.get')
+    @mock.patch('esi_leap.common.policy.authorize')
+    def test_delete(self, mock_authorize, mock_get, mock_cancel):
+        mock_get.return_value = self.test_oc
+
+        response = self.delete_json('/owner_changes/' + self.test_oc.uuid)
+
+        mock_authorize.assert_called_once_with(
+            'esi_leap:owner_change:delete',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_get.assert_called_once_with(self.test_oc.uuid)
+        mock_cancel.assert_called_once
+        self.assertEqual(http_client.OK, response.status_int)
+
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.cancel')
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.get')
+    @mock.patch('esi_leap.common.policy.authorize')
+    def test_delete_not_to_or_from_owner(self, mock_authorize, mock_get,
+                                         mock_cancel):
+        mock_get.return_value = self.test_oc2
+
+        response = self.delete_json('/owner_changes/' + self.test_oc2.uuid)
+
+        assert mock_authorize.call_count == 2
+        mock_authorize.assert_any_call(
+            'esi_leap:owner_change:delete',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_authorize.assert_any_call(
+            'esi_leap:owner_change:owner_change_admin',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_get.assert_called_once_with(self.test_oc2.uuid)
+        mock_cancel.assert_called_once
+        self.assertEqual(http_client.OK, response.status_int)
+
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.cancel')
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.get')
+    @mock.patch('esi_leap.common.policy.authorize')
+    def test_delete_not_exist(self, mock_authorize, mock_get, mock_cancel):
+        mock_get.return_value = None
+
+        response = self.delete_json('/owner_changes/non-existent-uuid',
+                                    expect_errors=True)
+
+        mock_authorize.assert_called_once_with(
+            'esi_leap:owner_change:delete',
+            self.context.to_policy_values(),
+            self.context.to_policy_values()
+        )
+        mock_cancel.assert_not_called
+        self.assertEqual(http_client.INTERNAL_SERVER_ERROR,
+                         response.status_int)

--- a/esi_leap/tests/api/controllers/v1/test_utils.py
+++ b/esi_leap/tests/api/controllers/v1/test_utils.py
@@ -464,7 +464,7 @@ class TestGetObjectUtils(testtools.TestCase):
 
 class TestCheckResourceAdminUtils(testtools.TestCase):
 
-    @mock.patch.object(test_node_1, 'is_resource_admin',
+    @mock.patch.object(test_node_1, 'check_admin',
                        return_value=True)
     @mock.patch.object(policy, 'authorize', spec=True)
     @mock.patch('esi_leap.api.controllers.v1.utils.ro_factory.'
@@ -473,19 +473,21 @@ class TestCheckResourceAdminUtils(testtools.TestCase):
     def test_check_resource_admin_owner(self,
                                         mock_gro,
                                         mock_authorize,
-                                        mock_is_resource_admin):
+                                        mock_ca):
 
         utils.check_resource_admin(
             owner_ctx.to_policy_values(), test_offer.resource_type,
-            test_offer.resource_uuid, test_offer.project_id)
+            test_offer.resource_uuid, test_offer.project_id, start,
+            end)
 
         mock_gro.assert_called_once_with(
             test_offer.resource_type,
             test_offer.resource_uuid)
-        mock_is_resource_admin.assert_called_once_with(test_offer.project_id)
+        mock_ca.assert_called_once_with(test_offer.project_id,
+                                        start, end)
         assert not mock_authorize.called
 
-    @mock.patch.object(test_node_2, 'is_resource_admin',
+    @mock.patch.object(test_node_2, 'check_admin',
                        return_value=False)
     @mock.patch.object(policy, 'authorize', spec=True)
     @mock.patch('esi_leap.api.controllers.v1.utils.ro_factory.'
@@ -494,7 +496,7 @@ class TestCheckResourceAdminUtils(testtools.TestCase):
     def test_check_resource_admin_admin(self,
                                         mock_gro,
                                         mock_authorize,
-                                        mock_is_resource_admin):
+                                        mock_ca):
 
         bad_test_offer = offer.Offer(
             resource_type='test_node',
@@ -505,18 +507,19 @@ class TestCheckResourceAdminUtils(testtools.TestCase):
         utils.check_resource_admin(admin_ctx.to_policy_values(),
                                    bad_test_offer.resource_type,
                                    bad_test_offer.resource_uuid,
-                                   bad_test_offer.project_id)
+                                   bad_test_offer.project_id,
+                                   start, end)
 
         mock_gro.assert_called_once_with(
             bad_test_offer.resource_type,
             bad_test_offer.resource_uuid)
-        mock_is_resource_admin.assert_called_once_with(
-            bad_test_offer.project_id)
+        mock_ca.assert_called_once_with(
+            bad_test_offer.project_id, start, end)
         mock_authorize.assert_called_once_with('esi_leap:offer:offer_admin',
                                                admin_ctx.to_policy_values(),
                                                admin_ctx.to_policy_values())
 
-    @mock.patch.object(test_node_2, 'is_resource_admin',
+    @mock.patch.object(test_node_2, 'check_admin',
                        return_value=False)
     @mock.patch.object(policy, 'authorize', spec=True)
     @mock.patch('esi_leap.api.controllers.v1.utils.ro_factory.'
@@ -525,7 +528,7 @@ class TestCheckResourceAdminUtils(testtools.TestCase):
     def test_check_resource_admin_invalid_owner(self,
                                                 mock_gro,
                                                 mock_authorize,
-                                                mock_is_resource_admin):
+                                                mock_ca):
 
         mock_authorize.side_effect = oslo_policy.PolicyNotAuthorized(
             'esi_leap:offer:offer_admin',
@@ -542,13 +545,13 @@ class TestCheckResourceAdminUtils(testtools.TestCase):
                           owner_ctx_2.to_policy_values(),
                           bad_test_offer.resource_type,
                           bad_test_offer.resource_uuid,
-                          bad_test_offer.project_id)
+                          bad_test_offer.project_id, start, end)
 
         mock_gro.assert_called_once_with(
             bad_test_offer.resource_type,
             bad_test_offer.resource_uuid)
-        mock_is_resource_admin.assert_called_once_with(
-            bad_test_offer.project_id)
+        mock_ca.assert_called_once_with(
+            bad_test_offer.project_id, start, end)
         mock_authorize.assert_called_once_with('esi_leap:offer:offer_admin',
                                                owner_ctx_2.to_policy_values(),
                                                owner_ctx_2.to_policy_values())

--- a/esi_leap/tests/manager/test_service.py
+++ b/esi_leap/tests/manager/test_service.py
@@ -12,93 +12,124 @@
 
 import datetime
 import mock
-from oslo_context import context as ctx
 from oslo_utils import uuidutils
 
 from esi_leap.common import statuses
 from esi_leap.manager.service import ManagerService
 from esi_leap.objects import lease
 from esi_leap.objects import offer
+from esi_leap.objects import owner_change
+from esi_leap.tests import base
 
 
-lessee_ctx = ctx.RequestContext(project_id="lesseeid",
-                                roles=['lessee'])
-owner_ctx = ctx.RequestContext(project_id='ownerid',
-                               roles=['owner'])
+class TestService(base.TestCase):
 
-o_uuid = uuidutils.generate_uuid()
+    def setUp(self):
+        super(TestService, self).setUp()
 
-test_offer = offer.Offer(
-    resource_type='test_node',
-    resource_uuid='abc',
-    name="o",
-    uuid=o_uuid,
-    status=statuses.AVAILABLE,
-    start_time=datetime.datetime(3000, 7, 16),
-    end_time=datetime.datetime(4000, 7, 16),
-    project_id=owner_ctx.project_id
-)
+        self.test_offer = offer.Offer(
+            resource_type='test_node',
+            resource_uuid='abc',
+            name="o",
+            uuid=uuidutils.generate_uuid(),
+            status=statuses.AVAILABLE,
+            start_time=datetime.datetime(3000, 7, 16),
+            end_time=datetime.datetime(4000, 7, 16),
+            project_id='ownerid'
+        )
 
-test_lease = lease.Lease(
-    offer_uuid=o_uuid,
-    name='c',
-    uuid=uuidutils.generate_uuid(),
-    project_id=lessee_ctx.project_id,
-    status=statuses.CREATED,
-    start_time=datetime.datetime(3000, 7, 16),
-    end_time=datetime.datetime(4000, 7, 16),
-)
+        self.test_lease = lease.Lease(
+            offer_uuid=self.test_offer.uuid,
+            name='c',
+            uuid=uuidutils.generate_uuid(),
+            project_id='lesseeid',
+            status=statuses.CREATED,
+            start_time=datetime.datetime(3000, 7, 16),
+            end_time=datetime.datetime(4000, 7, 16),
+        )
 
+        self.test_owner_change = owner_change.OwnerChange(
+            resource_type='test_node',
+            resource_uuid='abc',
+            uuid=uuidutils.generate_uuid(),
+            status=statuses.CREATED,
+            start_time=datetime.datetime(3000, 7, 16),
+            end_time=datetime.datetime(4000, 7, 16),
+            from_project_id='ownerid',
+            to_project_id='ownerid2',
+        )
 
-@mock.patch('esi_leap.manager.service.timeutils.utcnow')
-@mock.patch('esi_leap.manager.service.LOG.info')
-@mock.patch('esi_leap.manager.service.lease.Lease.get_all')
-def test__fulfill_leases(mock_ga, mock_log, mock_utcnow):
-    mock_ga.return_value = [test_lease]
-    mock_utcnow.return_value = datetime.datetime(3500, 7, 16)
+    @mock.patch('esi_leap.objects.lease.Lease.fulfill')
+    @mock.patch('oslo_utils.timeutils.utcnow')
+    @mock.patch('esi_leap.objects.lease.Lease.get_all')
+    def test__fulfill_leases(self, mock_ga, mock_utcnow, mock_fulfill):
+        mock_ga.return_value = [self.test_lease, self.test_lease]
+        mock_utcnow.return_value = datetime.datetime(3500, 7, 16)
 
-    s = ManagerService()
-
-    with mock.patch.object(test_lease, 'fulfill') as mock_fulfill:
+        s = ManagerService()
         s._fulfill_leases()
 
-        mock_fulfill.assert_called_once()
+        assert mock_fulfill.call_count == 2
+        mock_ga.assert_called_once_with({
+            'status': [statuses.CREATED]
+        }, s._context)
 
-    mock_ga.assert_called_once()
-    mock_log.assert_called_once()
+    @mock.patch('esi_leap.objects.lease.Lease.expire')
+    @mock.patch('oslo_utils.timeutils.utcnow')
+    @mock.patch('esi_leap.objects.lease.Lease.get_all')
+    def test__expire_leases(self, mock_ga, mock_utcnow, mock_expire):
+        mock_ga.return_value = [self.test_lease, self.test_lease]
+        mock_utcnow.return_value = datetime.datetime(5000, 7, 16)
 
-
-@mock.patch('esi_leap.manager.service.timeutils.utcnow')
-@mock.patch('esi_leap.manager.service.LOG.info')
-@mock.patch('esi_leap.manager.service.lease.Lease.get_all')
-def test__expire_leases(mock_ga, mock_log, mock_utcnow):
-    mock_ga.return_value = [test_lease]
-    mock_utcnow.return_value = datetime.datetime(3500, 7, 16)
-
-    s = ManagerService()
-
-    with mock.patch.object(test_lease, 'expire') as mock_expire:
+        s = ManagerService()
         s._expire_leases()
 
-        mock_expire.assert_called_once()
+        assert mock_expire.call_count == 2
+        mock_ga.assert_called_once_with({
+            'status': [statuses.ACTIVE, statuses.CREATED]
+        }, s._context)
 
-    mock_ga.assert_called_once()
-    mock_log.assert_called_once()
+    @mock.patch('esi_leap.objects.offer.Offer.expire')
+    @mock.patch('oslo_utils.timeutils.utcnow')
+    @mock.patch('esi_leap.objects.offer.Offer.get_all')
+    def test__expire_offers(self, mock_ga, mock_utcnow, mock_expire):
+        mock_ga.return_value = [self.test_offer, self.test_offer]
+        mock_utcnow.return_value = datetime.datetime(5000, 7, 16)
 
-
-@mock.patch('esi_leap.manager.service.timeutils.utcnow')
-@mock.patch('esi_leap.manager.service.LOG.info')
-@mock.patch('esi_leap.manager.service.offer.Offer.get_all')
-def test__expire_offers(mock_ga, mock_log, mock_utcnow):
-    mock_ga.return_value = [test_offer]
-    mock_utcnow.return_value = datetime.datetime(3500, 7, 16)
-
-    s = ManagerService()
-
-    with mock.patch.object(test_offer, 'expire') as mock_expire:
+        s = ManagerService()
         s._expire_offers()
 
-        mock_expire.assert_called_once()
+        assert mock_expire.call_count == 2
+        mock_ga.assert_called_once_with({
+            'status': statuses.AVAILABLE
+        }, s._context)
 
-    mock_ga.assert_called_once()
-    mock_log.assert_called_once()
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.fulfill')
+    @mock.patch('oslo_utils.timeutils.utcnow')
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.get_all')
+    def test__fulfill_owner_changes(self, mock_ga, mock_utcnow, mock_fulfill):
+        mock_ga.return_value = [self.test_owner_change, self.test_owner_change]
+        mock_utcnow.return_value = datetime.datetime(3500, 7, 16)
+
+        s = ManagerService()
+        s._fulfill_owner_changes()
+
+        assert mock_fulfill.call_count == 2
+        mock_ga.assert_called_once_with({
+            'status': [statuses.CREATED]
+        }, s._context)
+
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.expire')
+    @mock.patch('oslo_utils.timeutils.utcnow')
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.get_all')
+    def test__expire_owner_changes(self, mock_ga, mock_utcnow, mock_expire):
+        mock_ga.return_value = [self.test_owner_change, self.test_owner_change]
+        mock_utcnow.return_value = datetime.datetime(5000, 7, 16)
+
+        s = ManagerService()
+        s._expire_owner_changes()
+
+        assert mock_expire.call_count == 2
+        mock_ga.assert_called_once_with({
+            'status': [statuses.ACTIVE, statuses.CREATED]
+        }, s._context)

--- a/esi_leap/tests/objects/test_lease.py
+++ b/esi_leap/tests/objects/test_lease.py
@@ -121,7 +121,8 @@ class TestLeaseObject(base.DBTestCase):
         mock_rva.assert_called_once_with(lease.resource_type,
                                          lease.resource_uuid,
                                          lease.start_time,
-                                         lease.end_time)
+                                         lease.end_time,
+                                         is_owner_change=False)
 
     @mock.patch('esi_leap.db.sqlalchemy.api.resource_verify_availability')
     @mock.patch('esi_leap.db.sqlalchemy.api.offer_verify_availability')

--- a/esi_leap/tests/objects/test_offer.py
+++ b/esi_leap/tests/objects/test_offer.py
@@ -137,7 +137,8 @@ class TestOfferObject(base.DBTestCase):
         mock_rva.assert_called_once_with(o.resource_type,
                                          o.resource_uuid,
                                          o.start_time,
-                                         o.end_time)
+                                         o.end_time,
+                                         is_owner_change=False)
         mock_oc.assert_called_once_with(self.test_offer_data)
 
     def test_create_invalid_time(self):

--- a/esi_leap/tests/objects/test_owner_change.py
+++ b/esi_leap/tests/objects/test_owner_change.py
@@ -1,0 +1,265 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import datetime
+import mock
+from oslo_utils import uuidutils
+import tempfile
+import threading
+
+from esi_leap.common import exception
+from esi_leap.common import statuses
+from esi_leap.objects import lease as lease_obj
+from esi_leap.objects import offer as offer_obj
+from esi_leap.objects import owner_change
+from esi_leap.resource_objects.test_node import TestNode
+from esi_leap.tests import base
+
+
+class TestOwnerChangeObject(base.DBTestCase):
+
+    def setUp(self):
+        super(TestOwnerChangeObject, self).setUp()
+
+        self.now = datetime.datetime(2016, 7, 16, 19, 20, 30)
+        self.test_node = TestNode('test-node', '12345')
+        self.test_offer = offer_obj.Offer(
+            resource_type='test_node',
+            resource_uuid='12345',
+            uuid=uuidutils.generate_uuid(),
+            status=statuses.AVAILABLE,
+            project_id='54321',
+        )
+        self.test_lease = lease_obj.Lease(
+            uuid=uuidutils.generate_uuid(),
+            resource_type='test_node',
+            resource_uuid='11345',
+            project_id='67890',
+            owner_id='54321'
+        )
+        self.test_oc_data = {
+            'id': 27,
+            'uuid': uuidutils.generate_uuid(),
+            'from_owner_id': 'owner1',
+            'to_owner_id': 'owner2',
+            'resource_type': 'test_node',
+            'resource_uuid': '12345',
+            'start_time': self.now,
+            'end_time': self.now + datetime.timedelta(days=100),
+            'fulfill_time': None,
+            'expire_time': None,
+            'status': statuses.ACTIVE,
+            'created_at': None,
+            'updated_at': None
+        }
+        self.config(lock_path=tempfile.mkdtemp(), group='oslo_concurrency')
+
+    @mock.patch('esi_leap.db.sqlalchemy.api.owner_change_get_by_uuid')
+    def test_get(self, mock_ocgbu):
+        oc_uuid = self.test_oc_data['uuid']
+        mock_ocgbu.return_value = self.test_oc_data
+
+        oc = owner_change.OwnerChange.get(oc_uuid, self.context)
+
+        mock_ocgbu.assert_called_once_with(oc_uuid)
+        self.assertEqual(self.context, oc._context)
+
+    @mock.patch('esi_leap.db.sqlalchemy.api.owner_change_get_all')
+    def test_get_all(self, mock_ocga):
+        mock_ocga.return_value = [self.test_oc_data]
+
+        ocs = owner_change.OwnerChange.get_all({}, self.context)
+
+        mock_ocga.assert_called_once_with({})
+        self.assertEqual(len(ocs), 1)
+        self.assertIsInstance(ocs[0], owner_change.OwnerChange)
+        self.assertEqual(self.context, ocs[0]._context)
+
+    @mock.patch('esi_leap.db.sqlalchemy.api.resource_verify_availability')
+    @mock.patch('esi_leap.db.sqlalchemy.api.owner_change_create')
+    def test_create(self, mock_occ, mock_rva):
+        oc = owner_change.OwnerChange(self.context, **self.test_oc_data)
+        mock_occ.return_value = self.test_oc_data
+
+        oc.create(self.context)
+
+        mock_rva.assert_called_once_with(oc.resource_type,
+                                         oc.resource_uuid,
+                                         oc.start_time,
+                                         oc.end_time,
+                                         is_owner_change=True)
+        mock_occ.assert_called_once_with(self.test_oc_data)
+
+    def test_create_invalid_time(self):
+        bad_oc_data = {
+            'id': 27,
+            'uuid': '534653c9-880d-4c2d-6d6d-11111111111',
+            'from_owner_id': 'owner1',
+            'to_owner_id': 'owner2',
+            'resource_type': 'test_node',
+            'resource_uuid': '12345',
+            'start_time': self.now + datetime.timedelta(days=100),
+            'end_time': self.now,
+            'status': statuses.CREATED,
+            'created_at': None,
+            'updated_at': None
+        }
+
+        oc = owner_change.OwnerChange(self.context, **bad_oc_data)
+
+        self.assertRaises(exception.InvalidTimeRange, oc.create)
+
+    @mock.patch('esi_leap.db.sqlalchemy.api.resource_verify_availability')
+    @mock.patch('esi_leap.db.sqlalchemy.api.owner_change_create')
+    def test_create_concurrent(self, mock_occ, mock_rva):
+        oc = owner_change.OwnerChange(self.context, **self.test_oc_data)
+        oc2 = owner_change.OwnerChange(self.context, **self.test_oc_data)
+        oc2.id = 28
+
+        def create_mock(updates):
+            mock_rva.side_effect = Exception("bad")
+
+        mock_occ.side_effect = create_mock
+
+        thread = threading.Thread(target=oc.create)
+        thread2 = threading.Thread(target=oc2.create)
+
+        thread.start()
+        thread2.start()
+
+        thread.join()
+        thread2.join()
+
+        assert mock_rva.call_count == 2
+        mock_occ.assert_called_once()
+
+    @mock.patch('esi_leap.db.sqlalchemy.api.owner_change_destroy')
+    def test_destroy(self, mock_ocd):
+        oc = owner_change.OwnerChange(self.context, **self.test_oc_data)
+        oc.destroy()
+        mock_ocd.assert_called_once_with(oc.uuid)
+
+    @mock.patch('esi_leap.db.sqlalchemy.api.owner_change_update')
+    def test_save(self, mock_ocu):
+        oc = owner_change.OwnerChange(self.context, **self.test_oc_data)
+        new_status = statuses.CANCELLED
+        updated_at = datetime.datetime(2006, 12, 11, 0, 0)
+
+        updated_oc = self.test_oc_data.copy()
+        updated_oc['status'] = new_status
+        updated_oc['updated_at'] = updated_at
+        mock_ocu.return_value = updated_oc
+
+        oc.status = new_status
+        oc.save(self.context)
+
+        updated_values = self.test_oc_data.copy()
+        updated_values['status'] = new_status
+        mock_ocu.assert_called_once_with(oc.uuid, updated_values)
+        self.assertEqual(self.context, oc._context)
+        self.assertEqual(updated_at, oc.updated_at)
+
+    @mock.patch('esi_leap.resource_objects.test_node.TestNode.set_owner')
+    @mock.patch('esi_leap.db.sqlalchemy.api.owner_change_update')
+    def test_fulfill(self, mock_ocu, mock_so):
+        oc_fulfill_data = self.test_oc_data.copy()
+        oc_fulfill_data['status'] = statuses.ACTIVE
+        mock_ocu.return_value = oc_fulfill_data
+
+        oc = owner_change.OwnerChange(self.context, **self.test_oc_data)
+        oc.fulfill()
+
+        mock_so.assert_called_once_with(oc.to_owner_id)
+        mock_ocu.assert_called_once
+
+    @mock.patch('esi_leap.objects.lease.Lease.cancel')
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.leases')
+    @mock.patch('esi_leap.objects.offer.Offer.cancel')
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.offers')
+    @mock.patch('esi_leap.resource_objects.test_node.TestNode.set_owner')
+    @mock.patch('esi_leap.db.sqlalchemy.api.owner_change_update')
+    def test_cancel(self, mock_ocu, mock_so, mock_offers, mock_oc,
+                    mock_leases, mock_lc):
+        mock_offers.return_value = [self.test_offer, self.test_offer]
+        mock_leases.return_value = [self.test_lease, self.test_lease]
+        oc_cancel_data = self.test_oc_data.copy()
+        oc_cancel_data['status'] = statuses.CANCELLED
+        mock_ocu.return_value = oc_cancel_data
+
+        oc = owner_change.OwnerChange(self.context, **self.test_oc_data)
+        oc.cancel()
+
+        mock_offers.assert_called_once
+        assert mock_oc.call_count == 2
+        mock_leases.assert_called_once
+        assert mock_lc.call_count == 2
+        mock_so.assert_called_once_with(oc.from_owner_id)
+        mock_ocu.assert_called_once
+
+    @mock.patch('esi_leap.objects.lease.Lease.cancel')
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.leases')
+    @mock.patch('esi_leap.objects.offer.Offer.cancel')
+    @mock.patch('esi_leap.objects.owner_change.OwnerChange.offers')
+    @mock.patch('esi_leap.resource_objects.test_node.TestNode.set_owner')
+    @mock.patch('esi_leap.db.sqlalchemy.api.owner_change_update')
+    def test_expire(self, mock_ocu, mock_so, mock_offers, mock_oc,
+                    mock_leases, mock_lc):
+        mock_offers.return_value = [self.test_offer, self.test_offer]
+        mock_leases.return_value = [self.test_lease, self.test_lease]
+        oc_expire_data = self.test_oc_data.copy()
+        oc_expire_data['status'] = statuses.EXPIRED
+        mock_ocu.return_value = oc_expire_data
+
+        oc = owner_change.OwnerChange(self.context, **self.test_oc_data)
+        oc.expire()
+
+        mock_offers.assert_called_once
+        assert mock_oc.call_count == 2
+        mock_leases.assert_called_once
+        assert mock_lc.call_count == 2
+        mock_so.assert_called_once_with(oc.from_owner_id)
+        mock_ocu.assert_called_once
+
+    @mock.patch('esi_leap.db.sqlalchemy.api.offer_get_all')
+    def test_offers(self, mock_oga):
+        oc = owner_change.OwnerChange(self.context, **self.test_oc_data)
+        oc.offers()
+
+        expected_filters = {
+            'project_id': oc.to_owner_id,
+            'start_time': oc.start_time,
+            'end_time': oc.end_time,
+            'time_filter_type': 'within',
+            'status': statuses.AVAILABLE
+        }
+        mock_oga.assert_called_once_with(expected_filters)
+
+    @mock.patch('esi_leap.db.sqlalchemy.api.lease_get_all')
+    def test_leases(self, mock_lga):
+        oc = owner_change.OwnerChange(self.context, **self.test_oc_data)
+        oc.leases()
+
+        expected_filters = {
+            'owner_id': oc.to_owner_id,
+            'start_time': oc.start_time,
+            'end_time': oc.end_time,
+            'time_filter_type': 'within',
+            'status': [statuses.CREATED, statuses.ACTIVE]
+        }
+        mock_lga.assert_called_once_with(expected_filters)
+
+    @mock.patch('esi_leap.resource_objects.resource_object_factory.'
+                'ResourceObjectFactory.get_resource_object')
+    def test_resource_object(self, mock_gro):
+        oc = owner_change.OwnerChange(self.context, **self.test_oc_data)
+        oc.resource_object()
+        mock_gro.assert_called_once_with(oc.resource_type, oc.resource_uuid)

--- a/esi_leap/tests/resource_objects/test_base.py
+++ b/esi_leap/tests/resource_objects/test_base.py
@@ -12,6 +12,7 @@
 
 import datetime
 from esi_leap.resource_objects import ironic_node
+from esi_leap.resource_objects import test_node
 from esi_leap.tests import base
 import mock
 
@@ -20,14 +21,29 @@ class TestResourceObjectInterface(base.TestCase):
 
     def setUp(self):
         super(TestResourceObjectInterface, self).setUp()
+        self.base_time = datetime.datetime(2016, 7, 16, 19, 20, 30)
 
     @mock.patch(
         'esi_leap.db.sqlalchemy.api.resource_verify_availability')
     def test_verify_availability_for_offer(self, mock_rva):
-        start = datetime.datetime(2016, 7, 16, 19, 20, 30)
-        end = start + datetime.timedelta(days=10)
+        start = self.base_time
+        end = self.base_time + datetime.timedelta(days=10)
         test_node = ironic_node.IronicNode("1111")
 
         test_node.verify_availability(start, end)
         mock_rva.assert_called_once_with(
-            'ironic_node', '1111', start, end)
+            'ironic_node', '1111', start, end,
+            is_owner_change=False)
+
+    @mock.patch(
+        'esi_leap.db.sqlalchemy.api.resource_check_admin')
+    def test_check_admin(self, mock_cra):
+        node = test_node.TestNode('1111', '123456')
+        start = self.base_time
+        end = self.base_time + datetime.timedelta(days=1)
+
+        node.check_admin('654321', start, end)
+
+        mock_cra.assert_called_once_with('test_node', '1111',
+                                         start, end, '123456',
+                                         '654321')

--- a/esi_leap/tests/resource_objects/test_dummy_node.py
+++ b/esi_leap/tests/resource_objects/test_dummy_node.py
@@ -111,13 +111,15 @@ class TestDummyNode(base.TestCase):
             self.fake_dummy_node.expire_lease(fake_lease)
             self.assertEqual(mock_file_open.call_count, 2)
 
-    def test_is_resource_admin(self):
+    def test_set_owner(self):
+        mock_open = mock.mock_open(read_data=self.fake_read_data_2)
+        with mock.patch('builtins.open', mock_open) as mock_file_open:
+            self.fake_dummy_node.set_owner('54321')
+            self.assertEqual(mock_file_open.call_count, 2)
+
+    def test_resource_admin_project_id(self):
         mock_open = mock.mock_open(read_data=self.fake_read_data_1)
         with mock.patch('builtins.open', mock_open) as mock_file_open:
-            res1 = self.fake_dummy_node.is_resource_admin(
-                self.fake_admin_project_id_1)
-            res2 = self.fake_dummy_node.is_resource_admin(
-                self.fake_admin_project_id_2)
-            self.assertEqual(res1, False)
-            self.assertEqual(res2, True)
-            self.assertEqual(mock_file_open.call_count, 2)
+            self.assertEqual(self.fake_admin_project_id_2,
+                             self.fake_dummy_node.resource_admin_project_id())
+            self.assertEqual(mock_file_open.call_count, 1)

--- a/esi_leap/tests/resource_objects/test_ironic_node.py
+++ b/esi_leap/tests/resource_objects/test_ironic_node.py
@@ -136,11 +136,16 @@ class TestIronicNode(base.TestCase):
             mock_lease_uuid_false.assert_called_once()
 
     @mock.patch.object(ironic_node, 'get_ironic_client', autospec=True)
-    def test_is_resource_admin(self, client_mock):
+    def test_set_owner(self, client_mock):
+        test_ironic_node = ironic_node.IronicNode("1111")
+        test_ironic_node.set_owner('54321')
+        client_mock.assert_called_once()
+        client_mock.return_value.node.update.assert_called_once()
+
+    @mock.patch.object(ironic_node, 'get_ironic_client', autospec=True)
+    def test_resource_admin_project_id(self, client_mock):
         fake_get_node = FakeIronicNode()
         client_mock.return_value.node.get.return_value = fake_get_node
         test_ironic_node = ironic_node.IronicNode("1111")
-        res1 = test_ironic_node.is_resource_admin(self.fake_admin_project_id_1)
-        res2 = test_ironic_node.is_resource_admin(self.fake_admin_project_id_2)
-        self.assertEqual(res1, False)
-        self.assertEqual(res2, True)
+        self.assertEqual(self.fake_admin_project_id_2,
+                         test_ironic_node.resource_admin_project_id())

--- a/esi_leap/tests/resource_objects/test_test_node.py
+++ b/esi_leap/tests/resource_objects/test_test_node.py
@@ -9,6 +9,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+
 import datetime
 from esi_leap.common import statuses
 from esi_leap.resource_objects import test_node
@@ -75,10 +76,10 @@ class TestTestNode(base.TestCase):
             self.fake_test_node.expire_lease(
                 fake_lease), None)
 
-    def test_is_resource_admin(self):
-        res1 = self.fake_test_node.is_resource_admin(
-            self.fake_admin_project_id_1)
-        self.assertEqual(res1, False)
-        res2 = self.fake_test_node.is_resource_admin(
-            self.fake_admin_project_id_2)
-        self.assertEqual(res2, True)
+    def test_set_owner(self):
+        self.assertEqual(self.fake_test_node.set_owner('12345'), None)
+
+    def test_resource_admin_project_id(self):
+        self.assertEqual(
+            self.fake_admin_project_id_2,
+            self.fake_test_node.resource_admin_project_id())


### PR DESCRIPTION
An owner change allows a user - by default, only admins - to
specify a length of time during which a resource object will
change ownership. The manager will take care of activating and
reverting that change.