### PR TITLE
Update resource admin db api

### DIFF
--- a/esi_leap/api/controllers/v1/utils.py
+++ b/esi_leap/api/controllers/v1/utils.py
@@ -60,7 +60,8 @@ def check_resource_admin(cdict, resource_type, resource_uuid, project_id,
                          start_time, end_time):
     resource = ro_factory.ResourceObjectFactory.get_resource_object(
         resource_type, resource_uuid)
-    if not resource.check_admin(project_id, start_time, end_time):
+    resource_admin_project_id = resource.get_admin(start_time, end_time)
+    if resource_admin_project_id != project_id:
         policy.authorize('esi_leap:offer:offer_admin', cdict, cdict)
 
 

--- a/esi_leap/db/api.py
+++ b/esi_leap/db/api.py
@@ -148,10 +148,9 @@ def resource_verify_availability(r_type, r_uuid, start, end):
         r_type, r_uuid, start, end)
 
 
-def resource_check_admin(resource_type, resource_uuid,
-                         start_time, end_time,
-                         default_admin_project_id, project_id):
-    return IMPL.resource_check_admin(
+def resource_get_admin_from_owner_change(
         resource_type, resource_uuid,
-        start_time, end_time,
-        default_admin_project_id, project_id)
+        start_time, end_time):
+    return IMPL.resource_get_admin_from_owner_change(
+        resource_type, resource_uuid,
+        start_time, end_time)

--- a/esi_leap/resource_objects/base.py
+++ b/esi_leap/resource_objects/base.py
@@ -78,12 +78,14 @@ class ResourceObjectInterface(object, metaclass=abc.ABCMeta):
             is_owner_change=is_owner_change
         )
 
-    def check_admin(self, project_id, start_time, end_time):
-        return self.dbapi.resource_check_admin(
+    def get_admin(self, start_time, end_time):
+        oc_admin_id = self.dbapi.resource_get_admin_from_owner_change(
             self.resource_type,
             self.get_resource_uuid(),
             start_time,
-            end_time,
-            self.resource_admin_project_id(),
-            project_id
+            end_time
         )
+        if oc_admin_id is None:
+            # use default
+            oc_admin_id = self.resource_admin_project_id()
+        return oc_admin_id

--- a/esi_leap/tests/resource_objects/test_base.py
+++ b/esi_leap/tests/resource_objects/test_base.py
@@ -36,14 +36,29 @@ class TestResourceObjectInterface(base.TestCase):
             is_owner_change=False)
 
     @mock.patch(
-        'esi_leap.db.sqlalchemy.api.resource_check_admin')
-    def test_check_admin(self, mock_cra):
+        'esi_leap.db.sqlalchemy.api.resource_get_admin_from_owner_change')
+    def test_get_admin(self, mock_gafoc):
+        mock_gafoc.return_value = '654321'
         node = test_node.TestNode('1111', '123456')
         start = self.base_time
         end = self.base_time + datetime.timedelta(days=1)
 
-        node.check_admin('654321', start, end)
+        admin_project_id = node.get_admin(start, end)
 
-        mock_cra.assert_called_once_with('test_node', '1111',
-                                         start, end, '123456',
-                                         '654321')
+        mock_gafoc.assert_called_once_with('test_node', '1111',
+                                           start, end)
+        self.assertEqual('654321', admin_project_id)
+
+    @mock.patch(
+        'esi_leap.db.sqlalchemy.api.resource_get_admin_from_owner_change')
+    def test_get_admin_use_default(self, mock_gafoc):
+        mock_gafoc.return_value = None
+        node = test_node.TestNode('1111', '123456')
+        start = self.base_time
+        end = self.base_time + datetime.timedelta(days=1)
+
+        admin_project_id = node.get_admin(start, end)
+
+        mock_gafoc.assert_called_once_with('test_node', '1111',
+                                           start, end)
+        self.assertEqual('123456', admin_project_id)


### PR DESCRIPTION
Previously, the resource admin db api would take in various project
IDs and check for a match within the db api. This prevents the code
from distinguishing between the cases where the check fails because
of a time conflict, and when the check fails because the passed in
project IDs do not match. That, in turn, prevents us from effectively
checking the admin case, as that case should only be checked if there
is no time conflict.

This change updates the resource admin db api to simply return the
project ID as determined by the owner change, allowing us to more
effectively route our way through various alternatives at the API
level.