### PR TITLE
Allow nodes and projects to be specified by name in the REST API

### DIFF
--- a/esi_leap/api/controllers/v1/utils.py
+++ b/esi_leap/api/controllers/v1/utils.py
@@ -56,10 +56,10 @@ def get_offer_authorized(uuid_or_name, cdict, status_filter=None):
     return offer_objs[0]
 
 
-def check_resource_admin(cdict, resource_type, resource_uuid, project_id,
+def check_resource_admin(cdict, resource_type, resource_ident, project_id,
                          start_time, end_time):
     resource = ro_factory.ResourceObjectFactory.get_resource_object(
-        resource_type, resource_uuid)
+        resource_type, resource_ident)
     if not resource.check_admin(project_id, start_time, end_time):
         policy.authorize('esi_leap:offer:offer_admin', cdict, cdict)
 

--- a/esi_leap/common/exception.py
+++ b/esi_leap/common/exception.py
@@ -91,6 +91,10 @@ class ProjectNoPermission(ESILeapException):
     msg_fmt = _("You do not have permissions on project %(project_id)s.")
 
 
+class ProjectNoSuchName(ESILeapException):
+    msg_fmt = _("No project named %(name)s.")
+
+
 class ResourceTimeConflict(ESILeapException):
     msg_fmt = ("Time conflict for %(resource_type)s %(resource_uuid)s.")
 

--- a/esi_leap/common/keystone.py
+++ b/esi_leap/common/keystone.py
@@ -12,7 +12,9 @@
 
 from keystoneauth1 import loading as ks_loading
 from keystoneclient import client as keystone_client
+from oslo_utils import uuidutils
 
+from esi_leap.common import exception
 import esi_leap.conf
 
 
@@ -41,3 +43,14 @@ def get_parent_project_id_tree(project_id):
         project = get_keystone_client().projects.get(project.parent_id)
         project_ids.append(project.id)
     return project_ids
+
+
+def get_project_uuid_from_ident(project_ident):
+    if uuidutils.is_uuid_like(project_ident):
+        return project_ident
+    else:
+        projects = get_keystone_client().projects.list(name=project_ident)
+        if len(projects) > 0:
+            # projects have unique names
+            return projects[0].id
+        raise exception.ProjectNoSuchName(name=project_ident)

--- a/esi_leap/resource_objects/ironic_node.py
+++ b/esi_leap/resource_objects/ironic_node.py
@@ -46,6 +46,11 @@ class IronicNode(base.ResourceObjectInterface):
     def __init__(self, uuid):
         self._uuid = uuid
 
+    @classmethod
+    def get_by_name(cls, name):
+        node = get_ironic_client().node.get(name)
+        return IronicNode(node.uuid)
+
     def get_resource_uuid(self):
         return self._uuid
 

--- a/esi_leap/resource_objects/resource_object_factory.py
+++ b/esi_leap/resource_objects/resource_object_factory.py
@@ -10,6 +10,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from oslo_utils import uuidutils
+
 from esi_leap.common import exception
 from esi_leap.resource_objects import dummy_node
 from esi_leap.resource_objects import ironic_node
@@ -21,11 +23,14 @@ RESOURCE_TYPES = ['ironic_node', 'dummy_node', 'test_node']
 class ResourceObjectFactory(object):
 
     @staticmethod
-    def get_resource_object(resource_type, resource_uuid):
+    def get_resource_object(resource_type, resource_ident):
         if resource_type == 'ironic_node':
-            return ironic_node.IronicNode(resource_uuid)
+            if uuidutils.is_uuid_like(resource_ident):
+                return ironic_node.IronicNode(resource_ident)
+            else:
+                return ironic_node.IronicNode.get_by_name(resource_ident)
         elif resource_type == 'dummy_node':
-            return dummy_node.DummyNode(resource_uuid)
+            return dummy_node.DummyNode(resource_ident)
         elif resource_type == 'test_node':
-            return test_node.TestNode(resource_uuid)
+            return test_node.TestNode(resource_ident)
         raise exception.ResourceTypeUnknown(resource_type=resource_type)

--- a/esi_leap/tests/common/test_keystone.py
+++ b/esi_leap/tests/common/test_keystone.py
@@ -1,0 +1,63 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+
+from esi_leap.common import exception as e
+from esi_leap.common import keystone
+from esi_leap.tests import base
+
+
+class FakeProject(object):
+    def __init__(self):
+        self.id = "uuid"
+        self.name = "name"
+
+
+class KeystoneTestCase(base.TestCase):
+
+    @mock.patch('oslo_utils.uuidutils.is_uuid_like')
+    def test_get_project_uuid_from_ident_uuid(self, mock_iul):
+        mock_iul.return_value = True
+
+        project_uuid = keystone.get_project_uuid_from_ident('uuid')
+
+        mock_iul.assert_called_once_with('uuid')
+        self.assertEqual('uuid', project_uuid)
+
+    @mock.patch.object(keystone, 'get_keystone_client', autospec=True)
+    @mock.patch('oslo_utils.uuidutils.is_uuid_like')
+    def test_get_project_uuid_from_ident_name(self, mock_iul, mock_keystone):
+        mock_iul.return_value = False
+        mock_keystone.return_value.projects.list.return_value = [FakeProject()]
+
+        project_uuid = keystone.get_project_uuid_from_ident('name')
+
+        mock_iul.assert_called_once_with('name')
+        self.assertEqual('uuid', project_uuid)
+        mock_keystone.return_value.projects.list.assert_called_once_with(
+            name='name')
+
+    @mock.patch.object(keystone, 'get_keystone_client', autospec=True)
+    @mock.patch('oslo_utils.uuidutils.is_uuid_like')
+    def test_get_project_uuid_from_ident_name_no_match(self, mock_iul,
+                                                       mock_keystone):
+        mock_iul.return_value = False
+        mock_keystone.return_value.projects.list.return_value = []
+
+        self.assertRaises(e.ProjectNoSuchName,
+                          keystone.get_project_uuid_from_ident,
+                          'name')
+
+        mock_iul.assert_called_once_with('name')
+        mock_keystone.return_value.projects.list.assert_called_once_with(
+            name='name')

--- a/esi_leap/tests/resource_objects/test_ironic_node.py
+++ b/esi_leap/tests/resource_objects/test_ironic_node.py
@@ -54,6 +54,15 @@ class TestIronicNode(base.TestCase):
         self.assertEqual("1111", test_ironic_node.get_resource_uuid())
 
     @mock.patch.object(ironic_node, 'get_ironic_client', autospec=True)
+    def test_get_by_name(self, client_mock):
+        fake_get_node = FakeIronicNode()
+        client_mock.return_value.node.get.return_value = fake_get_node
+        test_ironic_node = ironic_node.IronicNode.get_by_name("node-name")
+        self.assertEqual('1111', test_ironic_node.get_resource_uuid())
+        client_mock.assert_called_once()
+        client_mock.return_value.node.get.assert_called_once_with("node-name")
+
+    @mock.patch.object(ironic_node, 'get_ironic_client', autospec=True)
     def test_get_lease_uuid(self, client_mock):
         fake_get_node = FakeIronicNode()
         client_mock.return_value.node.get.return_value = fake_get_node

--- a/esi_leap/tests/resource_objects/test_resource_object_factory.py
+++ b/esi_leap/tests/resource_objects/test_resource_object_factory.py
@@ -1,0 +1,69 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+
+from esi_leap.common import exception
+from esi_leap import resource_objects
+from esi_leap.resource_objects import resource_object_factory as ro_factory
+from esi_leap.tests import base
+
+
+class TestResourceObjectFactory(base.TestCase):
+
+    def setUp(self):
+        super(TestResourceObjectFactory, self).setUp()
+
+    @mock.patch('oslo_utils.uuidutils.is_uuid_like')
+    def test_ironic_node(self, mock_iul):
+        mock_iul.return_value = True
+        node = ro_factory.ResourceObjectFactory.get_resource_object(
+            'ironic_node', '1111')
+
+        mock_iul.assert_called_once_with('1111')
+        self.assertTrue(isinstance(node,
+                                   resource_objects.ironic_node.IronicNode))
+        self.assertEqual("1111", node.get_resource_uuid())
+
+    @mock.patch('esi_leap.resource_objects.ironic_node.IronicNode.get_by_name')
+    @mock.patch('oslo_utils.uuidutils.is_uuid_like')
+    def test_ironic_node_by_name(self, mock_iul, mock_gbn):
+        mock_iul.return_value = False
+        mock_gbn.return_value = resource_objects.ironic_node.IronicNode('1111')
+        node = ro_factory.ResourceObjectFactory.get_resource_object(
+            'ironic_node', 'node-name')
+
+        mock_iul.assert_called_once_with('node-name')
+        mock_gbn.assert_called_once_with('node-name')
+        self.assertTrue(isinstance(node,
+                                   resource_objects.ironic_node.IronicNode))
+        self.assertEqual("1111", node.get_resource_uuid())
+
+    def test_dummy_node(self):
+        node = ro_factory.ResourceObjectFactory.get_resource_object(
+            'dummy_node', '1111')
+        self.assertTrue(isinstance(node,
+                                   resource_objects.dummy_node.DummyNode))
+        self.assertEqual("1111", node.get_resource_uuid())
+
+    def test_test_node(self):
+        node = ro_factory.ResourceObjectFactory.get_resource_object(
+            'test_node', '1111')
+        self.assertTrue(isinstance(node,
+                                   resource_objects.test_node.TestNode))
+        self.assertEqual("1111", node.get_resource_uuid())
+
+    def test_unknown_resource_type(self):
+        self.assertRaises(exception.ResourceTypeUnknown,
+                          ro_factory.ResourceObjectFactory.
+                          get_resource_object,
+                          'foo_node', '1111')


### PR DESCRIPTION
Nodes and projects are identified by UUID in the database, but
allowing users to specify them by UUID *or* name when using the
REST API will be very convenient.