### PR TITLE
Allow lessees to create offers and leases

### DIFF
--- a/esi_leap/common/exception.py
+++ b/esi_leap/common/exception.py
@@ -46,12 +46,21 @@ class LeaseDuplicateName(ESILeapException):
     msg_fmt = _("Duplicate leases with name %(name)s.")
 
 
+class LeaseNotActive(ESILeapException):
+    msg_fmt = _("Lease with name or uuid %(lease_id)s not active.")
+
+
 class LeaseNotFound(ESILeapException):
     msg_fmt = _("Lease with name or uuid %(lease_id)s not found.")
 
 
 class LeaseNoOfferUUID(ESILeapException):
     msg_fmt = _("Cannot create lease without parameter offer_uuid.")
+
+
+class LeaseNoTimeAvailabilities(ESILeapException):
+    msg_fmt = _("Lease %(lease_uuid)s has no availabilities at given "
+                "time range %(start_time)s, %(end_time)s.")
 
 
 class OfferNoPermission(ESILeapException):

--- a/esi_leap/db/api.py
+++ b/esi_leap/db/api.py
@@ -142,6 +142,11 @@ def lease_destroy(lease_uuid):
     return IMPL.lease_destroy(lease_uuid)
 
 
+def lease_verify_child_availability(lease_ref, start, end):
+    return IMPL.lease_verify_child_availability(
+        lease_ref, start, end)
+
+
 # Resource object
 def resource_verify_availability(r_type, r_uuid, start, end):
     return IMPL.resource_verify_availability(

--- a/esi_leap/db/sqlalchemy/models.py
+++ b/esi_leap/db/sqlalchemy/models.py
@@ -57,6 +57,13 @@ class Offer(Base):
     end_time = Column(DateTime)
     status = Column(String(15), nullable=False, default=statuses.AVAILABLE)
     properties = Column(db_types.JsonEncodedDict, nullable=True)
+    parent_lease_uuid = Column(String(36),
+                               ForeignKey('leases.uuid'),
+                               nullable=True)
+    parent_lease = orm.relationship(
+        "Lease",
+        foreign_keys=[parent_lease_uuid],
+    )
 
 
 class Lease(Base):
@@ -86,11 +93,18 @@ class Lease(Base):
     offer_uuid = Column(String(36),
                         ForeignKey('offers.uuid'),
                         nullable=True)
+    parent_lease_uuid = Column(String(36),
+                               ForeignKey('leases.uuid'),
+                               nullable=True)
     offer = orm.relationship(
         Offer,
         backref=orm.backref('offers'),
         foreign_keys=offer_uuid,
         primaryjoin=offer_uuid == Offer.uuid)
+    parent_lease = orm.relationship(
+        "Lease",
+        backref=orm.backref('child_leases', remote_side=uuid),
+    )
 
 
 class OwnerChange(Base):


### PR DESCRIPTION
This change allows lessees to create offers and leases within the duration
of their lease. If the parent lease is cancelled, the children offers and
leases will be cancelled as well.