### PR TITLE
Lease/offer API returns resource and project names

### DIFF
--- a/esi_leap/objects/lease.py
+++ b/esi_leap/objects/lease.py
@@ -22,8 +22,8 @@ from esi_leap.objects import offer as offer_obj
 from esi_leap.resource_objects import resource_object_factory as ro_factory
 
 from oslo_config import cfg
-from oslo_versionedobjects import base as versioned_objects_base
 from oslo_log import log as logging
+from oslo_versionedobjects import base as versioned_objects_base
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)

--- a/esi_leap/objects/offer.py
+++ b/esi_leap/objects/offer.py
@@ -20,8 +20,8 @@ from esi_leap.objects import lease as lease_obj
 from esi_leap.resource_objects import resource_object_factory as ro_factory
 
 from oslo_config import cfg
-from oslo_versionedobjects import base as versioned_objects_base
 from oslo_log import log as logging
+from oslo_versionedobjects import base as versioned_objects_base
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)

--- a/esi_leap/resource_objects/base.py
+++ b/esi_leap/resource_objects/base.py
@@ -27,6 +27,12 @@ class ResourceObjectInterface(object, metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
+    def get_resource_name(self):
+        """Returns resource's name
+
+        """
+
+    @abc.abstractmethod
     def get_lease_uuid(self):
         """Returns resource's associated lease, if any
 

--- a/esi_leap/resource_objects/dummy_node.py
+++ b/esi_leap/resource_objects/dummy_node.py
@@ -31,6 +31,9 @@ class DummyNode(base.ResourceObjectInterface):
     def get_resource_uuid(self):
         return self._uuid
 
+    def get_resource_name(self):
+        return "dummy-node-%s" % self._uuid
+
     def get_lease_uuid(self):
         with open(self._path) as node_file:
             node_dict = json.load(node_file)

--- a/esi_leap/resource_objects/ironic_node.py
+++ b/esi_leap/resource_objects/ironic_node.py
@@ -54,6 +54,10 @@ class IronicNode(base.ResourceObjectInterface):
     def get_resource_uuid(self):
         return self._uuid
 
+    def get_resource_name(self):
+        node = get_ironic_client().node.get(self._uuid)
+        return node.name
+
     def get_lease_uuid(self):
         node = get_ironic_client().node.get(self._uuid)
         return node.properties.get('lease_uuid', None)

--- a/esi_leap/resource_objects/test_node.py
+++ b/esi_leap/resource_objects/test_node.py
@@ -24,6 +24,9 @@ class TestNode(base.ResourceObjectInterface):
     def get_resource_uuid(self):
         return self._uuid
 
+    def get_resource_name(self):
+        return "test-node-%s" % self._uuid
+
     def get_lease_uuid(self):
         return '12345'
 

--- a/esi_leap/tests/resource_objects/test_dummy_node.py
+++ b/esi_leap/tests/resource_objects/test_dummy_node.py
@@ -76,6 +76,10 @@ class TestDummyNode(base.TestCase):
     def test_get_resource_uuid(self):
         self.assertEqual("1111", self.fake_dummy_node.get_resource_uuid())
 
+    def test_get_resource_name(self):
+        self.assertEqual("dummy-node-1111",
+                         self.fake_dummy_node.get_resource_name())
+
     def test_get_lease_uuid(self):
         mock_open = mock.mock_open(read_data=self.fake_read_data_1)
         with mock.patch('builtins.open', mock_open) as mock_file_open:

--- a/esi_leap/tests/resource_objects/test_ironic_node.py
+++ b/esi_leap/tests/resource_objects/test_ironic_node.py
@@ -23,6 +23,7 @@ class FakeIronicNode(object):
         self.created_at = start
         self.lessee = "abcdef"
         self.owner = "123456"
+        self.name = "fake-node"
         self.properties = {"lease_uuid": "001"}
         self.provision_state = "available"
         self.uuid = "1111"
@@ -52,6 +53,17 @@ class TestIronicNode(base.TestCase):
     def test_get_resource_uuid(self):
         test_ironic_node = ironic_node.IronicNode("1111")
         self.assertEqual("1111", test_ironic_node.get_resource_uuid())
+
+    @mock.patch.object(ironic_node, 'get_ironic_client', autospec=True)
+    def test_get_resource_name(self, client_mock):
+        fake_get_node = FakeIronicNode()
+        client_mock.return_value.node.get.return_value = fake_get_node
+        test_ironic_node = ironic_node.IronicNode("1111")
+        resource_name = test_ironic_node.get_resource_name()
+        self.assertEqual('fake-node', resource_name)
+        client_mock.assert_called_once()
+        client_mock.return_value.node.get.assert_called_once_with(
+            test_ironic_node._uuid)
 
     @mock.patch.object(ironic_node, 'get_ironic_client', autospec=True)
     def test_get_by_name(self, client_mock):

--- a/esi_leap/tests/resource_objects/test_test_node.py
+++ b/esi_leap/tests/resource_objects/test_test_node.py
@@ -52,6 +52,10 @@ class TestTestNode(base.TestCase):
         resource_uuid = self.fake_test_node.get_resource_uuid()
         self.assertEqual(resource_uuid, '1111')
 
+    def test_get_resource_name(self):
+        self.assertEqual("test-node-1111",
+                         self.fake_test_node.get_resource_name())
+
     def test_get_lease_uuid(self):
         lease_uuid = self.fake_test_node.get_lease_uuid()
         self.assertEqual(lease_uuid, '12345')


### PR DESCRIPTION
Users find it easier to work with names, rather than just UUIDs;
however an end user may not have permission to see resource or
project names, even if those projects and resources are involved
in future leasing events. Having the API return names allows
the CLI to display those values.