### PR TITLE
Add resource list functionality

### DIFF
--- a/esi_leap/api/controllers/v1/node.py
+++ b/esi_leap/api/controllers/v1/node.py
@@ -1,0 +1,52 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import pecan
+from pecan import rest
+import wsme
+from wsme import types as wtypes
+import wsmeext.pecan as wsme_pecan
+
+from esi_leap.api.controllers import base
+from esi_leap.api.controllers import types
+from esi_leap.common import ironic
+import esi_leap.conf
+
+CONF = esi_leap.conf.CONF
+
+
+class Node(base.ESILEAPBase):
+
+    name = wsme.wsattr(wtypes.text)
+
+    def __init__(self, **kwargs):
+        setattr(self, "name", kwargs.get("name", "foo"))
+
+
+class NodeCollection(types.Collection):
+    nodes = [Node]
+
+    def __init__(self, **kwargs):
+        self._type = 'nodes'
+
+
+class NodesController(rest.RestController):
+
+    @wsme_pecan.wsexpose(NodeCollection)
+    def get_all(self):
+        context = pecan.request.context
+        client = ironic.get_ironic_client(context)
+        node_collection = NodeCollection()
+        nodes = client.node.list()
+
+        node_collection.nodes = [Node(name=n.name) for n in nodes]
+        return node_collection

--- a/esi_leap/api/controllers/v1/root.py
+++ b/esi_leap/api/controllers/v1/root.py
@@ -17,6 +17,7 @@ from pecan import rest
 from esi_leap.api.controllers.v1 import lease
 from esi_leap.api.controllers.v1 import offer
 from esi_leap.api.controllers.v1 import owner_change
+from esi_leap.api.controllers.v1 import node
 
 
 class Controller(rest.RestController):
@@ -24,6 +25,7 @@ class Controller(rest.RestController):
     leases = lease.LeasesController()
     offers = offer.OffersController()
     owner_changes = owner_change.OwnerChangesController()
+    nodes = node.NodesController()
 
     @pecan.expose(content_type='application/json')
     def index(self):

--- a/esi_leap/common/ironic.py
+++ b/esi_leap/common/ironic.py
@@ -1,0 +1,41 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from keystoneauth1 import loading as ks_loading
+from keystoneauth1 import service_token
+from keystoneauth1 import token_endpoint
+
+from ironicclient import client as ironic_client
+
+import esi_leap.conf
+
+
+CONF = esi_leap.conf.CONF
+_cached_ironic_client = None
+
+
+def get_ironic_client(context):
+    session = ks_loading.load_session_from_conf_options(
+        CONF, 'ironic')
+    service_auth = ks_loading.load_auth_from_conf_options(CONF, 'ironic')
+    endpoint = ks_loading.load_adapter_from_conf_options(
+        CONF, 'ironic', session=session, auth=service_auth).get_endpoint()
+    user_auth = service_token.ServiceTokenAuthWrapper(
+        user_auth=token_endpoint.Token(endpoint, context.auth_token),
+        service_auth=service_auth)
+    sess = ks_loading.load_session_from_conf_options(
+        CONF, 'ironic', auth=user_auth)
+
+    kwargs = {'os_ironic_api_version': '1.65'}
+    cli = ironic_client.get_client(1,
+                                   session=sess, **kwargs)
+    return cli

--- a/esi_leap/tests/api/controllers/v1/test_node.py
+++ b/esi_leap/tests/api/controllers/v1/test_node.py
@@ -1,0 +1,35 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+
+from esi_leap.tests.api import base as test_api_base
+from esi_leap.common import ironic
+
+
+class FakeIronicNode(object):
+    def __init__(self):
+        self.name = "fake-node"
+
+
+class TestNodesController(test_api_base.APITestCase):
+
+    def setUp(self):
+        super(TestNodesController, self).setUp()
+
+    @mock.patch.object(ironic, 'get_ironic_client', autospec=True)
+    def test_get_all(self, client_mock):
+        fake_node = FakeIronicNode()
+        client_mock.return_value.node.list.return_value = [fake_node]
+        data = self.get_json("/nodes")
+        client_mock.assert_called_once()
+        self.assertEqual(data["nodes"][0]["name"], "fake-node")


### PR DESCRIPTION
Set up a NodesController and an API path for getting all ironic nodes.
Right now, it only returns the names of the nodes, and the get_ironic_client method in esi_leap/common/ironic.py is copied verbatim from esi_leap/resource_objects/ironic_node.py. Ideally, we'd use the current user's credentials instead of the admin's.