### PR TITLE
Optimize name queries for list commands

### DIFF
--- a/esi_leap/api/controllers/v1/node.py
+++ b/esi_leap/api/controllers/v1/node.py
@@ -44,9 +44,9 @@ class NodesController(rest.RestController):
     @wsme_pecan.wsexpose(NodeCollection)
     def get_all(self):
         context = pecan.request.context
-        client = ironic.get_ironic_client(context)
-        node_collection = NodeCollection()
-        nodes = client.node.list()
+        nodes = ironic.get_node_list(context)
 
+        node_collection = NodeCollection()
         node_collection.nodes = [Node(name=n.name) for n in nodes]
+
         return node_collection

--- a/esi_leap/api/controllers/v1/root.py
+++ b/esi_leap/api/controllers/v1/root.py
@@ -15,9 +15,9 @@ import pecan
 from pecan import rest
 
 from esi_leap.api.controllers.v1 import lease
+from esi_leap.api.controllers.v1 import node
 from esi_leap.api.controllers.v1 import offer
 from esi_leap.api.controllers.v1 import owner_change
-from esi_leap.api.controllers.v1 import node
 
 
 class Controller(rest.RestController):

--- a/esi_leap/resource_objects/base.py
+++ b/esi_leap/resource_objects/base.py
@@ -27,7 +27,7 @@ class ResourceObjectInterface(object, metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def get_resource_name(self):
+    def get_resource_name(self, resource_list):
         """Returns resource's name
 
         """

--- a/esi_leap/resource_objects/dummy_node.py
+++ b/esi_leap/resource_objects/dummy_node.py
@@ -31,7 +31,7 @@ class DummyNode(base.ResourceObjectInterface):
     def get_resource_uuid(self):
         return self._uuid
 
-    def get_resource_name(self):
+    def get_resource_name(self, resource_list=None):
         return "dummy-node-%s" % self._uuid
 
     def get_lease_uuid(self):

--- a/esi_leap/resource_objects/ironic_node.py
+++ b/esi_leap/resource_objects/ironic_node.py
@@ -10,10 +10,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from keystoneauth1 import loading as ks_loading
-
-from ironicclient import client as ironic_client
-
+from esi_leap.common import ironic
 import esi_leap.conf
 from esi_leap.resource_objects import base
 
@@ -24,19 +21,9 @@ _cached_ironic_client = None
 
 def get_ironic_client():
     global _cached_ironic_client
-    if _cached_ironic_client is not None:
-        return _cached_ironic_client
-
-    auth_plugin = ks_loading.load_auth_from_conf_options(CONF, 'ironic')
-    sess = ks_loading.load_session_from_conf_options(CONF, 'ironic',
-                                                     auth=auth_plugin)
-
-    kwargs = {'os_ironic_api_version': '1.65'}
-    cli = ironic_client.get_client(1,
-                                   session=sess, **kwargs)
-    _cached_ironic_client = cli
-
-    return cli
+    if _cached_ironic_client is None:
+        _cached_ironic_client = ironic.get_ironic_client()
+    return _cached_ironic_client
 
 
 class IronicNode(base.ResourceObjectInterface):
@@ -54,9 +41,8 @@ class IronicNode(base.ResourceObjectInterface):
     def get_resource_uuid(self):
         return self._uuid
 
-    def get_resource_name(self):
-        node = get_ironic_client().node.get(self._uuid)
-        return node.name
+    def get_resource_name(self, resource_list=None):
+        return ironic.get_node_name(self._uuid, resource_list)
 
     def get_lease_uuid(self):
         node = get_ironic_client().node.get(self._uuid)

--- a/esi_leap/resource_objects/test_node.py
+++ b/esi_leap/resource_objects/test_node.py
@@ -24,7 +24,7 @@ class TestNode(base.ResourceObjectInterface):
     def get_resource_uuid(self):
         return self._uuid
 
-    def get_resource_name(self):
+    def get_resource_name(self, resource_list=None):
         return "test-node-%s" % self._uuid
 
     def get_lease_uuid(self):

--- a/esi_leap/tests/api/controllers/v1/test_lease.py
+++ b/esi_leap/tests/api/controllers/v1/test_lease.py
@@ -55,15 +55,23 @@ class TestLeasesController(test_api_base.APITestCase):
         data = self.get_json('/leases')
         self.assertEqual([], data['leases'])
 
+    @mock.patch('esi_leap.common.ironic.get_node_list')
+    @mock.patch('esi_leap.common.keystone.get_project_list')
     @mock.patch('esi_leap.api.controllers.v1.lease.'
                 'LeasesController._lease_get_dict_with_names')
     @mock.patch('esi_leap.objects.lease.Lease.get_all')
-    def test_one(self, mock_ga, mock_lgdwn):
+    def test_one(self, mock_ga, mock_lgdwn, mock_gpl, mock_gnl):
         mock_ga.return_value = [self.test_lease]
         mock_lgdwn.return_value = self.test_lease.to_dict()
+        mock_gpl.return_value = []
+        mock_gnl.return_value = []
+
         data = self.get_json('/leases')
+
         self.assertEqual(self.test_lease.uuid,
                          data['leases'][0]["uuid"])
+        mock_gpl.assert_called_once()
+        mock_gnl.assert_called_once()
         mock_lgdwn.assert_called_once()
 
     @mock.patch('esi_leap.api.controllers.v1.lease.'
@@ -266,13 +274,18 @@ class TestLeasesController(test_api_base.APITestCase):
         mock_create.assert_not_called()
         self.assertEqual(http_client.FORBIDDEN, request.status_int)
 
+    @mock.patch('esi_leap.common.ironic.get_node_list')
+    @mock.patch('esi_leap.common.keystone.get_project_list')
     @mock.patch('esi_leap.api.controllers.v1.lease.LeasesController.'
                 '_lease_get_dict_with_names')
     @mock.patch('esi_leap.api.controllers.v1.lease.LeasesController.'
                 '_lease_get_all_authorize_filters')
     @mock.patch('esi_leap.objects.lease.Lease.get_all')
-    def test_get_nofilters(self, mock_get_all, mock_lgaaf, mock_lgdwn):
+    def test_get_nofilters(self, mock_get_all, mock_lgaaf, mock_lgdwn,
+                           mock_gpl, mock_gnl):
         mock_get_all.return_value = [self.test_lease, self.test_lease]
+        mock_gpl.return_value = []
+        mock_gnl.return_value = []
 
         self.get_json('/leases')
 
@@ -287,8 +300,12 @@ class TestLeasesController(test_api_base.APITestCase):
                                            resource_type=None,
                                            resource_uuid=None)
         mock_get_all.assert_called_once()
+        mock_gpl.assert_called_once()
+        mock_gnl.assert_called_once()
         self.assertEqual(2, mock_lgdwn.call_count)
 
+    @mock.patch('esi_leap.common.ironic.get_node_list')
+    @mock.patch('esi_leap.common.keystone.get_project_list')
     @mock.patch('esi_leap.api.controllers.v1.lease.LeasesController.'
                 '_lease_get_dict_with_names')
     @mock.patch('esi_leap.common.keystone.get_project_uuid_from_ident')
@@ -296,10 +313,12 @@ class TestLeasesController(test_api_base.APITestCase):
                 '_lease_get_all_authorize_filters')
     @mock.patch('esi_leap.objects.lease.Lease.get_all')
     def test_get_project_filter(self, mock_get_all, mock_lgaaf,
-                                mock_gpufi, mock_lgdwn):
+                                mock_gpufi, mock_lgdwn, mock_gpl,
+                                mock_gnl):
         mock_gpufi.return_value = '12345'
         mock_get_all.return_value = [self.test_lease, self.test_lease]
-
+        mock_gpl.return_value = []
+        mock_gnl.return_value = []
         self.get_json('/leases?project_id=12345')
 
         mock_gpufi.assert_called_once_with('12345')
@@ -314,8 +333,12 @@ class TestLeasesController(test_api_base.APITestCase):
                                            resource_type=None,
                                            resource_uuid=None)
         mock_get_all.assert_called_once()
+        mock_gpl.assert_called_once()
+        mock_gnl.assert_called_once()
         self.assertEqual(2, mock_lgdwn.call_count)
 
+    @mock.patch('esi_leap.common.ironic.get_node_list')
+    @mock.patch('esi_leap.common.keystone.get_project_list')
     @mock.patch('esi_leap.api.controllers.v1.lease.LeasesController.'
                 '_lease_get_dict_with_names')
     @mock.patch('esi_leap.common.keystone.get_project_uuid_from_ident')
@@ -323,9 +346,12 @@ class TestLeasesController(test_api_base.APITestCase):
                 '_lease_get_all_authorize_filters')
     @mock.patch('esi_leap.objects.lease.Lease.get_all')
     def test_get_owner_filter(self, mock_get_all, mock_lgaaf,
-                              mock_gpufi, mock_lgdwn):
+                              mock_gpufi, mock_lgdwn, mock_gpl,
+                              mock_gnl):
         mock_gpufi.return_value = '54321'
         mock_get_all.return_value = [self.test_lease, self.test_lease]
+        mock_gpl.return_value = []
+        mock_gnl.return_value = []
 
         self.get_json('/leases?owner_id=54321')
 
@@ -342,8 +368,12 @@ class TestLeasesController(test_api_base.APITestCase):
                                            resource_uuid=None)
 
         mock_get_all.assert_called_once()
+        mock_gpl.assert_called_once()
+        mock_gnl.assert_called_once()
         self.assertEqual(2, mock_lgdwn.call_count)
 
+    @mock.patch('esi_leap.common.ironic.get_node_list')
+    @mock.patch('esi_leap.common.keystone.get_project_list')
     @mock.patch('esi_leap.api.controllers.v1.lease.LeasesController.'
                 '_lease_get_dict_with_names')
     @mock.patch('esi_leap.resource_objects.resource_object_factory.'
@@ -352,9 +382,12 @@ class TestLeasesController(test_api_base.APITestCase):
                 '_lease_get_all_authorize_filters')
     @mock.patch('esi_leap.objects.lease.Lease.get_all')
     def test_get_resource_filter(self, mock_get_all, mock_lgaaf,
-                                 mock_gro, mock_lgdwn):
+                                 mock_gro, mock_lgdwn, mock_gpl,
+                                 mock_gnl):
         mock_gro.return_value = TestNode('54321')
         mock_get_all.return_value = [self.test_lease, self.test_lease]
+        mock_gpl.return_value = []
+        mock_gnl.return_value = []
 
         self.get_json('/leases?resource_uuid=54321&resource_type=test_node')
 
@@ -371,8 +404,12 @@ class TestLeasesController(test_api_base.APITestCase):
                                            resource_uuid='54321')
 
         mock_get_all.assert_called_once()
+        mock_gpl.assert_called_once()
+        mock_gnl.assert_called_once()
         self.assertEqual(2, mock_lgdwn.call_count)
 
+    @mock.patch('esi_leap.common.ironic.get_node_list')
+    @mock.patch('esi_leap.common.keystone.get_project_list')
     @mock.patch('esi_leap.api.controllers.v1.lease.LeasesController.'
                 '_lease_get_dict_with_names')
     @mock.patch('esi_leap.resource_objects.resource_object_factory.'
@@ -382,9 +419,12 @@ class TestLeasesController(test_api_base.APITestCase):
     @mock.patch('esi_leap.objects.lease.Lease.get_all')
     def test_get_resource_filter_default_resource_type(self, mock_get_all,
                                                        mock_lgaaf, mock_gro,
-                                                       mock_lgdwn):
+                                                       mock_lgdwn, mock_gpl,
+                                                       mock_gnl):
         mock_gro.return_value = IronicNode('54321')
         mock_get_all.return_value = [self.test_lease, self.test_lease]
+        mock_gpl.return_value = []
+        mock_gnl.return_value = []
 
         self.get_json('/leases?resource_uuid=54321')
 
@@ -401,6 +441,8 @@ class TestLeasesController(test_api_base.APITestCase):
                                            resource_uuid='54321')
 
         mock_get_all.assert_called_once()
+        mock_gpl.assert_called_once()
+        mock_gnl.assert_called_once()
         self.assertEqual(2, mock_lgdwn.call_count)
 
 

--- a/esi_leap/tests/api/controllers/v1/test_node.py
+++ b/esi_leap/tests/api/controllers/v1/test_node.py
@@ -13,7 +13,6 @@
 import mock
 
 from esi_leap.tests.api import base as test_api_base
-from esi_leap.common import ironic
 
 
 class FakeIronicNode(object):
@@ -26,10 +25,12 @@ class TestNodesController(test_api_base.APITestCase):
     def setUp(self):
         super(TestNodesController, self).setUp()
 
-    @mock.patch.object(ironic, 'get_ironic_client', autospec=True)
-    def test_get_all(self, client_mock):
+    @mock.patch('esi_leap.common.ironic.get_node_list')
+    def test_get_all(self, mock_gnl):
         fake_node = FakeIronicNode()
-        client_mock.return_value.node.list.return_value = [fake_node]
+        mock_gnl.return_value = [fake_node]
+
         data = self.get_json("/nodes")
-        client_mock.assert_called_once()
+
+        mock_gnl.assert_called_once_with(self.context)
         self.assertEqual(data["nodes"][0]["name"], "fake-node")

--- a/esi_leap/tests/common/test_ironic.py
+++ b/esi_leap/tests/common/test_ironic.py
@@ -1,0 +1,47 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+
+from esi_leap.common import ironic
+from esi_leap.tests import base
+
+
+class FakeNode(object):
+    def __init__(self):
+        self.uuid = "uuid"
+        self.name = "name"
+
+
+class IronicTestCase(base.TestCase):
+
+    @mock.patch.object(ironic, 'get_ironic_client', autospec=True)
+    def test_get_node_name_no_list(self, mock_ironic):
+        mock_ironic.return_value.node.get.return_value = FakeNode()
+
+        node_name = ironic.get_node_name('12345')
+
+        self.assertEqual('name', node_name)
+
+    @mock.patch.object(ironic, 'get_ironic_client', autospec=True)
+    def test_get_node_name_list(self, mock_ironic):
+        node_list = [FakeNode()]
+        node_name = ironic.get_node_name('uuid', node_list)
+
+        self.assertEqual('name', node_name)
+
+    @mock.patch.object(ironic, 'get_ironic_client', autospec=True)
+    def test_get_node_name_list_no_match(self, mock_ironic):
+        node_list = [FakeNode()]
+        node_name = ironic.get_node_name('uuid2', node_list)
+
+        self.assertEqual('', node_name)

--- a/esi_leap/tests/common/test_keystone.py
+++ b/esi_leap/tests/common/test_keystone.py
@@ -62,66 +62,24 @@ class KeystoneTestCase(base.TestCase):
         mock_keystone.return_value.projects.list.assert_called_once_with(
             name='name')
 
-    @mock.patch('esi_leap.common.keystone.get_project_list')
-    def test_search_project_list(self, mock_gpl):
-        test_project1 = mock.Mock(id='12345')
-        test_project2 = mock.Mock(id='67890')
-        test_project1.name = 'test-project-1'
-        test_project2.name = 'test-project-2'
-
-        mock_gpl.return_value = [test_project1, test_project2]
-
-        project = keystone.search_project_list('67890')
-
-        mock_gpl.assert_called_once()
-        self.assertEqual(test_project2, project)
-
-    @mock.patch('esi_leap.common.keystone.refresh_project_list')
-    @mock.patch('esi_leap.common.keystone.get_project_list')
-    def test_search_project_list_refresh(self, mock_gpl, mock_rpl):
-        test_project1 = mock.Mock(id='12345')
-        test_project2 = mock.Mock(id='67890')
-        test_project1.name = 'test-project-1'
-        test_project2.name = 'test-project-2'
-
-        mock_gpl.side_effect = [[test_project1],
-                                [test_project1, test_project2]]
-
-        project = keystone.search_project_list('67890')
-
-        self.assertEqual(2, mock_gpl.call_count)
-        mock_rpl.assert_called_once()
-        self.assertEqual(test_project2, project)
-
-    @mock.patch('esi_leap.common.keystone.search_project_list')
-    def test_get_project_name(self, mock_spl):
-        test_project = mock.Mock(id='12345', name='test-project')
-        test_project.name = 'test-project'
-
-        mock_spl.return_value = test_project
+    @mock.patch.object(keystone, 'get_keystone_client', autospec=True)
+    def test_get_project_name_no_list(self, mock_keystone):
+        mock_keystone.return_value.projects.get.return_value = FakeProject()
 
         project_name = keystone.get_project_name('12345')
 
-        mock_spl.assert_called_once_with('12345')
-        self.assertEqual('test-project', project_name)
+        self.assertEqual('name', project_name)
 
-    @mock.patch('esi_leap.common.keystone.search_project_list')
-    def test_get_project_name_no_id(self, mock_spl):
-        test_project = mock.Mock(id='12345', name='test-project')
-        test_project.name = 'test-project'
+    @mock.patch.object(keystone, 'get_keystone_client', autospec=True)
+    def test_get_project_name_list(self, mock_keystone):
+        project_list = [FakeProject()]
+        project_name = keystone.get_project_name('uuid', project_list)
 
-        mock_spl.return_value = test_project
+        self.assertEqual('name', project_name)
 
-        project_name = keystone.get_project_name(None)
+    @mock.patch.object(keystone, 'get_keystone_client', autospec=True)
+    def test_get_project_name_list_no_match(self, mock_keystone):
+        project_list = [FakeProject()]
+        project_name = keystone.get_project_name('uuid2', project_list)
 
-        mock_spl.assert_not_called()
-        self.assertEqual('', project_name)
-
-    @mock.patch('esi_leap.common.keystone.search_project_list')
-    def test_get_project_name_no_match(self, mock_spl):
-        mock_spl.return_value = None
-
-        project_name = keystone.get_project_name('123456')
-
-        mock_spl.assert_called_once_with('123456')
         self.assertEqual('', project_name)

--- a/esi_leap/tests/resource_objects/test_ironic_node.py
+++ b/esi_leap/tests/resource_objects/test_ironic_node.py
@@ -54,16 +54,15 @@ class TestIronicNode(base.TestCase):
         test_ironic_node = ironic_node.IronicNode("1111")
         self.assertEqual("1111", test_ironic_node.get_resource_uuid())
 
-    @mock.patch.object(ironic_node, 'get_ironic_client', autospec=True)
-    def test_get_resource_name(self, client_mock):
-        fake_get_node = FakeIronicNode()
-        client_mock.return_value.node.get.return_value = fake_get_node
+    @mock.patch('esi_leap.common.ironic.get_node_name')
+    def test_get_resource_name(self, mock_gnn):
+        mock_gnn.return_value = 'node-name'
         test_ironic_node = ironic_node.IronicNode("1111")
+
         resource_name = test_ironic_node.get_resource_name()
-        self.assertEqual('fake-node', resource_name)
-        client_mock.assert_called_once()
-        client_mock.return_value.node.get.assert_called_once_with(
-            test_ironic_node._uuid)
+
+        self.assertEqual('node-name', resource_name)
+        mock_gnn.assert_called_once_with('1111', None)
 
     @mock.patch.object(ironic_node, 'get_ironic_client', autospec=True)
     def test_get_by_name(self, client_mock):


### PR DESCRIPTION
Optimize name queries for list commands by grabbing a list of
all projects/nodes and searching the list (rather than doing
an API request per project/node).