### PR TITLE
Use is_lease_* and is_offer_* policy rules

### DIFF
--- a/esi_leap/api/controllers/v1/owner_change.py
+++ b/esi_leap/api/controllers/v1/owner_change.py
@@ -63,7 +63,7 @@ class OwnerChangesController(rest.RestController):
         request = pecan.request.context
         cdict = request.to_policy_values()
 
-        utils.policy_authorize('esi_leap:owner_change:get', cdict)
+        utils.policy_authorize('esi_leap:owner_change:get', cdict, cdict)
 
         oc = owner_change_obj.OwnerChange.get(owner_change_uuid)
         if oc is None:
@@ -71,8 +71,9 @@ class OwnerChangesController(rest.RestController):
                 owner_change_uuid=owner_change_uuid)
 
         if cdict['project_id'] not in (oc.from_owner_id, oc.to_owner_id):
-            utils.policy_authorize('esi_leap:owner_change:owner_change_admin',
-                                   cdict, 'owner change', owner_change_uuid)
+            utils.resource_policy_authorize(
+                'esi_leap:owner_change:owner_change_admin',
+                cdict, cdict, 'owner change', owner_change_uuid)
 
         return OwnerChange(**oc.to_dict())
 
@@ -87,7 +88,7 @@ class OwnerChangesController(rest.RestController):
         request = pecan.request.context
 
         cdict = request.to_policy_values()
-        utils.policy_authorize('esi_leap:owner_change:get', cdict)
+        utils.policy_authorize('esi_leap:owner_change:get', cdict, cdict)
 
         if (start_time and end_time is None) or\
            (end_time and start_time is None):
@@ -108,7 +109,7 @@ class OwnerChangesController(rest.RestController):
 
         try:
             utils.policy_authorize(
-                'esi_leap:owner_change:owner_change_admin', cdict)
+                'esi_leap:owner_change:owner_change_admin', cdict, cdict)
             from_or_to_owner_id = None
         except exception.HTTPForbidden:
             from_or_to_owner_id = cdict['project_id']
@@ -141,7 +142,7 @@ class OwnerChangesController(rest.RestController):
     def post(self, new_owner_change):
         request = pecan.request.context
         cdict = request.to_policy_values()
-        utils.policy_authorize('esi_leap:owner_change:create', cdict)
+        utils.policy_authorize('esi_leap:owner_change:create', cdict, cdict)
 
         owner_change_dict = new_owner_change.to_dict()
         owner_change_dict['uuid'] = uuidutils.generate_uuid()
@@ -173,7 +174,7 @@ class OwnerChangesController(rest.RestController):
     def delete(self, owner_change_uuid):
         request = pecan.request.context
         cdict = request.to_policy_values()
-        utils.policy_authorize('esi_leap:owner_change:delete', cdict)
+        utils.policy_authorize('esi_leap:owner_change:delete', cdict, cdict)
 
         oc = owner_change_obj.OwnerChange.get(owner_change_uuid)
         if oc is None:
@@ -181,7 +182,8 @@ class OwnerChangesController(rest.RestController):
                 owner_change_uuid=owner_change_uuid)
 
         if cdict['project_id'] not in (oc.from_owner_id, oc.to_owner_id):
-            utils.policy_authorize('esi_leap:owner_change:owner_change_admin',
-                                   cdict, 'owner change', owner_change_uuid)
+            utils.resource_policy_authorize(
+                'esi_leap:owner_change:owner_change_admin',
+                cdict, cdict, 'owner change', owner_change_uuid)
 
         oc.cancel()

--- a/esi_leap/common/policy.py
+++ b/esi_leap/common/policy.py
@@ -29,6 +29,15 @@ default_policies = [
     policy.RuleDefault('is_lessee',
                        'role:lessee or role:esi_leap_lessee',
                        description='Lessee API access'),
+    policy.RuleDefault('is_offer_owner',
+                       'project_id:%(offer.project_id)s',
+                       description='Owner of offer'),
+    policy.RuleDefault('is_lease_owner',
+                       'project_id:%(lease.owner_id)s',
+                       description='Owner of lease'),
+    policy.RuleDefault('is_lease_lessee',
+                       'project_id:%(lease.project_id)s',
+                       description='Lessee of lease'),
 ]
 
 lease_policies = [
@@ -47,13 +56,17 @@ lease_policies = [
         [{'path': '/leases', 'method': 'POST'}]),
     policy.DocumentedRuleDefault(
         'esi_leap:lease:get',
-        'rule:is_admin or rule:is_lessee or rule:is_owner',
+        'rule:is_admin or rule:is_lease_owner or rule:is_lease_lessee',
+        'Retrieve a single lease',
+        [{'path': '/leases/{lease_ident}', 'method': 'GET'}]),
+    policy.DocumentedRuleDefault(
+        'esi_leap:lease:get_all',
+        'rule:is_admin or rule:is_owner or rule:is_lessee',
         'Retrieve all leases owned by project_id',
-        [{'path': '/leases', 'method': 'GET'},
-         {'path': '/leases/{lease_ident}', 'method': 'GET'}]),
+        [{'path': '/leases', 'method': 'GET'}]),
     policy.DocumentedRuleDefault(
         'esi_leap:lease:delete',
-        'rule:is_admin or rule:is_owner or rule:is_lessee',
+        'rule:is_admin or rule:is_lease_owner or rule:is_lease_lessee',
         'Delete lease',
         [{'path': '/leases/{lease_ident}', 'method': 'DELETE'}]),
 ]
@@ -75,17 +88,21 @@ offer_policies = [
     policy.DocumentedRuleDefault(
         'esi_leap:offer:get',
         'rule:is_admin or rule:is_owner or rule:is_lessee',
-        'Retrieve offer',
-        [{'path': '/offers', 'method': 'GET'},
-         {'path': '/offers/{offer_ident}', 'method': 'GET'}]),
+        'Retrieve a single offer',
+        [{'path': '/offers/{offer_ident}', 'method': 'GET'}]),
+    policy.DocumentedRuleDefault(
+        'esi_leap:offer:get_all',
+        'rule:is_admin or rule:is_owner or rule:is_lessee',
+        'Retrieve multiple offers',
+        [{'path': '/offers', 'method': 'GET'}]),
     policy.DocumentedRuleDefault(
         'esi_leap:offer:delete',
-        'rule:is_admin or rule:is_owner',
+        'rule:is_admin or rule:is_offer_owner',
         'Delete offer',
         [{'path': '/offers/{offer_ident}', 'method': 'DELETE'}]),
     policy.DocumentedRuleDefault(
         'esi_leap:offer:claim',
-        'rule:is_admin or rule:is_lessee',
+        'rule:is_admin or rule:is_owner or rule:is_lessee',
         'Claim an offer',
         [{'path': '/offers/{offer_ident}/claim', 'method': 'POST'}]),
 ]


### PR DESCRIPTION
This change moves us more in line with OpenStack standards, and
also simplifies some of our controller logic by falling back to
oslo policy.