### PR TITLE
Fix error when controller attempts to retrieve project name

### DIFF
--- a/esi_leap/common/keystone.py
+++ b/esi_leap/common/keystone.py
@@ -63,12 +63,16 @@ def get_project_list():
 
 def get_project_name(project_id, project_list=None):
     project_name = ''
-    if project_list is None:
-        project = get_keystone_client().projects.get(project_id)
-    else:
-        project = next((p for p in project_list
-                        if getattr(p, 'id') == project_id),
-                       None)
-    if project:
-        project_name = project.name
+    project = None
+
+    if project_id:
+        if project_list is None:
+            project = get_keystone_client().projects.get(project_id)
+        else:
+            project = next((p for p in project_list
+                            if getattr(p, 'id') == project_id),
+                           None)
+        if project:
+            project_name = project.name
+
     return project_name

--- a/esi_leap/tests/common/test_keystone.py
+++ b/esi_leap/tests/common/test_keystone.py
@@ -83,3 +83,10 @@ class KeystoneTestCase(base.TestCase):
         project_name = keystone.get_project_name('uuid2', project_list)
 
         self.assertEqual('', project_name)
+
+    @mock.patch.object(keystone, 'get_keystone_client', autospec=True)
+    def test_get_project_name_none(self, mock_keystone):
+        project_list = [FakeProject()]
+        project_name = keystone.get_project_name(None, project_list)
+
+        self.assertEqual('', project_name)


### PR DESCRIPTION
The controller will attempt to retrieve a project name even if
the project id is not set - for example, if an offer does not have
a lessee specified. This patch fixes the issue.