### PR TITLE
Update the lease returned when claiming an offer to include names

### DIFF
--- a/esi_leap/api/controllers/v1/lease.py
+++ b/esi_leap/api/controllers/v1/lease.py
@@ -78,7 +78,7 @@ class LeasesController(rest.RestController):
         lease = utils.check_lease_policy_and_retrieve(
             request, 'esi_leap:lease:get', lease_id)
 
-        return Lease(**LeasesController._lease_get_dict_with_names(lease))
+        return Lease(**utils.lease_get_dict_with_added_info(lease))
 
     @wsme_pecan.wsexpose(LeaseCollection, wtypes.text,
                          datetime.datetime, datetime.datetime, wtypes.text,
@@ -119,7 +119,7 @@ class LeasesController(rest.RestController):
             node_list = ironic.get_node_list()
             for lease in leases:
                 lease_collection.leases.append(
-                    Lease(**LeasesController._lease_get_dict_with_names(
+                    Lease(**utils.lease_get_dict_with_added_info(
                         lease, project_list, node_list)))
         return lease_collection
 
@@ -164,7 +164,7 @@ class LeasesController(rest.RestController):
 
         lease = lease_obj.Lease(**lease_dict)
         lease.create(request)
-        return Lease(**LeasesController._lease_get_dict_with_names(lease))
+        return Lease(**utils.lease_get_dict_with_added_info(lease))
 
     @wsme_pecan.wsexpose(Lease, wtypes.text)
     def delete(self, lease_id):
@@ -242,15 +242,3 @@ class LeasesController(rest.RestController):
                 filters[k] = v
 
         return filters
-
-    @staticmethod
-    def _lease_get_dict_with_names(lease, project_list=None, node_list=None):
-        resource = lease.resource_object()
-
-        lease_dict = lease.to_dict()
-        lease_dict['project'] = keystone.get_project_name(lease.project_id,
-                                                          project_list)
-        lease_dict['owner'] = keystone.get_project_name(lease.owner_id,
-                                                        project_list)
-        lease_dict['resource'] = resource.get_resource_name(node_list)
-        return lease_dict

--- a/esi_leap/api/controllers/v1/offer.py
+++ b/esi_leap/api/controllers/v1/offer.py
@@ -85,7 +85,7 @@ class OffersController(rest.RestController):
             request, 'esi_leap:offer:get', offer_id)
         utils.check_offer_lessee(cdict, offer)
 
-        o = OffersController._add_offer_availabilities_and_names(offer)
+        o = utils.offer_get_dict_with_added_info(offer)
 
         return Offer(**o)
 
@@ -170,7 +170,7 @@ class OffersController(rest.RestController):
             project_list = keystone.get_project_list()
             node_list = ironic.get_node_list()
             offer_collection.offers = [
-                Offer(**OffersController._add_offer_availabilities_and_names(
+                Offer(**utils.offer_get_dict_with_added_info(
                     o, project_list, node_list))
                 for o in offers]
 
@@ -222,7 +222,7 @@ class OffersController(rest.RestController):
 
         o = offer_obj.Offer(**offer_dict)
         o.create()
-        return Offer(**OffersController._add_offer_availabilities_and_names(o))
+        return Offer(**utils.offer_get_dict_with_added_info(o))
 
     @wsme_pecan.wsexpose(Offer, wtypes.text)
     def delete(self, offer_id):
@@ -266,19 +266,4 @@ class OffersController(rest.RestController):
 
         new_lease = lease_obj.Lease(**lease_dict)
         new_lease.create(request)
-        return lease.Lease(**new_lease.to_dict())
-
-    @staticmethod
-    def _add_offer_availabilities_and_names(offer, project_list=None,
-                                            node_list=None):
-        availabilities = offer.get_availabilities()
-        resource = offer.resource_object()
-
-        o = offer.to_dict()
-        o['availabilities'] = availabilities
-        o['project'] = keystone.get_project_name(offer.project_id,
-                                                 project_list)
-        o['lessee'] = keystone.get_project_name(offer.lessee_id,
-                                                project_list)
-        o['resource'] = resource.get_resource_name(node_list)
-        return o
+        return lease.Lease(**utils.lease_get_dict_with_added_info(new_lease))

--- a/esi_leap/api/controllers/v1/utils.py
+++ b/esi_leap/api/controllers/v1/utils.py
@@ -139,3 +139,31 @@ def check_offer_lessee(cdict, offer):
         resource_policy_authorize(
             'esi_leap:offer:offer_admin',
             cdict, cdict, 'offer', offer.uuid)
+
+
+def offer_get_dict_with_added_info(offer,
+                                   project_list=None,
+                                   node_list=None):
+    availabilities = offer.get_availabilities()
+    resource = offer.resource_object()
+
+    o = offer.to_dict()
+    o['availabilities'] = availabilities
+    o['project'] = keystone.get_project_name(offer.project_id,
+                                             project_list)
+    o['lessee'] = keystone.get_project_name(offer.lessee_id,
+                                            project_list)
+    o['resource'] = resource.get_resource_name(node_list)
+    return o
+
+
+def lease_get_dict_with_added_info(lease, project_list=None, node_list=None):
+    resource = lease.resource_object()
+
+    lease_dict = lease.to_dict()
+    lease_dict['project'] = keystone.get_project_name(lease.project_id,
+                                                      project_list)
+    lease_dict['owner'] = keystone.get_project_name(lease.owner_id,
+                                                    project_list)
+    lease_dict['resource'] = resource.get_resource_name(node_list)
+    return lease_dict

--- a/esi_leap/tests/api/controllers/v1/test_lease.py
+++ b/esi_leap/tests/api/controllers/v1/test_lease.py
@@ -57,12 +57,12 @@ class TestLeasesController(test_api_base.APITestCase):
 
     @mock.patch('esi_leap.common.ironic.get_node_list')
     @mock.patch('esi_leap.common.keystone.get_project_list')
-    @mock.patch('esi_leap.api.controllers.v1.lease.'
-                'LeasesController._lease_get_dict_with_names')
+    @mock.patch('esi_leap.api.controllers.v1.utils.'
+                'lease_get_dict_with_added_info')
     @mock.patch('esi_leap.objects.lease.Lease.get_all')
-    def test_one(self, mock_ga, mock_lgdwn, mock_gpl, mock_gnl):
+    def test_one(self, mock_ga, mock_lgdwai, mock_gpl, mock_gnl):
         mock_ga.return_value = [self.test_lease]
-        mock_lgdwn.return_value = self.test_lease.to_dict()
+        mock_lgdwai.return_value = self.test_lease.to_dict()
         mock_gpl.return_value = []
         mock_gnl.return_value = []
 
@@ -72,10 +72,10 @@ class TestLeasesController(test_api_base.APITestCase):
                          data['leases'][0]["uuid"])
         mock_gpl.assert_called_once()
         mock_gnl.assert_called_once()
-        mock_lgdwn.assert_called_once()
+        mock_lgdwai.assert_called_once()
 
-    @mock.patch('esi_leap.api.controllers.v1.lease.'
-                'LeasesController._lease_get_dict_with_names')
+    @mock.patch('esi_leap.api.controllers.v1.utils.'
+                'lease_get_dict_with_added_info')
     @mock.patch('esi_leap.resource_objects.resource_object_factory.'
                 'ResourceObjectFactory.get_resource_object')
     @mock.patch('esi_leap.common.keystone.get_project_uuid_from_ident')
@@ -83,7 +83,7 @@ class TestLeasesController(test_api_base.APITestCase):
     @mock.patch('esi_leap.api.controllers.v1.utils.check_resource_admin')
     @mock.patch('esi_leap.objects.lease.Lease.create')
     def test_post(self, mock_create, mock_cra, mock_generate_uuid,
-                  mock_gpufi, mock_gro, mock_lgdwn):
+                  mock_gpufi, mock_gro, mock_lgdwai):
         resource = TestNode('1234567890')
         data = {
             "project_id": "lesseeid",
@@ -95,16 +95,16 @@ class TestLeasesController(test_api_base.APITestCase):
         return_data = data.copy()
         return_data['owner_id'] = self.context.project_id
         return_data['uuid'] = self.test_lease.uuid
-        lgdwn_return_data = return_data.copy()
-        lgdwn_return_data["start_time"] = datetime.datetime(
+        lgdwai_return_data = return_data.copy()
+        lgdwai_return_data["start_time"] = datetime.datetime(
             2016, 7, 16, 19, 20, 30)
-        lgdwn_return_data["end_time"] = datetime.datetime(
+        lgdwai_return_data["end_time"] = datetime.datetime(
             2016, 8, 16, 19, 20, 30)
 
         mock_gro.return_value = resource
         mock_gpufi.return_value = 'lesseeid'
         mock_generate_uuid.return_value = self.test_lease.uuid
-        mock_lgdwn.return_value = lgdwn_return_data
+        mock_lgdwai.return_value = lgdwai_return_data
 
         request = self.post_json('/leases', data)
 
@@ -115,12 +115,12 @@ class TestLeasesController(test_api_base.APITestCase):
             resource,
             self.context.project_id)
         mock_create.assert_called_once()
-        mock_lgdwn.assert_called_once()
+        mock_lgdwai.assert_called_once()
         self.assertEqual(return_data, request.json)
         self.assertEqual(http_client.CREATED, request.status_int)
 
-    @mock.patch('esi_leap.api.controllers.v1.lease.'
-                'LeasesController._lease_get_dict_with_names')
+    @mock.patch('esi_leap.api.controllers.v1.utils.'
+                'lease_get_dict_with_added_info')
     @mock.patch('esi_leap.resource_objects.resource_object_factory.'
                 'ResourceObjectFactory.get_resource_object')
     @mock.patch('esi_leap.common.keystone.get_project_uuid_from_ident')
@@ -129,7 +129,7 @@ class TestLeasesController(test_api_base.APITestCase):
     @mock.patch('esi_leap.objects.lease.Lease.create')
     def test_post_default_resource_type(self, mock_create, mock_cra,
                                         mock_generate_uuid, mock_gpufi,
-                                        mock_gro, mock_lgdwn):
+                                        mock_gro, mock_lgdwai):
         resource = IronicNode('1234567890')
         data = {
             "project_id": "lesseeid",
@@ -141,16 +141,16 @@ class TestLeasesController(test_api_base.APITestCase):
         return_data["resource_type"] = "ironic_node"
         return_data["owner_id"] = self.context.project_id
         return_data["uuid"] = self.test_lease.uuid
-        lgdwn_return_data = return_data.copy()
-        lgdwn_return_data["start_time"] = datetime.datetime(
+        lgdwai_return_data = return_data.copy()
+        lgdwai_return_data["start_time"] = datetime.datetime(
             2016, 7, 16, 19, 20, 30)
-        lgdwn_return_data["end_time"] = datetime.datetime(
+        lgdwai_return_data["end_time"] = datetime.datetime(
             2016, 8, 16, 19, 20, 30)
 
         mock_gro.return_value = resource
         mock_gpufi.return_value = 'lesseeid'
         mock_generate_uuid.return_value = self.test_lease.uuid
-        mock_lgdwn.return_value = lgdwn_return_data
+        mock_lgdwai.return_value = lgdwai_return_data
 
         request = self.post_json('/leases', data)
 
@@ -161,12 +161,12 @@ class TestLeasesController(test_api_base.APITestCase):
             resource,
             self.context.project_id)
         mock_create.assert_called_once()
-        mock_lgdwn.assert_called_once()
+        mock_lgdwai.assert_called_once()
         self.assertEqual(return_data, request.json)
         self.assertEqual(http_client.CREATED, request.status_int)
 
-    @mock.patch('esi_leap.api.controllers.v1.lease.'
-                'LeasesController._lease_get_dict_with_names')
+    @mock.patch('esi_leap.api.controllers.v1.utils.'
+                'lease_get_dict_with_added_info')
     @mock.patch('esi_leap.api.controllers.v1.utils.'
                 'check_resource_lease_admin')
     @mock.patch('esi_leap.resource_objects.resource_object_factory.'
@@ -177,7 +177,7 @@ class TestLeasesController(test_api_base.APITestCase):
     @mock.patch('esi_leap.objects.lease.Lease.create')
     def test_post_non_admin_parent_lease(self, mock_create, mock_cra,
                                          mock_generate_uuid, mock_gpufi,
-                                         mock_gro, mock_crla, mock_lgdwn):
+                                         mock_gro, mock_crla, mock_lgdwai):
         resource = IronicNode('1234567890')
         data = {
             "project_id": "lesseeid",
@@ -191,10 +191,10 @@ class TestLeasesController(test_api_base.APITestCase):
         return_data['resource_type'] = 'ironic_node'
         return_data['parent_lease_uuid'] = \
             self.test_lease_with_parent.parent_lease_uuid
-        lgdwn_return_data = return_data.copy()
-        lgdwn_return_data["start_time"] = datetime.datetime(
+        lgdwai_return_data = return_data.copy()
+        lgdwai_return_data["start_time"] = datetime.datetime(
             2016, 7, 17, 19, 20, 30)
-        lgdwn_return_data["end_time"] = datetime.datetime(
+        lgdwai_return_data["end_time"] = datetime.datetime(
             2016, 8, 14, 19, 20, 30)
 
         mock_gro.return_value = resource
@@ -203,7 +203,7 @@ class TestLeasesController(test_api_base.APITestCase):
         mock_cra.side_effect = exception.HTTPResourceForbidden(
             resource_type='ironic_node', resource='1234567890')
         mock_crla.return_value = self.test_lease_with_parent.parent_lease_uuid
-        mock_lgdwn.return_value = lgdwn_return_data
+        mock_lgdwai.return_value = lgdwai_return_data
 
         request = self.post_json('/leases', data)
 
@@ -220,7 +220,7 @@ class TestLeasesController(test_api_base.APITestCase):
             datetime.datetime(2016, 7, 17, 19, 20, 30),
             datetime.datetime(2016, 8, 14, 19, 20, 30))
         mock_create.assert_called_once()
-        mock_lgdwn.assert_called_once()
+        mock_lgdwai.assert_called_once()
         self.assertEqual(return_data, request.json)
         self.assertEqual(http_client.CREATED, request.status_int)
 
@@ -268,12 +268,12 @@ class TestLeasesController(test_api_base.APITestCase):
 
     @mock.patch('esi_leap.common.ironic.get_node_list')
     @mock.patch('esi_leap.common.keystone.get_project_list')
-    @mock.patch('esi_leap.api.controllers.v1.lease.LeasesController.'
-                '_lease_get_dict_with_names')
+    @mock.patch('esi_leap.api.controllers.v1.utils.'
+                'lease_get_dict_with_added_info')
     @mock.patch('esi_leap.api.controllers.v1.lease.LeasesController.'
                 '_lease_get_all_authorize_filters')
     @mock.patch('esi_leap.objects.lease.Lease.get_all')
-    def test_get_nofilters(self, mock_get_all, mock_lgaaf, mock_lgdwn,
+    def test_get_nofilters(self, mock_get_all, mock_lgaaf, mock_lgdwai,
                            mock_gpl, mock_gnl):
         mock_get_all.return_value = [self.test_lease, self.test_lease]
         mock_gpl.return_value = []
@@ -294,18 +294,18 @@ class TestLeasesController(test_api_base.APITestCase):
         mock_get_all.assert_called_once()
         mock_gpl.assert_called_once()
         mock_gnl.assert_called_once()
-        self.assertEqual(2, mock_lgdwn.call_count)
+        self.assertEqual(2, mock_lgdwai.call_count)
 
     @mock.patch('esi_leap.common.ironic.get_node_list')
     @mock.patch('esi_leap.common.keystone.get_project_list')
-    @mock.patch('esi_leap.api.controllers.v1.lease.LeasesController.'
-                '_lease_get_dict_with_names')
+    @mock.patch('esi_leap.api.controllers.v1.utils.'
+                'lease_get_dict_with_added_info')
     @mock.patch('esi_leap.common.keystone.get_project_uuid_from_ident')
     @mock.patch('esi_leap.api.controllers.v1.lease.LeasesController.'
                 '_lease_get_all_authorize_filters')
     @mock.patch('esi_leap.objects.lease.Lease.get_all')
     def test_get_project_filter(self, mock_get_all, mock_lgaaf,
-                                mock_gpufi, mock_lgdwn, mock_gpl,
+                                mock_gpufi, mock_lgdwai, mock_gpl,
                                 mock_gnl):
         mock_gpufi.return_value = '12345'
         mock_get_all.return_value = [self.test_lease, self.test_lease]
@@ -327,18 +327,18 @@ class TestLeasesController(test_api_base.APITestCase):
         mock_get_all.assert_called_once()
         mock_gpl.assert_called_once()
         mock_gnl.assert_called_once()
-        self.assertEqual(2, mock_lgdwn.call_count)
+        self.assertEqual(2, mock_lgdwai.call_count)
 
     @mock.patch('esi_leap.common.ironic.get_node_list')
     @mock.patch('esi_leap.common.keystone.get_project_list')
-    @mock.patch('esi_leap.api.controllers.v1.lease.LeasesController.'
-                '_lease_get_dict_with_names')
+    @mock.patch('esi_leap.api.controllers.v1.utils.'
+                'lease_get_dict_with_added_info')
     @mock.patch('esi_leap.common.keystone.get_project_uuid_from_ident')
     @mock.patch('esi_leap.api.controllers.v1.lease.LeasesController.'
                 '_lease_get_all_authorize_filters')
     @mock.patch('esi_leap.objects.lease.Lease.get_all')
     def test_get_owner_filter(self, mock_get_all, mock_lgaaf,
-                              mock_gpufi, mock_lgdwn, mock_gpl,
+                              mock_gpufi, mock_lgdwai, mock_gpl,
                               mock_gnl):
         mock_gpufi.return_value = '54321'
         mock_get_all.return_value = [self.test_lease, self.test_lease]
@@ -362,19 +362,19 @@ class TestLeasesController(test_api_base.APITestCase):
         mock_get_all.assert_called_once()
         mock_gpl.assert_called_once()
         mock_gnl.assert_called_once()
-        self.assertEqual(2, mock_lgdwn.call_count)
+        self.assertEqual(2, mock_lgdwai.call_count)
 
     @mock.patch('esi_leap.common.ironic.get_node_list')
     @mock.patch('esi_leap.common.keystone.get_project_list')
-    @mock.patch('esi_leap.api.controllers.v1.lease.LeasesController.'
-                '_lease_get_dict_with_names')
+    @mock.patch('esi_leap.api.controllers.v1.utils.'
+                'lease_get_dict_with_added_info')
     @mock.patch('esi_leap.resource_objects.resource_object_factory.'
                 'ResourceObjectFactory.get_resource_object')
     @mock.patch('esi_leap.api.controllers.v1.lease.LeasesController.'
                 '_lease_get_all_authorize_filters')
     @mock.patch('esi_leap.objects.lease.Lease.get_all')
     def test_get_resource_filter(self, mock_get_all, mock_lgaaf,
-                                 mock_gro, mock_lgdwn, mock_gpl,
+                                 mock_gro, mock_lgdwai, mock_gpl,
                                  mock_gnl):
         mock_gro.return_value = TestNode('54321')
         mock_get_all.return_value = [self.test_lease, self.test_lease]
@@ -398,12 +398,12 @@ class TestLeasesController(test_api_base.APITestCase):
         mock_get_all.assert_called_once()
         mock_gpl.assert_called_once()
         mock_gnl.assert_called_once()
-        self.assertEqual(2, mock_lgdwn.call_count)
+        self.assertEqual(2, mock_lgdwai.call_count)
 
     @mock.patch('esi_leap.common.ironic.get_node_list')
     @mock.patch('esi_leap.common.keystone.get_project_list')
-    @mock.patch('esi_leap.api.controllers.v1.lease.LeasesController.'
-                '_lease_get_dict_with_names')
+    @mock.patch('esi_leap.api.controllers.v1.utils.'
+                'lease_get_dict_with_added_info')
     @mock.patch('esi_leap.resource_objects.resource_object_factory.'
                 'ResourceObjectFactory.get_resource_object')
     @mock.patch('esi_leap.api.controllers.v1.lease.LeasesController.'
@@ -411,7 +411,7 @@ class TestLeasesController(test_api_base.APITestCase):
     @mock.patch('esi_leap.objects.lease.Lease.get_all')
     def test_get_resource_filter_default_resource_type(self, mock_get_all,
                                                        mock_lgaaf, mock_gro,
-                                                       mock_lgdwn, mock_gpl,
+                                                       mock_lgdwai, mock_gpl,
                                                        mock_gnl):
         mock_gro.return_value = IronicNode('54321')
         mock_get_all.return_value = [self.test_lease, self.test_lease]
@@ -435,7 +435,7 @@ class TestLeasesController(test_api_base.APITestCase):
         mock_get_all.assert_called_once()
         mock_gpl.assert_called_once()
         mock_gnl.assert_called_once()
-        self.assertEqual(2, mock_lgdwn.call_count)
+        self.assertEqual(2, mock_lgdwai.call_count)
 
 
 class TestLeaseControllersGetAllFilters(testtools.TestCase):
@@ -669,43 +669,3 @@ class TestLeaseControllersGetAllFilters(testtools.TestCase):
         filters = LeasesController._lease_get_all_authorize_filters(
             self.admin_ctx.to_policy_values(), status='any')
         self.assertEqual(expected_filters, filters)
-
-
-class TestLeaseControllerStaticMethods(testtools.TestCase):
-
-    def setUp(self):
-        super(TestLeaseControllerStaticMethods, self).setUp()
-
-        self.test_lease = lease_obj.Lease(
-            start_time=datetime.datetime(2016, 7, 16, 19, 20, 30),
-            end_time=datetime.datetime(2016, 8, 16, 19, 20, 30),
-            uuid=uuidutils.generate_uuid(),
-            resource_type='test_node',
-            resource_uuid='111',
-            project_id='lesseeid',
-            owner_id='ownerid',
-            parent_lease_uuid=None
-        )
-
-    @mock.patch('esi_leap.resource_objects.test_node.TestNode.'
-                'get_resource_name')
-    @mock.patch('esi_leap.common.keystone.get_project_name')
-    @mock.patch('esi_leap.resource_objects.resource_object_factory.'
-                'ResourceObjectFactory.get_resource_object')
-    def test_lease_get_dict_with_names(self, mock_gro, mock_gpn, mock_grn):
-        mock_gro.return_value = TestNode('111')
-        mock_gpn.return_value = 'project-name'
-        mock_grn.return_value = 'resource-name'
-
-        output_dict = LeasesController._lease_get_dict_with_names(
-            self.test_lease)
-
-        expected_output_dict = self.test_lease.to_dict()
-        expected_output_dict['resource'] = 'resource-name'
-        expected_output_dict['project'] = 'project-name'
-        expected_output_dict['owner'] = 'project-name'
-
-        mock_gro.assert_called_once()
-        self.assertEqual(2, mock_gpn.call_count)
-        mock_grn.assert_called_once()
-        self.assertEqual(expected_output_dict, output_dict)

--- a/esi_leap/tests/api/controllers/v1/test_offer.py
+++ b/esi_leap/tests/api/controllers/v1/test_offer.py
@@ -14,9 +14,7 @@ import datetime
 import http.client as http_client
 import mock
 from oslo_utils import uuidutils
-import testtools
 
-from esi_leap.api.controllers.v1.offer import OffersController
 from esi_leap.common import exception
 from esi_leap.common import statuses
 from esi_leap.objects import offer
@@ -119,15 +117,15 @@ class TestOffersController(test_api_base.APITestCase):
     @mock.patch('oslo_utils.uuidutils.generate_uuid')
     @mock.patch('esi_leap.api.controllers.v1.utils.check_resource_admin')
     @mock.patch('esi_leap.objects.offer.Offer.create')
-    @mock.patch('esi_leap.api.controllers.v1.offer.' +
-                'OffersController._add_offer_availabilities_and_names')
-    def test_post(self, mock_aoa, mock_create, mock_cra, mock_generate_uuid,
-                  mock_gro):
+    @mock.patch('esi_leap.api.controllers.v1.utils.' +
+                'offer_get_dict_with_added_info')
+    def test_post(self, mock_ogdwai, mock_create, mock_cra,
+                  mock_generate_uuid, mock_gro):
         resource = TestNode(self.test_offer.resource_uuid)
         mock_gro.return_value = resource
         mock_generate_uuid.return_value = self.test_offer.uuid
         mock_create.return_value = self.test_offer
-        mock_aoa.return_value = self.test_offer.to_dict()
+        mock_ogdwai.return_value = self.test_offer.to_dict()
 
         data = {
             "resource_type": self.test_offer.resource_type,
@@ -151,7 +149,7 @@ class TestOffersController(test_api_base.APITestCase):
             resource,
             self.context.project_id)
         mock_create.assert_called_once()
-        mock_aoa.assert_called_once()
+        mock_ogdwai.assert_called_once()
         self.assertEqual(data, request.json)
         self.assertEqual(http_client.CREATED, request.status_int)
 
@@ -160,14 +158,15 @@ class TestOffersController(test_api_base.APITestCase):
     @mock.patch('oslo_utils.uuidutils.generate_uuid')
     @mock.patch('esi_leap.api.controllers.v1.utils.check_resource_admin')
     @mock.patch('esi_leap.objects.offer.Offer.create')
-    @mock.patch('esi_leap.api.controllers.v1.offer.' +
-                'OffersController._add_offer_availabilities_and_names')
-    def test_post_default_resource_type(self, mock_aoa, mock_create, mock_cra,
-                                        mock_generate_uuid, mock_gro):
+    @mock.patch('esi_leap.api.controllers.v1.utils.' +
+                'offer_get_dict_with_added_info')
+    def test_post_default_resource_type(self, mock_ogdwai, mock_create,
+                                        mock_cra, mock_generate_uuid,
+                                        mock_gro):
         resource = IronicNode(self.test_offer_drt.resource_uuid)
         mock_gro.return_value = resource
         mock_generate_uuid.return_value = self.test_offer_drt.uuid
-        mock_aoa.return_value = self.test_offer_drt.to_dict()
+        mock_ogdwai.return_value = self.test_offer_drt.to_dict()
 
         data = {
             "resource_uuid": self.test_offer_drt.resource_uuid,
@@ -191,7 +190,7 @@ class TestOffersController(test_api_base.APITestCase):
             resource,
             self.context.project_id)
         mock_create.assert_called_once()
-        mock_aoa.assert_called_once()
+        mock_ogdwai.assert_called_once()
         self.assertEqual(data, request.json)
         self.assertEqual(http_client.CREATED, request.status_int)
 
@@ -201,16 +200,16 @@ class TestOffersController(test_api_base.APITestCase):
     @mock.patch('oslo_utils.uuidutils.generate_uuid')
     @mock.patch('esi_leap.api.controllers.v1.utils.check_resource_admin')
     @mock.patch('esi_leap.objects.offer.Offer.create')
-    @mock.patch('esi_leap.api.controllers.v1.offer.' +
-                'OffersController._add_offer_availabilities_and_names')
-    def test_post_lessee(self, mock_aoa, mock_create, mock_cra,
+    @mock.patch('esi_leap.api.controllers.v1.utils.' +
+                'offer_get_dict_with_added_info')
+    def test_post_lessee(self, mock_ogdwai, mock_create, mock_cra,
                          mock_generate_uuid, mock_gpufi, mock_gro):
         resource = TestNode(self.test_offer_lessee.resource_uuid)
         mock_gro.return_value = resource
         mock_gpufi.return_value = 'lessee_uuid'
         mock_generate_uuid.return_value = self.test_offer_lessee.uuid
         mock_create.return_value = self.test_offer_lessee
-        mock_aoa.return_value = self.test_offer_lessee.to_dict()
+        mock_ogdwai.return_value = self.test_offer_lessee.to_dict()
 
         data = {
             "resource_type": self.test_offer_lessee.resource_type,
@@ -236,7 +235,7 @@ class TestOffersController(test_api_base.APITestCase):
             resource,
             self.context.project_id)
         mock_create.assert_called_once()
-        mock_aoa.assert_called_once()
+        mock_ogdwai.assert_called_once()
         self.assertEqual(data, request.json)
         self.assertEqual(http_client.CREATED, request.status_int)
 
@@ -247,16 +246,16 @@ class TestOffersController(test_api_base.APITestCase):
     @mock.patch('oslo_utils.uuidutils.generate_uuid')
     @mock.patch('esi_leap.api.controllers.v1.utils.check_resource_admin')
     @mock.patch('esi_leap.objects.offer.Offer.create')
-    @mock.patch('esi_leap.api.controllers.v1.offer.' +
-                'OffersController._add_offer_availabilities_and_names')
-    def test_post_non_admin_parent_lease(self, mock_aoa, mock_create,
+    @mock.patch('esi_leap.api.controllers.v1.utils.' +
+                'offer_get_dict_with_added_info')
+    def test_post_non_admin_parent_lease(self, mock_ogdwai, mock_create,
                                          mock_cra, mock_generate_uuid,
                                          mock_gro, mock_crla):
         resource = TestNode(self.test_offer_with_parent.resource_uuid)
         mock_gro.return_value = resource
         mock_generate_uuid.return_value = self.test_offer_with_parent.uuid
         mock_create.return_value = self.test_offer_with_parent
-        mock_aoa.return_value = self.test_offer_with_parent.to_dict()
+        mock_ogdwai.return_value = self.test_offer_with_parent.to_dict()
         mock_cra.side_effect = exception.HTTPResourceForbidden(
             resource_type='test_node',
             resource=self.test_offer_with_parent.resource_uuid)
@@ -292,7 +291,7 @@ class TestOffersController(test_api_base.APITestCase):
             datetime.datetime(2016, 7, 16, 0, 0, 0),
             datetime.datetime(2016, 10, 24, 0, 0, 0))
         mock_create.assert_called_once()
-        mock_aoa.assert_called_once()
+        mock_ogdwai.assert_called_once()
         self.assertEqual(data, request.json)
         self.assertEqual(http_client.CREATED, request.status_int)
 
@@ -303,16 +302,16 @@ class TestOffersController(test_api_base.APITestCase):
     @mock.patch('oslo_utils.uuidutils.generate_uuid')
     @mock.patch('esi_leap.api.controllers.v1.utils.check_resource_admin')
     @mock.patch('esi_leap.objects.offer.Offer.create')
-    @mock.patch('esi_leap.api.controllers.v1.offer.' +
-                'OffersController._add_offer_availabilities_and_names')
-    def test_post_non_admin_no_parent_lease(self, mock_aoa, mock_create,
+    @mock.patch('esi_leap.api.controllers.v1.utils.' +
+                'offer_get_dict_with_added_info')
+    def test_post_non_admin_no_parent_lease(self, mock_ogdwai, mock_create,
                                             mock_cra, mock_generate_uuid,
                                             mock_gro, mock_crla):
         resource = TestNode(self.test_offer_with_parent.resource_uuid)
         mock_gro.return_value = resource
         mock_generate_uuid.return_value = self.test_offer_with_parent.uuid
         mock_create.return_value = self.test_offer_with_parent
-        mock_aoa.return_value = self.test_offer_with_parent.to_dict()
+        mock_ogdwai.return_value = self.test_offer_with_parent.to_dict()
         mock_cra.side_effect = exception.HTTPResourceForbidden(
             resource_type='test_node',
             resource=self.test_offer_with_parent.resource_uuid)
@@ -342,18 +341,18 @@ class TestOffersController(test_api_base.APITestCase):
             datetime.datetime(2016, 7, 16, 0, 0, 0),
             datetime.datetime(2016, 10, 24, 0, 0, 0))
         mock_create.assert_not_called()
-        mock_aoa.assert_not_called()
+        mock_ogdwai.assert_not_called()
         self.assertEqual(http_client.FORBIDDEN, request.status_int)
 
     @mock.patch('esi_leap.common.ironic.get_node_list')
     @mock.patch('esi_leap.common.keystone.get_project_list')
-    @mock.patch('esi_leap.api.controllers.v1.offer.' +
-                'OffersController._add_offer_availabilities_and_names')
+    @mock.patch('esi_leap.api.controllers.v1.utils.' +
+                'offer_get_dict_with_added_info')
     @mock.patch('esi_leap.objects.offer.Offer.get_all')
-    def test_get_nofilters(self, mock_get_all, mock_aoaan, mock_gpl,
+    def test_get_nofilters(self, mock_get_all, mock_ogdwai, mock_gpl,
                            mock_gnl):
         mock_get_all.return_value = [self.test_offer, self.test_offer_2]
-        mock_aoaan.side_effect = [
+        mock_ogdwai.side_effect = [
             _get_offer_response(self.test_offer, use_datetime=True),
             _get_offer_response(self.test_offer_2, use_datetime=True)]
         mock_gpl.return_value = []
@@ -368,18 +367,18 @@ class TestOffersController(test_api_base.APITestCase):
         mock_get_all.assert_called_once_with(expected_filters, self.context)
         mock_gpl.assert_called_once()
         mock_gnl.assert_called_once()
-        assert mock_aoaan.call_count == 2
+        assert mock_ogdwai.call_count == 2
         self.assertEqual(request, expected_resp)
 
     @mock.patch('esi_leap.common.ironic.get_node_list')
     @mock.patch('esi_leap.common.keystone.get_project_list')
-    @mock.patch('esi_leap.api.controllers.v1.offer.' +
-                'OffersController._add_offer_availabilities_and_names')
+    @mock.patch('esi_leap.api.controllers.v1.utils.' +
+                'offer_get_dict_with_added_info')
     @mock.patch('esi_leap.objects.offer.Offer.get_all')
-    def test_get_any_status(self, mock_get_all, mock_aoaan, mock_gpl,
+    def test_get_any_status(self, mock_get_all, mock_ogdwai, mock_gpl,
                             mock_gnl):
         mock_get_all.return_value = [self.test_offer, self.test_offer_2]
-        mock_aoaan.side_effect = [
+        mock_ogdwai.side_effect = [
             _get_offer_response(self.test_offer, use_datetime=True),
             _get_offer_response(self.test_offer_2, use_datetime=True)]
         mock_gpl.return_value = []
@@ -394,19 +393,19 @@ class TestOffersController(test_api_base.APITestCase):
         mock_get_all.assert_called_once_with(expected_filters, self.context)
         mock_gpl.assert_called_once()
         mock_gnl.assert_called_once()
-        assert mock_aoaan.call_count == 2
+        assert mock_ogdwai.call_count == 2
         self.assertEqual(request, expected_resp)
 
     @mock.patch('esi_leap.common.ironic.get_node_list')
     @mock.patch('esi_leap.common.keystone.get_project_list')
     @mock.patch('esi_leap.common.keystone.get_project_uuid_from_ident')
-    @mock.patch('esi_leap.api.controllers.v1.offer.' +
-                'OffersController._add_offer_availabilities_and_names')
+    @mock.patch('esi_leap.api.controllers.v1.utils.' +
+                'offer_get_dict_with_added_info')
     @mock.patch('esi_leap.objects.offer.Offer.get_all')
-    def test_get_project_filter(self, mock_get_all, mock_aoaan,
+    def test_get_project_filter(self, mock_get_all, mock_ogdwai,
                                 mock_gpufi, mock_gpl, mock_gnl):
         mock_get_all.return_value = [self.test_offer, self.test_offer_2]
-        mock_aoaan.side_effect = [
+        mock_ogdwai.side_effect = [
             _get_offer_response(self.test_offer, use_datetime=True),
             _get_offer_response(self.test_offer_2, use_datetime=True)]
         mock_gpufi.return_value = self.context.project_id
@@ -425,20 +424,20 @@ class TestOffersController(test_api_base.APITestCase):
         mock_get_all.assert_called_once_with(expected_filters, self.context)
         mock_gpl.assert_called_once()
         mock_gnl.assert_called_once()
-        assert mock_aoaan.call_count == 2
+        assert mock_ogdwai.call_count == 2
         self.assertEqual(request, expected_resp)
 
     @mock.patch('esi_leap.common.ironic.get_node_list')
     @mock.patch('esi_leap.common.keystone.get_project_list')
     @mock.patch('esi_leap.resource_objects.resource_object_factory.'
                 'ResourceObjectFactory.get_resource_object')
-    @mock.patch('esi_leap.api.controllers.v1.offer.' +
-                'OffersController._add_offer_availabilities_and_names')
+    @mock.patch('esi_leap.api.controllers.v1.utils.' +
+                'offer_get_dict_with_added_info')
     @mock.patch('esi_leap.objects.offer.Offer.get_all')
-    def test_get_resource_filter(self, mock_get_all, mock_aoaan, mock_gro,
+    def test_get_resource_filter(self, mock_get_all, mock_ogdwai, mock_gro,
                                  mock_gpl, mock_gnl):
         mock_get_all.return_value = [self.test_offer, self.test_offer_2]
-        mock_aoaan.side_effect = [
+        mock_ogdwai.side_effect = [
             _get_offer_response(self.test_offer, use_datetime=True),
             _get_offer_response(self.test_offer_2, use_datetime=True)]
         mock_gro.return_value = TestNode('54321')
@@ -458,23 +457,23 @@ class TestOffersController(test_api_base.APITestCase):
         mock_get_all.assert_called_once_with(expected_filters, self.context)
         mock_gpl.assert_called_once()
         mock_gnl.assert_called_once()
-        assert mock_aoaan.call_count == 2
+        assert mock_ogdwai.call_count == 2
         self.assertEqual(request, expected_resp)
 
     @mock.patch('esi_leap.common.ironic.get_node_list')
     @mock.patch('esi_leap.common.keystone.get_project_list')
     @mock.patch('esi_leap.resource_objects.resource_object_factory.'
                 'ResourceObjectFactory.get_resource_object')
-    @mock.patch('esi_leap.api.controllers.v1.offer.' +
-                'OffersController._add_offer_availabilities_and_names')
+    @mock.patch('esi_leap.api.controllers.v1.utils.' +
+                'offer_get_dict_with_added_info')
     @mock.patch('esi_leap.objects.offer.Offer.get_all')
     def test_get_resource_filter_default_resource_type(self, mock_get_all,
-                                                       mock_aoaan,
+                                                       mock_ogdwai,
                                                        mock_gro,
                                                        mock_gpl,
                                                        mock_gnl):
         mock_get_all.return_value = [self.test_offer, self.test_offer_2]
-        mock_aoaan.side_effect = [
+        mock_ogdwai.side_effect = [
             _get_offer_response(self.test_offer, use_datetime=True),
             _get_offer_response(self.test_offer_2, use_datetime=True)]
         mock_gro.return_value = IronicNode('54321')
@@ -494,19 +493,19 @@ class TestOffersController(test_api_base.APITestCase):
         mock_get_all.assert_called_once_with(expected_filters, self.context)
         mock_gpl.assert_called_once()
         mock_gnl.assert_called_once()
-        assert mock_aoaan.call_count == 2
+        assert mock_ogdwai.call_count == 2
         self.assertEqual(request, expected_resp)
 
     @mock.patch('esi_leap.common.ironic.get_node_list')
     @mock.patch('esi_leap.common.keystone.get_project_list')
-    @mock.patch('esi_leap.api.controllers.v1.offer.' +
-                'OffersController._add_offer_availabilities_and_names')
+    @mock.patch('esi_leap.api.controllers.v1.utils.' +
+                'offer_get_dict_with_added_info')
     @mock.patch('esi_leap.objects.offer.Offer.get_all')
     @mock.patch('esi_leap.api.controllers.v1.utils.policy_authorize')
     def test_get_lessee_filter(self, mock_authorize, mock_get_all,
-                               mock_aoaan, mock_gpl, mock_gnl):
+                               mock_ogdwai, mock_gpl, mock_gnl):
         mock_get_all.return_value = [self.test_offer, self.test_offer_2]
-        mock_aoaan.side_effect = [
+        mock_ogdwai.side_effect = [
             _get_offer_response(self.test_offer, use_datetime=True),
             _get_offer_response(self.test_offer_2, use_datetime=True)]
         mock_authorize.side_effect = [
@@ -526,17 +525,17 @@ class TestOffersController(test_api_base.APITestCase):
         mock_get_all.assert_called_once_with(expected_filters, self.context)
         mock_gpl.assert_called_once()
         mock_gnl.assert_called_once()
-        assert mock_aoaan.call_count == 2
+        assert mock_ogdwai.call_count == 2
         self.assertEqual(request, expected_resp)
 
     @mock.patch('esi_leap.api.controllers.v1.utils.check_offer_lessee')
     @mock.patch('esi_leap.api.controllers.v1.utils.'
                 'check_offer_policy_and_retrieve')
-    @mock.patch('esi_leap.api.controllers.v1.offer.' +
-                'OffersController._add_offer_availabilities_and_names')
-    def test_get_one(self, mock_aoa, mock_copar, mock_col):
+    @mock.patch('esi_leap.api.controllers.v1.utils.' +
+                'offer_get_dict_with_added_info')
+    def test_get_one(self, mock_ogdwai, mock_copar, mock_col):
         mock_copar.return_value = self.test_offer
-        mock_aoa.return_value = self.test_offer.to_dict()
+        mock_ogdwai.return_value = self.test_offer.to_dict()
 
         self.get_json('/offers/' + self.test_offer.uuid)
 
@@ -545,14 +544,16 @@ class TestOffersController(test_api_base.APITestCase):
                                            self.test_offer.uuid)
         mock_col.assert_called_once_with(self.context.to_policy_values(),
                                          self.test_offer)
-        mock_aoa.assert_called_once_with(self.test_offer)
+        mock_ogdwai.assert_called_once_with(self.test_offer)
 
     @mock.patch('oslo_utils.uuidutils.generate_uuid')
     @mock.patch('esi_leap.objects.lease.Lease.create')
     @mock.patch('esi_leap.api.controllers.v1.utils.check_offer_lessee')
     @mock.patch('esi_leap.api.controllers.v1.utils.'
                 'check_offer_policy_and_retrieve')
-    def test_claim(self, mock_copar, mock_col, mock_lease_create,
+    @mock.patch('esi_leap.api.controllers.v1.utils.'
+                'lease_get_dict_with_added_info')
+    def test_claim(self, mock_lgdwai, mock_copar, mock_col, mock_lease_create,
                    mock_generate_uuid):
         lease_uuid = '12345'
         mock_generate_uuid.return_value = lease_uuid
@@ -566,13 +567,6 @@ class TestOffersController(test_api_base.APITestCase):
         request = self.post_json('/offers/' + self.test_offer.uuid + '/claim',
                                  data)
 
-        data['project_id'] = self.context.project_id
-        data['uuid'] = lease_uuid
-        data['offer_uuid'] = self.test_offer.uuid
-        data['resource_type'] = self.test_offer.resource_type
-        data['resource_uuid'] = self.test_offer.resource_uuid
-        data['owner_id'] = self.test_offer.project_id
-
         mock_copar.assert_called_once_with(self.context,
                                            'esi_leap:offer:claim',
                                            self.test_offer.uuid,
@@ -580,7 +574,7 @@ class TestOffersController(test_api_base.APITestCase):
         mock_col.assert_called_once_with(self.context.to_policy_values(),
                                          self.test_offer)
         mock_lease_create.assert_called_once()
-        self.assertEqual(data, request.json)
+        mock_lgdwai.assert_called_once()
         self.assertEqual(http_client.CREATED, request.status_int)
 
     @mock.patch('oslo_utils.uuidutils.generate_uuid')
@@ -588,7 +582,9 @@ class TestOffersController(test_api_base.APITestCase):
     @mock.patch('esi_leap.api.controllers.v1.utils.check_offer_lessee')
     @mock.patch('esi_leap.api.controllers.v1.utils.'
                 'check_offer_policy_and_retrieve')
-    def test_claim_parent_lease(self, mock_copar, mock_col,
+    @mock.patch('esi_leap.api.controllers.v1.utils.'
+                'lease_get_dict_with_added_info')
+    def test_claim_parent_lease(self, mock_lgdwai, mock_copar, mock_col,
                                 mock_lease_create, mock_generate_uuid):
         lease_uuid = '12345'
         mock_generate_uuid.return_value = lease_uuid
@@ -603,15 +599,6 @@ class TestOffersController(test_api_base.APITestCase):
             '/offers/' + self.test_offer_with_parent.uuid + '/claim',
             data)
 
-        data['project_id'] = self.context.project_id
-        data['uuid'] = lease_uuid
-        data['offer_uuid'] = self.test_offer_with_parent.uuid
-        data['resource_type'] = self.test_offer_with_parent.resource_type
-        data['resource_uuid'] = self.test_offer_with_parent.resource_uuid
-        data['owner_id'] = self.test_offer_with_parent.project_id
-        data['parent_lease_uuid'] = \
-            self.test_offer_with_parent.parent_lease_uuid
-
         mock_copar.assert_called_once_with(self.context,
                                            'esi_leap:offer:claim',
                                            self.test_offer_with_parent.uuid,
@@ -619,48 +606,5 @@ class TestOffersController(test_api_base.APITestCase):
         mock_col.assert_called_once_with(self.context.to_policy_values(),
                                          self.test_offer_with_parent)
         mock_lease_create.assert_called_once()
-        self.assertEqual(data, request.json)
+        mock_lgdwai.assert_called_once()
         self.assertEqual(http_client.CREATED, request.status_int)
-
-
-class TestOffersControllerStaticMethods(testtools.TestCase):
-
-    @mock.patch('esi_leap.common.keystone.get_project_name')
-    @mock.patch('esi_leap.objects.offer.Offer.get_availabilities')
-    def test__add_offer_availabilities_and_names(self,
-                                                 mock_get_availabilities,
-                                                 mock_gpn):
-        mock_get_availabilities.return_value = []
-        mock_gpn.return_value = 'project-name'
-
-        start = datetime.datetime(2016, 7, 16)
-        o = offer.Offer(
-            resource_type='test_node',
-            resource_uuid='1234567890',
-            name="o",
-            status=statuses.AVAILABLE,
-            start_time=start,
-            end_time=start + datetime.timedelta(days=100),
-            project_id=uuidutils.generate_uuid(),
-            lessee_id=None
-        )
-
-        o_dict = OffersController._add_offer_availabilities_and_names(o)
-
-        expected_offer_dict = {
-            'resource_type': o.resource_type,
-            'resource_uuid': o.resource_uuid,
-            'resource': 'test-node-1234567890',
-            'name': o.name,
-            'project_id': o.project_id,
-            'project': 'project-name',
-            'lessee_id': None,
-            'lessee': 'project-name',
-            'start_time': o.start_time,
-            'end_time': o.end_time,
-            'status': o.status,
-            'availabilities': [],
-        }
-
-        self.assertEqual(expected_offer_dict, o_dict)
-        self.assertEqual(2, mock_gpn.call_count)


### PR DESCRIPTION
In order to allow the lease to include the names, we have to move
lease/offer controller functions into utils.