### PR TITLE
Update exception message for subleases/suboffers

### DIFF
--- a/esi_leap/api/controllers/v1/utils.py
+++ b/esi_leap/api/controllers/v1/utils.py
@@ -42,6 +42,13 @@ def check_resource_lease_admin(cdict, resource, project_id,
                 if start_time >= parent_lease.start_time and \
                    end_time <= parent_lease.end_time:
                     return parent_lease_uuid
+                else:
+                    raise exception.ResourceNoPermissionTime(
+                        resource_type=resource.resource_type,
+                        resource_uuid=resource.get_resource_uuid(),
+                        start_time=start_time,
+                        end_time=end_time)
+
     return
 
 

--- a/esi_leap/common/exception.py
+++ b/esi_leap/common/exception.py
@@ -115,6 +115,12 @@ class ResourceNoPermission(ESILeapException):
                 "%(resource_type)s %(resource_uuid)s.")
 
 
+class ResourceNoPermissionTime(ESILeapException):
+    msg_fmt = _("You do not have permissions on "
+                "%(resource_type)s %(resource_uuid)s for the time range "
+                "%(start_time)s - %(end_time)s.")
+
+
 class ResourceTypeUnknown(ESILeapException):
     msg_fmt = _("%(resource_type)s resource type unknown.")
 

--- a/esi_leap/tests/api/controllers/v1/test_utils.py
+++ b/esi_leap/tests/api/controllers/v1/test_utils.py
@@ -457,17 +457,17 @@ class TestCheckResourceLeaseAdminUtils(testtools.TestCase):
                                                  mock_glu,
                                                  mock_lease_get):
         mock_lease_get.return_value = self.test_lease
-        parent_lease_uuid = utils.check_resource_lease_admin(
-            owner_ctx.to_policy_values(),
-            test_node_1,
-            test_offer.project_id,
-            datetime.datetime(2016, 7, 15, 19, 20, 30),
-            datetime.datetime(2016, 8, 16, 19, 20, 30))
+        self.assertRaises(exception.ResourceNoPermissionTime,
+                          utils.check_resource_lease_admin,
+                          owner_ctx.to_policy_values(),
+                          test_node_1,
+                          test_offer.project_id,
+                          datetime.datetime(2016, 7, 15, 19, 20, 30),
+                          datetime.datetime(2016, 8, 16, 19, 20, 30))
 
         mock_gpi.assert_called_once()
         mock_glu.assert_called_once()
         mock_lease_get.assert_called_once_with('a-lease-uuid')
-        self.assertIsNone(parent_lease_uuid)
 
 
 class TestOfferPolicyAndRetrieveUtils(testtools.TestCase):


### PR DESCRIPTION
Updates the exception when a lessee tries to create a sublease/suboffer
that falls outside of the lease's range.