### PR TITLE
Removing restriction to delete Offer / Lease

### DIFF
--- a/esi_leap/api/controllers/v1/offer.py
+++ b/esi_leap/api/controllers/v1/offer.py
@@ -46,6 +46,7 @@ class Offer(base.ESILEAPBase):
     resource_type = wsme.wsattr(wtypes.text)
     resource_uuid = wsme.wsattr(wtypes.text, mandatory=True)
     resource = wsme.wsattr(wtypes.text, readonly=True)
+    resource_class = wsme.wsattr(wtypes.text)
     start_time = wsme.wsattr(datetime.datetime)
     end_time = wsme.wsattr(datetime.datetime)
     status = wsme.wsattr(wtypes.text, readonly=True)
@@ -59,7 +60,8 @@ class Offer(base.ESILEAPBase):
         for field in self.fields:
             setattr(self, field, kwargs.get(field, wtypes.Unset))
 
-        for attr in ['availabilities', 'project', 'lessee', 'resource']:
+        for attr in ['availabilities', 'project', 'lessee',
+                     'resource', 'resource_class']:
             setattr(self, attr, kwargs.get(attr, wtypes.Unset))
 
 
@@ -90,11 +92,12 @@ class OffersController(rest.RestController):
         return Offer(**o)
 
     @wsme_pecan.wsexpose(OfferCollection, wtypes.text, wtypes.text,
-                         wtypes.text, datetime.datetime, datetime.datetime,
+                         wtypes.text, wtypes.text, datetime.datetime,
                          datetime.datetime, datetime.datetime,
-                         wtypes.text)
+                         datetime.datetime, wtypes.text)
     def get_all(self, project_id=None, resource_type=None,
-                resource_uuid=None, start_time=None, end_time=None,
+                resource_class=None, resource_uuid=None,
+                start_time=None, end_time=None,
                 available_start_time=None, available_end_time=None,
                 status=None):
         request = pecan.request.context
@@ -136,7 +139,7 @@ class OffersController(rest.RestController):
                 a_end=available_end_time)
 
         if status is None:
-            status = statuses.AVAILABLE
+            status = statuses.OFFER_CAN_DELETE
         elif status == 'any':
             status = None
 
@@ -165,14 +168,21 @@ class OffersController(rest.RestController):
 
         offer_collection = OfferCollection()
         offers = offer_obj.Offer.get_all(filters, request)
+
         offer_collection.offers = []
         if len(offers) > 0:
             project_list = keystone.get_project_list()
             node_list = ironic.get_node_list()
-            offer_collection.offers = [
-                Offer(**utils.offer_get_dict_with_added_info(
-                    o, project_list, node_list))
-                for o in offers]
+            offers_with_added_info = [Offer(**utils.
+                                            offer_get_dict_with_added_info(
+                                                o, project_list, node_list))
+                                      for o in offers]
+            if resource_class:
+                offer_collection.offers = [o for o in offers_with_added_info
+                                           if o.resource_class ==
+                                           resource_class]
+            else:
+                offer_collection.offers = offers_with_added_info
 
         return offer_collection
 
@@ -187,7 +197,6 @@ class OffersController(rest.RestController):
         offer_dict['uuid'] = uuidutils.generate_uuid()
         if 'resource_type' not in offer_dict:
             offer_dict['resource_type'] = CONF.api.default_resource_type
-
         resource = ro_factory.ResourceObjectFactory.get_resource_object(
             offer_dict['resource_type'], offer_dict['resource_uuid'])
         offer_dict['resource_uuid'] = resource.get_resource_uuid()
@@ -229,7 +238,8 @@ class OffersController(rest.RestController):
         request = pecan.request.context
 
         offer = utils.check_offer_policy_and_retrieve(
-            request, 'esi_leap:offer:delete', offer_id, statuses.AVAILABLE)
+            request, 'esi_leap:offer:delete', offer_id,
+            statuses.OFFER_CAN_DELETE)
         offer.cancel()
 
     @wsme_pecan.wsexpose(lease.Lease, wtypes.text, body=lease.Lease,

--- a/esi_leap/api/controllers/v1/utils.py
+++ b/esi_leap/api/controllers/v1/utils.py
@@ -52,16 +52,16 @@ def check_resource_lease_admin(cdict, resource, project_id,
     return
 
 
-def get_offer(uuid_or_name, status_filter=None):
+def get_offer(uuid_or_name, status_filters=[]):
     if uuidutils.is_uuid_like(uuid_or_name):
         o = offer_obj.Offer.get(uuid_or_name)
-        if not status_filter or o.status == status_filter:
+        if not status_filters or o.status in status_filters:
             return o
         else:
             raise exception.OfferNotFound(offer_uuid=uuid_or_name)
     else:
         offer_objs = offer_obj.Offer.get_all({'name': uuid_or_name,
-                                              'status': status_filter})
+                                              'status': status_filters})
 
         if len(offer_objs) > 1:
             raise exception.OfferDuplicateName(
@@ -122,8 +122,8 @@ def check_lease_policy_and_retrieve(request, policy_name, lease_ident,
 
 
 def check_offer_policy_and_retrieve(request, policy_name, offer_ident,
-                                    status_filter=None):
-    offer = get_offer(offer_ident, status_filter)
+                                    status_filters=[]):
+    offer = get_offer(offer_ident, status_filters)
 
     cdict = request.to_policy_values()
     target = dict(cdict)
@@ -161,6 +161,7 @@ def offer_get_dict_with_added_info(offer,
     o['lessee'] = keystone.get_project_name(offer.lessee_id,
                                             project_list)
     o['resource'] = resource.get_resource_name(node_list)
+    o['resource_class'] = resource.get_resource_class()
     return o
 
 
@@ -173,4 +174,5 @@ def lease_get_dict_with_added_info(lease, project_list=None, node_list=None):
     lease_dict['owner'] = keystone.get_project_name(lease.owner_id,
                                                     project_list)
     lease_dict['resource'] = resource.get_resource_name(node_list)
+    lease_dict['resource_class'] = resource.get_resource_class()
     return lease_dict

--- a/esi_leap/cmd/dbsync.py
+++ b/esi_leap/cmd/dbsync.py
@@ -30,6 +30,21 @@ class DBCommand(object):
     def create_schema(self):
         migration.create_schema()
 
+    def upgrade(self):
+        migration.upgrade(CONF.command.revision)
+
+    def downgrade(self):
+        migration.downgrade(CONF.command.revision)
+
+    def stamp(self):
+        migration.stamp(CONF.command.revision)
+
+    def revision(self):
+        migration.revision(CONF.command.message, CONF.command.autogenerate)
+
+    def version(self):
+        print(migration.version())
+
 
 def add_command_parsers(subparsers):
     command_object = DBCommand()
@@ -38,6 +53,36 @@ def add_command_parsers(subparsers):
         'create_schema',
         help=_("Create the database schema."))
     parser.set_defaults(func=command_object.create_schema)
+
+    parser = subparsers.add_parser(
+        'upgrade',
+        help=_("Upgrade the database."))
+    parser.set_defaults(func=command_object.upgrade)
+    parser.add_argument('--revision', nargs='?')
+
+    parser = subparsers.add_parser(
+        'downgrade',
+        help=_("Downgrade the database."))
+    parser.set_defaults(func=command_object.downgrade)
+    parser.add_argument('--revision', nargs='?')
+
+    parser = subparsers.add_parser(
+        'stamp',
+        help=_("Stamp the database with provided revision."))
+    parser.set_defaults(func=command_object.stamp)
+    parser.add_argument('--revision', nargs='?')
+
+    parser = subparsers.add_parser(
+        'revision',
+        help=_("Creates template for migration"))
+    parser.set_defaults(func=command_object.revision)
+    parser.add_argument('-m', '--message')
+    parser.add_argument('--autogenerate', action='store_true')
+
+    parser = subparsers.add_parser(
+        'version',
+        help=_("Print the current version information and exit."))
+    parser.set_defaults(func=command_object.version)
 
 
 def main():

--- a/esi_leap/common/statuses.py
+++ b/esi_leap/common/statuses.py
@@ -16,3 +16,5 @@ DELETED = 'deleted'
 CREATED = 'created'
 ERROR = 'error'
 EXPIRED = 'expired'
+OFFER_CAN_DELETE = ['available', 'error']
+LEASE_CAN_DELETE = ['active', 'created', 'error']

--- a/esi_leap/db/api.py
+++ b/esi_leap/db/api.py
@@ -157,6 +157,5 @@ def resource_check_admin(resource_type, resource_uuid,
                          start_time, end_time,
                          default_admin_project_id, project_id):
     return IMPL.resource_check_admin(
-        resource_type, resource_uuid,
-        start_time, end_time,
+        resource_type, resource_uuid, start_time, end_time,
         default_admin_project_id, project_id)

--- a/esi_leap/db/migration.py
+++ b/esi_leap/db/migration.py
@@ -11,9 +11,12 @@
 #    under the License.
 
 from oslo_config import cfg
+from oslo_log import log as logging
 from stevedore import driver
 
 _IMPL = None
+
+LOG = logging.getLogger(__name__)
 
 
 def get_backend():
@@ -31,3 +34,19 @@ def version():
 
 def create_schema():
     return get_backend().create_schema()
+
+
+def upgrade(revision=None):
+    return get_backend().upgrade(revision)
+
+
+def downgrade(revision=None):
+    return get_backend().downgrade(revision)
+
+
+def stamp(revision):
+    return get_backend().stamp(revision)
+
+
+def revision(message, autogenerate):
+    return get_backend().revision(message, autogenerate)

--- a/esi_leap/db/sqlalchemy/alembic.ini
+++ b/esi_leap/db/sqlalchemy/alembic.ini
@@ -1,0 +1,89 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = %(here)s/alembic
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.
+prepend_sys_path = .
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to alembic/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat alembic/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+#sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = INFO
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/esi_leap/db/sqlalchemy/alembic/README.md
+++ b/esi_leap/db/sqlalchemy/alembic/README.md
@@ -1,0 +1,18 @@
+### DB Migration
+
+#### Create a DB revision
+1. Change the data models in models.py.
+2. Run `esi-leap-dbsync revision -m "xxx" --autogenerate`.
+3. Note: `autogenerate` may not detect the changes. See [details](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) here. You can adjust the migration script manually based on your data model changes.
+
+#### Upgrade
+`esi-leap-dbsync upgrade --revision <id>`
+
+#### Downgrade
+`esi-leap-dbsync downgrade --revision <id>`
+
+#### Version
+`esi-leap-dbsync version`
+
+#### Stamp
+`esi-leap-dbsync stamp --revision <id>`

--- a/esi_leap/db/sqlalchemy/alembic/env.py
+++ b/esi_leap/db/sqlalchemy/alembic/env.py
@@ -1,0 +1,62 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from alembic import context
+
+from esi_leap.db.sqlalchemy import models
+
+from logging.config import fileConfig
+
+from oslo_db.sqlalchemy import enginefacade
+from oslo_log import log as logging
+
+
+LOG = logging.getLogger(__name__)
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = models.Base.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    engine = enginefacade.writer.get_engine()
+    with engine.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+run_migrations_online()

--- a/esi_leap/db/sqlalchemy/alembic/script.py.mako
+++ b/esi_leap/db/sqlalchemy/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/esi_leap/db/sqlalchemy/api.py
+++ b/esi_leap/db/sqlalchemy/api.py
@@ -118,10 +118,14 @@ def offer_get_all(filters):
     start = filters.pop('start_time', None)
     end = filters.pop('end_time', None)
     time_filter_type = filters.pop('time_filter_type', None)
+    status = filters.pop('status', None)
     a_start = filters.pop('available_start_time', None)
     a_end = filters.pop('available_end_time', None)
 
     query = query.filter_by(**filters)
+
+    if status:
+        query = query.filter((models.Offer.status.in_(status)))
 
     if lessee_id:
         lessee_id_list = keystone.get_parent_project_id_tree(lessee_id)

--- a/esi_leap/db/sqlalchemy/migration.py
+++ b/esi_leap/db/sqlalchemy/migration.py
@@ -10,9 +10,87 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from oslo_db.sqlalchemy import enginefacade
+import alembic
+from alembic import config as alembic_config
+import alembic.migration as alembic_migration
 
 from esi_leap.db.sqlalchemy import models
+
+import os
+from oslo_db.sqlalchemy import enginefacade
+from oslo_log import log as logging
+
+
+LOG = logging.getLogger(__name__)
+
+
+def _alembic_config():
+    path = os.path.join(os.path.dirname(__file__), 'alembic.ini')
+    config = alembic_config.Config(path)
+    return config
+
+
+def version(config=None, engine=None):
+    """Current database version.
+
+    :returns: Database version
+    :rtype: string
+    """
+    if engine is None:
+        engine = enginefacade.writer.get_engine()
+    with engine.connect() as conn:
+        context = alembic_migration.MigrationContext.configure(conn)
+        return context.get_current_revision()
+
+
+def upgrade(revision, config=None):
+    """Used for upgrading database.
+
+    :param version: Desired database version
+    :type version: string
+    """
+    revision = revision or 'head'
+    config = config or _alembic_config()
+
+    alembic.command.upgrade(config, revision or 'head')
+
+
+def downgrade(revision, config=None):
+    """Used for downgrading database.
+
+    :param version: Desired database version
+    :type version: string
+    """
+    revision = revision or 'base'
+    config = config or _alembic_config()
+    return alembic.command.downgrade(config, revision)
+
+
+def stamp(revision, config=None):
+    """Stamps database with provided revision.
+
+    Don't run any migrations.
+
+    :param revision: Should match one from repository or head - to stamp
+                     database with most recent revision
+    :type revision: string
+    """
+    config = config or _alembic_config()
+    return alembic.command.stamp(config, revision=revision)
+
+
+def revision(message=None, autogenerate=False, config=None):
+    """Creates template for migration.
+
+    :param message: Text that will be used for migration title
+    :type message: string
+    :param autogenerate: If True - generates diff based on current database
+                         state
+    :type autogenerate: bool
+    """
+    config = config or _alembic_config()
+    return alembic.command.revision(config, message=message,
+                                    autogenerate=autogenerate)
 
 
 def create_schema(config=None, engine=None):
@@ -23,3 +101,4 @@ def create_schema(config=None, engine=None):
     if engine is None:
         engine = enginefacade.writer.get_engine()
     models.Base.metadata.create_all(engine)
+    stamp('head', config=config)

--- a/esi_leap/manager/service.py
+++ b/esi_leap/manager/service.py
@@ -90,7 +90,7 @@ class ManagerService(service.Service):
 
     def _expire_offers(self):
         LOG.info("Checking for expiring offers")
-        offers = offer_obj.Offer.get_all({'status': statuses.AVAILABLE},
+        offers = offer_obj.Offer.get_all({'status': statuses.OFFER_CAN_DELETE},
                                          self._context)
 
         for offer in offers:

--- a/esi_leap/objects/lease.py
+++ b/esi_leap/objects/lease.py
@@ -120,7 +120,7 @@ class Lease(base.ESILEAPObject):
             lease.cancel()
         offers = offer_obj.Offer.get_all(
             {'parent_lease_uuid': self.uuid,
-             'status': statuses.AVAILABLE},
+             'status': statuses.OFFER_CAN_DELETE},
             None)
         for offer in offers:
             offer.cancel()
@@ -178,7 +178,7 @@ class Lease(base.ESILEAPObject):
             lease.expire(context)
         offers = offer_obj.Offer.get_all(
             {'parent_lease_uuid': self.uuid,
-             'status': statuses.AVAILABLE},
+             'status': statuses.OFFER_CAN_DELETE},
             None)
         for offer in offers:
             offer.expire(context)

--- a/esi_leap/resource_objects/base.py
+++ b/esi_leap/resource_objects/base.py
@@ -51,6 +51,12 @@ class ResourceObjectInterface(object, metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
+    def get_resource_class(self):
+        """Returns resource's associated class, if any
+
+        """
+
+    @abc.abstractmethod
     def set_lease(self, lease):
         """Set the lease on the node
 

--- a/esi_leap/resource_objects/dummy_node.py
+++ b/esi_leap/resource_objects/dummy_node.py
@@ -49,6 +49,11 @@ class DummyNode(base.ResourceObjectInterface):
             node_dict = json.load(node_file)
         return node_dict.get("server_config", None)
 
+    def get_resource_class(self):
+        with open(self._path) as node_file:
+            node_dict = json.load(node_file)
+        return node_dict.get("resource_class", None)
+
     def set_lease(self, lease):
         with open(self._path) as node_file:
             node_dict = json.load(node_file)

--- a/esi_leap/resource_objects/ironic_node.py
+++ b/esi_leap/resource_objects/ironic_node.py
@@ -58,6 +58,10 @@ class IronicNode(base.ResourceObjectInterface):
         config.pop('lease_uuid', None)
         return config
 
+    def get_resource_class(self):
+        node = get_ironic_client().node.get(self._uuid)
+        return node.resource_class
+
     def set_lease(self, lease):
         patches = []
         patches.append({

--- a/esi_leap/resource_objects/test_node.py
+++ b/esi_leap/resource_objects/test_node.py
@@ -36,6 +36,9 @@ class TestNode(base.ResourceObjectInterface):
     def get_node_config(self):
         return {}
 
+    def get_resource_class(self):
+        return "fake"
+
     def set_lease(self, lease):
         return
 

--- a/esi_leap/tests/api/controllers/v1/test_offer.py
+++ b/esi_leap/tests/api/controllers/v1/test_offer.py
@@ -30,10 +30,15 @@ def _get_offer_response(o, use_datetime=False):
     else:
         start = '2016-07-16T00:00:00'
         end = '2016-10-24T00:00:00'
+    if o.resource_type in ['test_node', 'dummy_node']:
+        resource_class = 'fake'
+    elif o.resource_type == 'ironic_node':
+        resource_class = 'baremetal'
 
     return {
         'resource_type': o.resource_type,
         'resource_uuid': o.resource_uuid,
+        'resource_class': resource_class,
         'name': o.name,
         'project_id': o.project_id,
         'start_time': start,
@@ -358,7 +363,7 @@ class TestOffersController(test_api_base.APITestCase):
         mock_gpl.return_value = []
         mock_gnl.return_value = []
 
-        expected_filters = {'status': 'available'}
+        expected_filters = {'status': statuses.OFFER_CAN_DELETE}
         expected_resp = {'offers': [_get_offer_response(self.test_offer),
                                     _get_offer_response(self.test_offer_2)]}
 
@@ -413,7 +418,7 @@ class TestOffersController(test_api_base.APITestCase):
         mock_gnl.return_value = []
 
         expected_filters = {'project_id': self.context.project_id,
-                            'status': 'available'}
+                            'status': statuses.OFFER_CAN_DELETE}
         expected_resp = {'offers': [_get_offer_response(self.test_offer),
                                     _get_offer_response(self.test_offer_2)]}
 
@@ -444,7 +449,7 @@ class TestOffersController(test_api_base.APITestCase):
         mock_gpl.return_value = []
         mock_gnl.return_value = []
 
-        expected_filters = {'status': 'available',
+        expected_filters = {'status': statuses.OFFER_CAN_DELETE,
                             'resource_uuid': '54321',
                             'resource_type': 'test_node'}
         expected_resp = {'offers': [_get_offer_response(self.test_offer),
@@ -458,6 +463,33 @@ class TestOffersController(test_api_base.APITestCase):
         mock_gpl.assert_called_once()
         mock_gnl.assert_called_once()
         assert mock_ogdwai.call_count == 2
+        self.assertEqual(request, expected_resp)
+
+    @mock.patch('esi_leap.common.ironic.get_node_list')
+    @mock.patch('esi_leap.common.keystone.get_project_list')
+    @mock.patch('esi_leap.api.controllers.v1.utils.' +
+                'offer_get_dict_with_added_info')
+    @mock.patch('esi_leap.objects.offer.Offer.get_all')
+    def test_get_resource_class_filter(self, mock_get_all, mock_ogdwai,
+                                       mock_gpl, mock_gnl):
+        mock_get_all.return_value = [self.test_offer,
+                                     self.test_offer_2, self.test_offer_drt]
+        mock_ogdwai.side_effect = [
+            _get_offer_response(self.test_offer, use_datetime=True),
+            _get_offer_response(self.test_offer_2, use_datetime=True),
+            _get_offer_response(self.test_offer_drt, use_datetime=True)]
+        mock_gpl.return_value = []
+        mock_gnl.return_value = []
+        expected_filters = {'status': statuses.OFFER_CAN_DELETE}
+        expected_resp = {'offers': [_get_offer_response(self.test_offer),
+                                    _get_offer_response(self.test_offer_2)]}
+        request = self.get_json(
+            '/offers/?resource_class=fake')
+
+        mock_get_all.assert_called_once_with(expected_filters, self.context)
+        mock_gpl.assert_called_once()
+        mock_gnl.assert_called_once()
+        assert mock_ogdwai.call_count == 3
         self.assertEqual(request, expected_resp)
 
     @mock.patch('esi_leap.common.ironic.get_node_list')
@@ -480,7 +512,7 @@ class TestOffersController(test_api_base.APITestCase):
         mock_gpl.return_value = []
         mock_gnl.return_value = []
 
-        expected_filters = {'status': 'available',
+        expected_filters = {'status': statuses.OFFER_CAN_DELETE,
                             'resource_uuid': '54321',
                             'resource_type': 'ironic_node'}
         expected_resp = {'offers': [_get_offer_response(self.test_offer),
@@ -488,7 +520,6 @@ class TestOffersController(test_api_base.APITestCase):
 
         request = self.get_json(
             '/offers/?resource_uuid=54321')
-
         mock_gro.assert_called_once_with('ironic_node', '54321')
         mock_get_all.assert_called_once_with(expected_filters, self.context)
         mock_gpl.assert_called_once()
@@ -515,7 +546,7 @@ class TestOffersController(test_api_base.APITestCase):
         mock_gpl.return_value = []
         mock_gnl.return_value = []
 
-        expected_filters = {'status': 'available',
+        expected_filters = {'status': statuses.OFFER_CAN_DELETE,
                             'lessee_id': self.context.project_id}
         expected_resp = {'offers': [_get_offer_response(self.test_offer),
                                     _get_offer_response(self.test_offer_2)]}
@@ -608,3 +639,17 @@ class TestOffersController(test_api_base.APITestCase):
         mock_lease_create.assert_called_once()
         mock_lgdwai.assert_called_once()
         self.assertEqual(http_client.CREATED, request.status_int)
+
+    @mock.patch('esi_leap.api.controllers.v1.utils.'
+                'check_offer_policy_and_retrieve')
+    @mock.patch('esi_leap.objects.offer.Offer.cancel')
+    def test_delete(self, mock_cancel, mock_copar):
+        mock_copar.return_value = self.test_offer
+
+        self.delete_json('/offers/' + self.test_offer.uuid)
+
+        mock_copar.assert_called_once_with(self.context,
+                                           'esi_leap:offer:delete',
+                                           self.test_offer.uuid,
+                                           statuses.OFFER_CAN_DELETE)
+        mock_cancel.assert_called_once()

--- a/esi_leap/tests/api/controllers/v1/test_utils.py
+++ b/esi_leap/tests/api/controllers/v1/test_utils.py
@@ -669,6 +669,7 @@ class TestOfferGetDictWithAddedInfoUtils(testtools.TestCase):
         expected_offer_dict = {
             'resource_type': o.resource_type,
             'resource_uuid': o.resource_uuid,
+            'resource_class': 'fake',
             'resource': 'test-node-1234567890',
             'name': o.name,
             'project_id': o.project_id,
@@ -719,6 +720,7 @@ class TestLeaseGetDictWithAddedInfoUtils(testtools.TestCase):
         expected_output_dict['resource'] = 'resource-name'
         expected_output_dict['project'] = 'project-name'
         expected_output_dict['owner'] = 'project-name'
+        expected_output_dict['resource_class'] = 'fake'
 
         mock_gro.assert_called_once()
         self.assertEqual(2, mock_gpn.call_count)

--- a/esi_leap/tests/db/sqlalchemy/test_api.py
+++ b/esi_leap/tests/db/sqlalchemy/test_api.py
@@ -723,8 +723,7 @@ class TestResourceVerifyAvailabilityAPI(base.DBTestCase):
 
         start = test_lease_1['end_time'] + datetime.timedelta(days=1)
         end = test_lease_1['end_time'] + datetime.timedelta(days=5)
-        api.resource_verify_availability(r_type, r_uuid,
-                                         start, end)
+        api.resource_verify_availability(r_type, r_uuid, start, end)
 
         start = test_lease_1['start_time'] + datetime.timedelta(days=1)
         end = test_lease_1['end_time'] + datetime.timedelta(days=-1)

--- a/esi_leap/tests/manager/test_service.py
+++ b/esi_leap/tests/manager/test_service.py
@@ -147,7 +147,7 @@ class TestService(base.TestCase):
 
         assert mock_expire.call_count == 2
         mock_ga.assert_called_once_with({
-            'status': statuses.AVAILABLE
+            'status': statuses.OFFER_CAN_DELETE
         }, s._context)
 
     @mock.patch('esi_leap.objects.offer.Offer.save')
@@ -175,7 +175,7 @@ class TestService(base.TestCase):
 
         mock_expire.assert_called_once()
         mock_ga.assert_called_once_with({
-            'status': statuses.AVAILABLE
+            'status': statuses.OFFER_CAN_DELETE
         }, s._context)
         self.assertEqual(statuses.ERROR, error_offer.status)
         mock_save.assert_called_once()

--- a/esi_leap/tests/resource_objects/test_dummy_node.py
+++ b/esi_leap/tests/resource_objects/test_dummy_node.py
@@ -25,6 +25,7 @@ def get_test_dummy_node_1():
         "project_owner_id": "123456",
         "project_id": "654321",
         "lease_uuid": "001",
+        "resource_class": "fake",
         "server_config": {
             "new attribute XYZ": "new attribute XYZ",
             "cpu_type": "Intel Xeon",
@@ -39,6 +40,7 @@ def get_test_dummy_node_1():
 def get_test_dummy_node_2():
     return {
         "project_owner_id": "123456",
+        "resource_class": "fake",
         "server_config": {
             "new attribute XYZ": "new attribute XYZ",
             "cpu_type": "Intel Xeon",
@@ -99,6 +101,14 @@ class TestDummyNode(base.TestCase):
         with mock.patch('builtins.open', mock_open) as mock_file_open:
             config = self.fake_dummy_node.get_node_config()
             self.assertEqual(config, get_test_dummy_node_1()['server_config'])
+            mock_file_open.assert_called_once()
+
+    def test_get_resource_class(self):
+        mock_open = mock.mock_open(read_data=self.fake_read_data_1)
+        with mock.patch('builtins.open', mock_open) as mock_file_open:
+            resource_class = self.fake_dummy_node.get_resource_class()
+            self.assertEqual(resource_class,
+                             get_test_dummy_node_1()['resource_class'])
             mock_file_open.assert_called_once()
 
     def test_set_lease(self):

--- a/esi_leap/tests/resource_objects/test_ironic_node.py
+++ b/esi_leap/tests/resource_objects/test_ironic_node.py
@@ -27,6 +27,7 @@ class FakeIronicNode(object):
         self.properties = {"lease_uuid": "001"}
         self.provision_state = "available"
         self.uuid = "1111"
+        self.resource_class = "baremetal"
 
 
 class FakeLease(object):
@@ -106,6 +107,18 @@ class TestIronicNode(base.TestCase):
         expected_config = fake_get_node.properties
         expected_config.pop('lease_uuid', None)
         self.assertEqual(config, expected_config)
+        client_mock.assert_called_once()
+        client_mock.return_value.node.get.assert_called_once_with(
+            test_ironic_node._uuid)
+
+    @mock.patch.object(ironic_node, 'get_ironic_client', autospec=True)
+    def test_get_resource_class(self, client_mock):
+        fake_get_node = FakeIronicNode()
+        client_mock.return_value.node.get.return_value = fake_get_node
+        test_ironic_node = ironic_node.IronicNode("1111")
+        resource_class = test_ironic_node.get_resource_class()
+        expected_resource_class = fake_get_node.resource_class
+        self.assertEqual(resource_class, expected_resource_class)
         client_mock.assert_called_once()
         client_mock.return_value.node.get.assert_called_once_with(
             test_ironic_node._uuid)

--- a/esi_leap/tests/resource_objects/test_test_node.py
+++ b/esi_leap/tests/resource_objects/test_test_node.py
@@ -68,6 +68,10 @@ class TestTestNode(base.TestCase):
         config = self.fake_test_node.get_node_config()
         self.assertEqual(config, {})
 
+    def test_get_resource_class(self):
+        resource_class = self.fake_test_node.get_resource_class()
+        self.assertEqual(resource_class, 'fake')
+
     def test_set_lease(self):
         fake_lease = get_test_lease()
         self.assertEqual(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # process, which may cause wedges in the gate later.
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
 
-alembic>=0.8.10 # MIT
+alembic>=1.4.2 # MIT
 Babel!=2.4.0,>=2.3.4 # BSD
 eventlet!=0.18.3,!=0.20.1,>=0.18.2 # MIT
 iso8601>=0.1.11 # MIT

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,24 @@ name = esi-leap
 summary = ESI provider
 description-file =
     README.md
+license = Apache License, Version 2.0
+author = ESI
+author-email = esi@lists.massopen.cloud
+python-requires = >=3.6
+classifier =
+    Environment :: Console
+    Environment :: OpenStack
+    Intended Audience :: Developers
+    Intended Audience :: Information Technology
+    Intended Audience :: System Administrators
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
 
 [files]
 packages =


### PR DESCRIPTION
The restriction that only CREATED / ACTIVE lease and only AVAILABLE offers can be deleted is now removed. 
I tested this on demo server by deleting expired offers and leases and it worked.

Let me know if any more changes are required in this PR!