### PR TITLE
Added 'wait' state for leases

### DIFF
--- a/esi_leap/api/controllers/v1/lease.py
+++ b/esi_leap/api/controllers/v1/lease.py
@@ -193,7 +193,9 @@ class LeasesController(rest.RestController):
                                          resource_uuid=None):
 
         if status is None:
-            status = [statuses.CREATED, statuses.ACTIVE, statuses.ERROR]
+            status = [statuses.CREATED, statuses.ACTIVE, statuses.ERROR,
+                      statuses.WAIT_CANCEL, statuses.WAIT_EXPIRE,
+                      statuses.WAIT_FULFILL]
         elif status == 'any':
             status = None
         else:

--- a/esi_leap/common/statuses.py
+++ b/esi_leap/common/statuses.py
@@ -12,7 +12,12 @@
 
 ACTIVE = 'active'
 AVAILABLE = 'available'
-DELETED = 'deleted'
 CREATED = 'created'
+DELETED = 'deleted'
 ERROR = 'error'
 EXPIRED = 'expired'
+WAIT_CANCEL = 'wait cancel'
+WAIT_EXPIRE = 'wait expire'
+WAIT_FULFILL = 'wait fulfill'
+
+CANCELLABLE_LEASE_STATUSES = [ACTIVE, CREATED, WAIT_FULFILL]

--- a/esi_leap/objects/offer.py
+++ b/esi_leap/objects/offer.py
@@ -132,7 +132,7 @@ class Offer(base.ESILEAPObject):
         LOG.info("Deleting offer %s", self.uuid)
         leases = lease_obj.Lease.get_all(
             {'offer_uuid': self.uuid,
-             'status': [statuses.CREATED, statuses.ACTIVE]},
+             'status': statuses.CANCELLABLE_LEASE_STATUSES},
             None)
         for lease in leases:
             lease.cancel()
@@ -149,7 +149,7 @@ class Offer(base.ESILEAPObject):
         LOG.info("Expiring offer %s", self.uuid)
         leases = lease_obj.Lease.get_all(
             {'offer_uuid': self.uuid,
-             'status': [statuses.CREATED, statuses.ACTIVE]},
+             'status': statuses.CANCELLABLE_LEASE_STATUSES},
             None)
         for lease in leases:
             lease.expire(context)

--- a/esi_leap/tests/api/controllers/v1/test_lease.py
+++ b/esi_leap/tests/api/controllers/v1/test_lease.py
@@ -19,6 +19,7 @@ import testtools
 
 from esi_leap.api.controllers.v1.lease import LeasesController
 from esi_leap.common import exception
+from esi_leap.common import statuses
 from esi_leap.objects import lease as lease_obj
 from esi_leap.resource_objects.ironic_node import IronicNode
 from esi_leap.resource_objects.test_node import TestNode
@@ -729,7 +730,9 @@ class TestLeaseControllersGetAllFilters(testtools.TestCase):
 
         expected_filters = {
             'project_or_owner_id': 'adminid',
-            'status': ['created', 'active', 'error']
+            'status': [statuses.CREATED, statuses.ACTIVE, statuses.ERROR,
+                       statuses.WAIT_CANCEL, statuses.WAIT_EXPIRE,
+                       statuses.WAIT_FULFILL]
         }
 
         # admin


### PR DESCRIPTION
A lease can fail to be fulfilled or expired simply because the node
is not in the correct state. In such cases, we change the state of the
lease to 'wait' and simply try again later.