### PR TITLE
Making time-range flag inclusive for 'openstack esi lease list'

### DIFF
--- a/esi_leap/api/controllers/v1/lease.py
+++ b/esi_leap/api/controllers/v1/lease.py
@@ -22,6 +22,7 @@ import wsmeext.pecan as wsme_pecan
 from esi_leap.api.controllers import base
 from esi_leap.api.controllers import types
 from esi_leap.api.controllers.v1 import utils
+from esi_leap.common import constants
 from esi_leap.common import exception
 from esi_leap.common import ironic
 from esi_leap.common import keystone
@@ -115,6 +116,7 @@ class LeasesController(rest.RestController):
 
         lease_collection = LeaseCollection()
         leases = lease_obj.Lease.get_all(filters, request)
+
         lease_collection.leases = []
         if len(leases) > 0:
             project_list = keystone.get_project_list()
@@ -208,6 +210,7 @@ class LeasesController(rest.RestController):
             'end_time': end_time,
             'resource_type': resource_type,
             'resource_uuid': resource_uuid,
+            'time_filter_type': constants.WITHIN_TIME_FILTER,
         }
 
         if view == 'all':

--- a/esi_leap/common/constants.py
+++ b/esi_leap/common/constants.py
@@ -1,0 +1,13 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+WITHIN_TIME_FILTER = 'within'

--- a/esi_leap/db/sqlalchemy/api.py
+++ b/esi_leap/db/sqlalchemy/api.py
@@ -20,6 +20,7 @@ from oslo_log import log as logging
 import sqlalchemy as sa
 from sqlalchemy import or_
 
+from esi_leap.common import constants
 from esi_leap.common import exception
 from esi_leap.common import keystone
 from esi_leap.common import statuses
@@ -134,7 +135,7 @@ def offer_get_all(filters):
                                  models.Offer.lessee_id.in_(lessee_id_list)))
 
     if start and end:
-        if time_filter_type == 'within':
+        if time_filter_type == constants.WITHIN_TIME_FILTER:
             query = query.filter(((start <= models.Offer.start_time) &
                                   (end >= models.Offer.start_time)) |
 
@@ -294,7 +295,7 @@ def lease_get_all(filters):
         query = query.filter((models.Lease.status.in_(status)))
 
     if start and end:
-        if time_filter_type == 'within':
+        if time_filter_type == constants.WITHIN_TIME_FILTER:
             query = query.filter(((start <= models.Lease.start_time) &
                                   (end >= models.Lease.start_time)) |
 

--- a/esi_leap/tests/api/controllers/v1/test_lease.py
+++ b/esi_leap/tests/api/controllers/v1/test_lease.py
@@ -18,6 +18,7 @@ from oslo_utils import uuidutils
 import testtools
 
 from esi_leap.api.controllers.v1.lease import LeasesController
+from esi_leap.common import constants
 from esi_leap.common import exception
 from esi_leap.common import statuses
 from esi_leap.objects import lease as lease_obj
@@ -544,6 +545,7 @@ class TestLeaseControllersGetAllFilters(testtools.TestCase):
         expected_filters = {
             'status': ['random'],
             'offer_uuid': 'offeruuid',
+            'time_filter_type': constants.WITHIN_TIME_FILTER
         }
 
         # admin
@@ -577,7 +579,8 @@ class TestLeaseControllersGetAllFilters(testtools.TestCase):
     def test_lease_get_all_no_view_project_no_owner(self):
 
         expected_filters = {
-            'status': ['random']
+            'status': ['random'],
+            'time_filter_type': constants.WITHIN_TIME_FILTER
         }
 
         # admin
@@ -622,7 +625,8 @@ class TestLeaseControllersGetAllFilters(testtools.TestCase):
     def test_lease_get_all_no_view_any_projectid_owner(self):
 
         expected_filters = {
-            'status': ['random']
+            'status': ['random'],
+            'time_filter_type': constants.WITHIN_TIME_FILTER
         }
 
         # admin
@@ -679,7 +683,8 @@ class TestLeaseControllersGetAllFilters(testtools.TestCase):
     def test_lease_get_all_all_view(self):
 
         expected_filters = {
-            'status': ['random']
+            'status': ['random'],
+            'time_filter_type': constants.WITHIN_TIME_FILTER
         }
 
         # admin
@@ -719,7 +724,8 @@ class TestLeaseControllersGetAllFilters(testtools.TestCase):
         expected_filters = {
             'status': ['random'],
             'start_time': start,
-            'end_time': end
+            'end_time': end,
+            'time_filter_type': constants.WITHIN_TIME_FILTER
         }
 
         # admin
@@ -746,7 +752,8 @@ class TestLeaseControllersGetAllFilters(testtools.TestCase):
             'project_or_owner_id': 'adminid',
             'status': [statuses.CREATED, statuses.ACTIVE, statuses.ERROR,
                        statuses.WAIT_CANCEL, statuses.WAIT_EXPIRE,
-                       statuses.WAIT_FULFILL]
+                       statuses.WAIT_FULFILL],
+            'time_filter_type': constants.WITHIN_TIME_FILTER
         }
 
         # admin


### PR DESCRIPTION
Tried to do something analogous to : https://github.com/CCI-MOC/esi-leap/blob/master/esi_leap/db/sqlalchemy/api.py#L298-L302

But not sure whether it is correct since some unit tests fail...