### PR TITLE
Cleanup and optimization within esi_leap codebase

### DIFF
--- a/esi_leap/api/controllers/base.py
+++ b/esi_leap/api/controllers/base.py
@@ -17,7 +17,10 @@ from wsme import types as wtypes
 class ESILEAPBase(wtypes.Base):
 
     def to_dict(self):
-        return dict(
-            (k, getattr(self, k))
-            for k in self.fields
-            if hasattr(self, k) and getattr(self, k) != wsme.Unset)
+        esi_leap_dict = {}
+        if self.fields:
+            for key in self.fields:
+                val = getattr(self, key, wsme.Unset)
+                if val != wsme.Unset:
+                    esi_leap_dict[key] = val
+        return esi_leap_dict

--- a/esi_leap/api/controllers/types.py
+++ b/esi_leap/api/controllers/types.py
@@ -39,8 +39,6 @@ class JsonType(wtypes.UserType):
 
 class Collection(wtypes.Base):
 
-    next = wtypes.text
-
     @property
     def collection(self):
         return getattr(self, self._type)
@@ -54,7 +52,7 @@ class Collection(wtypes.Base):
             return wtypes.Unset
 
         url = url or self._type
-        q_args = ''.join(['%s=%s&' % (key, kwargs[key]) for key in kwargs])
+        q_args = ''.join(['%s=%s&' % item for item in kwargs.items()])
         next_args = '?%(args)slimit=%(limit)d&marker=%(marker)s' % {
             'args': q_args, 'limit': limit,
             'marker': getattr(self.collection[-1], 'uuid')}

--- a/esi_leap/api/controllers/v1/lease.py
+++ b/esi_leap/api/controllers/v1/lease.py
@@ -192,16 +192,14 @@ class LeasesController(rest.RestController):
                                          owner_id=None, resource_type=None,
                                          resource_uuid=None):
 
-        if status is None:
+        if status is not None:
+            status = [status] if status != 'any' else None
+        else:
             status = [statuses.CREATED, statuses.ACTIVE, statuses.ERROR,
                       statuses.WAIT_CANCEL, statuses.WAIT_EXPIRE,
                       statuses.WAIT_FULFILL]
-        elif status == 'any':
-            status = None
-        else:
-            status = [status]
 
-        possible_filters = {
+        filters = {
             'status': status,
             'offer_uuid': offer_uuid,
             'start_time': start_time,
@@ -213,8 +211,8 @@ class LeasesController(rest.RestController):
 
         if view == 'all':
             utils.policy_authorize('esi_leap:lease:lease_admin', cdict, cdict)
-            possible_filters['owner_id'] = owner_id
-            possible_filters['project_id'] = project_id
+            filters['owner_id'] = owner_id
+            filters['project_id'] = project_id
         else:
             utils.policy_authorize('esi_leap:lease:get_all', cdict, cdict)
 
@@ -223,32 +221,31 @@ class LeasesController(rest.RestController):
                     utils.policy_authorize('esi_leap:lease:lease_admin', cdict,
                                            cdict)
 
-                possible_filters['owner_id'] = owner_id
-                possible_filters['project_id'] = project_id
+                filters['owner_id'] = owner_id
+                filters['project_id'] = project_id
             else:
                 if project_id is None:
                     project_id = cdict['project_id']
-                    possible_filters['project_or_owner_id'] = project_id
+                    filters['project_or_owner_id'] = project_id
                 else:
                     if project_id != cdict['project_id']:
                         utils.policy_authorize('esi_leap:lease:lease_admin',
                                                cdict, cdict)
-                    possible_filters['project_id'] = project_id
+                    filters['project_id'] = project_id
 
-        if ((start_time and end_time is None) or
-                (end_time and start_time is None)):
+        # either both are defined or both are None
+        if bool(start_time) != bool(end_time):
+            raise exception.InvalidTimeAPICommand(resource='a lease',
+                                                  start_time=str(start_time),
+                                                  end_time=str(end_time))
+        if (start_time or end_time) and (end_time <= start_time):
             raise exception.InvalidTimeAPICommand(resource='a lease',
                                                   start_time=str(start_time),
                                                   end_time=str(end_time))
 
-        if start_time and end_time and end_time <= start_time:
-            raise exception.InvalidTimeAPICommand(resource='a lease',
-                                                  start_time=str(start_time),
-                                                  end_time=str(end_time))
-
-        filters = {}
-        for k, v in possible_filters.items():
-            if v is not None:
-                filters[k] = v
+        # unpack iterator to tuple so we can use 'del'
+        for k, v in tuple(filters.items()):
+            if v is None:
+                del filters[k]
 
         return filters

--- a/esi_leap/api/controllers/v1/node.py
+++ b/esi_leap/api/controllers/v1/node.py
@@ -41,8 +41,8 @@ class Node(base.ESILEAPBase):
     future_leases = wsme.wsattr(wtypes.text)
 
     def __init__(self, **kwargs):
-        self.fields = ['name', 'owner', 'uuid', 'offer_uuid', 'lease_uuid',
-                       'lessee', 'future_offers', 'future_leases']
+        self.fields = ('name', 'owner', 'uuid', 'offer_uuid', 'lease_uuid',
+                       'lessee', 'future_offers', 'future_leases')
         for field in self.fields:
             setattr(self, field, kwargs.get(field, wtypes.Unset))
 

--- a/esi_leap/api/controllers/v1/utils.py
+++ b/esi_leap/api/controllers/v1/utils.py
@@ -60,15 +60,16 @@ def get_offer(uuid_or_name, status_filters=[]):
         else:
             raise exception.OfferNotFound(offer_uuid=uuid_or_name)
     else:
-        offer_objs = offer_obj.Offer.get_all({'name': uuid_or_name,
-                                              'status': status_filters})
+        offers = offer_obj.Offer.get_all({'name': uuid_or_name,
+                                          'status': status_filters})
 
-        if len(offer_objs) > 1:
-            raise exception.OfferDuplicateName(name=uuid_or_name)
-        elif len(offer_objs) == 0:
-            raise exception.OfferNotFound(offer_uuid=uuid_or_name)
+        if len(offers) != 1:
+            if len(offers) == 0:
+                raise exception.OfferNotFound(offer_uuid=uuid_or_name)
+            else:
+                raise exception.OfferDuplicateName(name=uuid_or_name)
 
-        return offer_objs[0]
+        return offers[0]
 
 
 def get_lease(uuid_or_name, status_filters=[]):
@@ -82,10 +83,11 @@ def get_lease(uuid_or_name, status_filters=[]):
         leases = lease_obj.Lease.get_all({'name': uuid_or_name,
                                           'status': status_filters})
 
-        if len(leases) > 1:
-            raise exception.LeaseDuplicateName(name=uuid_or_name)
-        elif len(leases) == 0:
-            raise exception.LeaseNotFound(lease_id=uuid_or_name)
+        if len(leases) != 1:
+            if len(leases) == 0:
+                raise exception.LeaseNotFound(lease_id=uuid_or_name)
+            else:
+                raise exception.LeaseDuplicateName(name=uuid_or_name)
 
         return leases[0]
 

--- a/esi_leap/common/ironic.py
+++ b/esi_leap/common/ironic.py
@@ -48,12 +48,10 @@ def get_node_list(context=None):
 
 
 def get_node_name(node_uuid, node_list=None):
-    node_name = ''
     if node_list is None:
         node = get_ironic_client().node.get(node_uuid)
     else:
         node = next((n for n in node_list if getattr(n, 'uuid') == node_uuid),
                     None)
-    if node:
-        node_name = node.name
-    return node_name
+
+    return node.name if node else ''

--- a/esi_leap/common/keystone.py
+++ b/esi_leap/common/keystone.py
@@ -38,10 +38,11 @@ def get_keystone_client():
 
 
 def get_parent_project_id_tree(project_id):
-    project = get_keystone_client().projects.get(project_id)
+    ks_client = get_keystone_client()
+    project = ks_client.projects.get(project_id)
     project_ids = [project.id]
     while project.parent_id is not None:
-        project = get_keystone_client().projects.get(project.parent_id)
+        project = ks_client.projects.get(project.parent_id)
         project_ids.append(project.id)
     return project_ids
 
@@ -62,9 +63,6 @@ def get_project_list():
 
 
 def get_project_name(project_id, project_list=None):
-    project_name = ''
-    project = None
-
     if project_id:
         if project_list is None:
             project = get_keystone_client().projects.get(project_id)
@@ -72,7 +70,6 @@ def get_project_name(project_id, project_list=None):
             project = next((p for p in project_list
                             if getattr(p, 'id') == project_id),
                            None)
-        if project:
-            project_name = project.name
-
-    return project_name
+        return project.name if project else ''
+    else:
+        return ''

--- a/esi_leap/common/utils.py
+++ b/esi_leap/common/utils.py
@@ -13,7 +13,6 @@
 from oslo_concurrency import lockutils
 
 _prefix = 'esileap'
-synchronized = lockutils.synchronized_with_prefix(_prefix)
 lock = lockutils.lock_with_prefix(_prefix)
 
 

--- a/esi_leap/db/api.py
+++ b/esi_leap/db/api.py
@@ -60,13 +60,13 @@ def to_dict(func):
     def decorator(*args, **kwargs):
         res = func(*args, **kwargs)
 
-        if isinstance(res, list):
+        try:
             return [item.to_dict() for item in res]
-
-        if res:
-            return res.to_dict()
-        else:
-            return None
+        except (AttributeError, TypeError):
+            if res:
+                return res.to_dict()
+            else:
+                return None
 
     return decorator
 

--- a/esi_leap/objects/base.py
+++ b/esi_leap/objects/base.py
@@ -41,12 +41,6 @@ class ESILEAPObject(object_base.VersionedObject):
                 for db_obj in db_objs]
 
     def to_dict(self):
-        def _attr_as_dict(field):
-            attr = getattr(self, field)
-            if isinstance(attr, ESILEAPObject):
-                attr = attr.as_dict()
-            return attr
-
         return dict((k, getattr(self, k))
                     for k in self.fields
                     if self.obj_attr_is_set(k))

--- a/esi_leap/resource_objects/ironic_node.py
+++ b/esi_leap/resource_objects/ironic_node.py
@@ -78,9 +78,10 @@ class IronicNode(base.ResourceObjectInterface):
 
     def expire_lease(self, lease):
         patches = []
-        if self.get_lease_uuid() != lease.uuid:
+        uuid = self.get_lease_uuid()
+        if uuid != lease.uuid:
             return
-        if self.get_lease_uuid():
+        if uuid:
             patches.append({
                 'op': 'remove',
                 'path': '/properties/lease_uuid',

--- a/esi_leap/tests/api/base.py
+++ b/esi_leap/tests/api/base.py
@@ -36,6 +36,7 @@ class APITestCase(base.DBTestCase):
         self.patch_context = mock.patch(
             'oslo_context.context.RequestContext.from_environ')
         self.mock_context = self.patch_context.start()
+        self.addCleanup(self.patch_context.stop)
         self.mock_context.return_value = self.context
 
         self.config(lock_path=tempfile.mkdtemp(), group='oslo_concurrency')

--- a/esi_leap/tests/resource_objects/test_ironic_node.py
+++ b/esi_leap/tests/resource_objects/test_ironic_node.py
@@ -150,7 +150,7 @@ class TestIronicNode(base.TestCase):
                 test_ironic_node.expire_lease(fake_lease)
 
                 mock_project_id_get.assert_called_once()
-                self.assertEqual(mock_lease_uuid_true.call_count, 2)
+                mock_lease_uuid_true.assert_called_once()
                 self.assertEqual(client_mock.call_count, 3)
                 client_mock.return_value.node.update.assert_called_once()
                 client_mock.return_value.node.get.assert_called_once_with(


### PR DESCRIPTION
Some of the code in the codebase contains redundancies, has missing edge
case coverage, or is implemented in ways that could be more efficient.
This commit addresses this, implementing the following changes:

- esi_leap/api/controllers/base.py:to_dict:20-28:
  - Remove redundant getattr() calls, as the previous implementation
    called getattr() twice for every field in self.fields and contained
    a redundant hasattr() call.
  - Benchmarked as potentially twice as fast.

- esi_leap/api/controllers/types.py:41:
  - Removed the class variable 'next', as it is seemingly unused and
    since defining 'next' may cause problems with iterators.

- esi_leap/api/controllers/types.py:collection:55-57:
  - Previous implementation instantiated a list object that would be
    immediately discarded.
  - New implementation appears to be ~10% faster.

- esi_leap/api/controllers/v1/lease.py:
      _lease_get_all_authorize_filters:193-195:
  - Old implementation preformed 3 conditional checks if status is not
    None or 'any', this performs 1 check in that case and 2 checks max.

- esi_leap/api/controllers/v1/lease.py:
      _lease_get_all_authorize_filters:200:246:
- esi_leap/api/controllers/v1/offer.py:get_all:148-163:
  - The 'possible_filters' dict is redundant-- we don't need to create 2
    objects. This renames 'possible_filters' to 'filters' and deletes
    dict entries with null values at the end instead.

- esi_leap/api/controllers/v1/lease.py:
      _lease_get_all_authorize_filters:233-241:
- esi_leap/api/controllers/v1/offer.py:get_all:117-135:
  - Previous validation of start/end datetime objects performed 5-8
    checks/comparisons, this reduces that to 4.
  - Also cleans up formatting a bit in the process.

- esi_leap/api/controllers/v1/utils.py:get_offer:63-72:
  - Changed variable name to be consistent with get_lease() function.

- esi_leap/api/controllers/v1/utils.py:get_offer:66-70:
- esi_leap/api/controllers/v1/utils.py:get_lease:86-90:
  - Previous implementation always performed 2 checks, this performs 1-2
    checks with the second check only taking place if an exception is to
    be thrown

- esi_leap/common/ironic.py:get_node_name:51-60:
- esi_leap/common/keystone.py:get_project_name:66-76:
  - Eliminates redundant resource_name variable.

- esi_leap/common/keystone.py:get_parent_project_id_tree:41-45:
  - Previous implementation performed multiple calls to
    get_keystone_client(), this performs only one.

- esi_leap/db/api.py:decorator:63-69:
  - Previous version will raise error if the output of res is a non-list
    iterable (e.g. a tuple)

- esi_leap/objects/base.py:to_dict:43:
  - _attr_as_dict() defined but doesn't seem to be used. Removing it
    doesn't seem to break anything.

- esi_leap/objects/lease.py:create:68-108:
- esi_leap/objects/lease.py:cancel:123-141:
- esi_leap/objects/lease.py:fulfill:153-168:
- esi_leap/objects/lease.py:expire:183-201:
- esi_leap/objects/offer.py:create:122-152:
- esi_leap/objects/offer.py:cancel:162-166:
- esi_leap/objects/offer.py:expire:176-180:
  - Previous implementation, which created a locally-scoped decorated
    function which was immediately called is slightly slower, needs
    slightly more overhead, and is clunky. Replaced with a context
    manager.
- esi_leap/common/utils.py:16:
  - Refactoring described above removed all instances of the
    'synchronized' decorator, so it can be removed here too.
- esi_leap/objects/offer.py:cancel:162-163:
- esi_leap/objects/offer.py:expire:176-177:
  - Added external=True to lock creation command.

- esi_leap/resource_objects/ironic_node.py:expire_lease:81-84:
  - Eliminated redundant lease.get_lease_uuid() call.
- esi_leap/tests/resource_objects/test_ironic_node.py:test_expire_lease:
  - Updated to reflect elimination of redundant get_lease_uuid call.

- esi_leap/tests/api/base.py:setUp:39:
  - Patcher is now stopped upon test case teardown.