### PR TITLE
Ensured exception handling logs exception type

### DIFF
--- a/esi_leap/manager/service.py
+++ b/esi_leap/manager/service.py
@@ -72,7 +72,9 @@ class ManagerService(service.Service):
                     LOG.info('Fulfilling lease %s', lease.uuid)
                     lease.fulfill(self._context)
                 except Exception as e:
-                    LOG.info('Error fulfilling lease; setting to ERROR: %s', e)
+                    LOG.info('Error fulfilling lease: %s: %s' %
+                             (type(e).__name__, e))
+                    LOG.info('Setting lease status to ERROR')
                     lease.status = statuses.ERROR
                     lease.save()
 
@@ -89,7 +91,9 @@ class ManagerService(service.Service):
                     LOG.info('Expiring lease %s', lease.uuid)
                     lease.expire(self._context)
                 except Exception as e:
-                    LOG.info('Error expiring lease; setting to ERROR: %s', e)
+                    LOG.info('Error expiring lease: %s: %s' %
+                             (type(e).__name__, e))
+                    LOG.info('Setting lease status to ERROR')
                     lease.status = statuses.ERROR
                     lease.save()
 
@@ -99,10 +103,12 @@ class ManagerService(service.Service):
             {'status': [statuses.WAIT_CANCEL]}, self._context)
         for lease in leases:
             try:
-                LOG.info('Canceling lease %s', lease.uuid)
+                LOG.info('Cancelling lease %s', lease.uuid)
                 lease.cancel(self._context)
             except Exception as e:
-                LOG.info('Error cancelling lease; setting to ERROR: %s', e)
+                LOG.info('Error cancelling lease: %s: %s' %
+                         (type(e).__name__, e))
+                LOG.info('Setting lease status to ERROR')
                 lease.status = statuses.ERROR
                 lease.save()
 
@@ -119,7 +125,8 @@ class ManagerService(service.Service):
                              offer.resource_uuid)
                     offer.expire(self._context)
                 except Exception as e:
-                    LOG.info('Error expiring offer: %s', e)
+                    LOG.info('Error expiring offer: %s: %s' %
+                             (type(e).__name__, e))
                     offer.status = statuses.ERROR
                     offer.save()
 

--- a/esi_leap/objects/lease.py
+++ b/esi_leap/objects/lease.py
@@ -135,7 +135,9 @@ class Lease(base.ESILEAPObject):
                 self.status = statuses.DELETED
                 self.expire_time = datetime.datetime.now()
             except Exception as e:
-                LOG.info('Error canceling lease; setting to WAIT: %s', e)
+                LOG.info('Error canceling lease: %s: %s' %
+                         (type(e).__name__, e))
+                LOG.info('Setting lease status to WAIT')
                 self.status = statuses.WAIT_CANCEL
             self.save(None)
 
@@ -162,7 +164,9 @@ class Lease(base.ESILEAPObject):
                 self.status = statuses.ACTIVE
                 self.fulfill_time = datetime.datetime.now()
             except Exception as e:
-                LOG.info('Error fulfilling lease; setting to WAIT: %s', e)
+                LOG.info('Error fulfilling lease: %s: %s' %
+                         (type(e).__name__, e))
+                LOG.info('Setting lease status to WAIT')
                 self.status = statuses.WAIT_FULFILL
             self.save(context)
 
@@ -195,7 +199,9 @@ class Lease(base.ESILEAPObject):
                 self.status = statuses.EXPIRED
                 self.expire_time = datetime.datetime.now()
             except Exception as e:
-                LOG.info('Error expiring lease; setting to WAIT: %s', e)
+                LOG.info('Error expiring lease: %s: %s' %
+                         (type(e).__name__, e))
+                LOG.info('Setting lease status to WAIT')
                 self.status = statuses.WAIT_EXPIRE
             self.save(context)
 


### PR DESCRIPTION
If an operation on an object fails with an exception, the exception
message will be displayed, but currently, the type is excluded. This is
not ideal-- if an exception like OutOfMemory('64G/64G') was raised, the
message may not provide enough context to solve the root problem. This
patch addresses this.

Addresses #267.