### PR TITLE
Add state fields to node controller

### DIFF
--- a/esi_leap/api/controllers/v1/node.py
+++ b/esi_leap/api/controllers/v1/node.py
@@ -33,6 +33,8 @@ class Node(base.ESILEAPBase):
 
     name = wsme.wsattr(wtypes.text)
     owner = wsme.wsattr(wtypes.text)
+    maintenance = wsme.wsattr(wtypes.text)
+    provision_state = wsme.wsattr(wtypes.text)
     uuid = wsme.wsattr(wtypes.text)
     offer_uuid = wsme.wsattr(wtypes.text)
     lease_uuid = wsme.wsattr(wtypes.text)
@@ -42,7 +44,8 @@ class Node(base.ESILEAPBase):
 
     def __init__(self, **kwargs):
         self.fields = ('name', 'owner', 'uuid', 'offer_uuid', 'lease_uuid',
-                       'lessee', 'future_offers', 'future_leases')
+                       'lessee', 'future_offers', 'future_leases',
+                       'provision_state', 'maintenance')
         for field in self.fields:
             setattr(self, field, kwargs.get(field, wtypes.Unset))
 
@@ -91,6 +94,8 @@ class NodesController(rest.RestController):
                                      if lease.resource_uuid == node.uuid])
 
             n = Node(name=node.name, uuid=node.uuid,
+                     provision_state=node.provision_state,
+                     maintenance=str(node.maintenance),
                      owner=keystone.get_project_name(node.owner, project_list),
                      lessee=keystone.get_project_name(node.lessee,
                                                       project_list),

--- a/esi_leap/tests/api/controllers/v1/test_node.py
+++ b/esi_leap/tests/api/controllers/v1/test_node.py
@@ -22,6 +22,8 @@ class FakeIronicNode(object):
         self.uuid = 'fake-uuid'
         self.properties = {'lease_uuid': 'fake-lease-uuid'}
         self.lessee = 'fake-project-uuid'
+        self.maintenance = False
+        self.provision_state = 'active'
 
 
 class FakeProject(object):


### PR DESCRIPTION
When displaying node information, it's often useful to be able to
see the node's provisioning state and maintenance info.