### PR TITLE
openstack esi lease list/show bug

### DIFF
--- a/esi_leap/resource_objects/ironic_node.py
+++ b/esi_leap/resource_objects/ironic_node.py
@@ -15,10 +15,22 @@ from oslo_utils.uuidutils import is_uuid_like
 from esi_leap.common import ironic
 import esi_leap.conf
 from esi_leap.resource_objects import base
+from ironicclient.common.apiclient import exceptions
 
 
 CONF = esi_leap.conf.CONF
 _cached_ironic_client = None
+
+
+class UnknownIronicNode(object):
+    def __init__(self):
+        self.name = 'unknown-node'
+        self.owner = ''
+        self.uuid = 'unknown-uuid'
+        self.properties = {}
+        self.lessee = ''
+        self.maintenance = False
+        self.provision_state = 'unknown'
 
 
 def get_ironic_client():
@@ -101,6 +113,10 @@ class IronicNode(base.ResourceObjectInterface):
         return self._get_node().owner
 
     def _get_node(self, resource_list=None):
-        if not self._node:
-            self._node = ironic.get_node(self._uuid, resource_list)
+        try:
+            if not self._node:
+                self._node = ironic.get_node(self._uuid, resource_list)
+        except exceptions.NotFound:
+            self._node = UnknownIronicNode()
+
         return self._node

--- a/esi_leap/tests/resource_objects/test_ironic_node.py
+++ b/esi_leap/tests/resource_objects/test_ironic_node.py
@@ -14,6 +14,7 @@ import datetime
 from esi_leap.common import statuses
 from esi_leap.resource_objects import ironic_node
 from esi_leap.tests import base
+from ironicclient.common.apiclient import exceptions
 import mock
 
 start = datetime.datetime(2016, 7, 16, 19, 20, 30)
@@ -197,3 +198,12 @@ class TestIronicNode(base.TestCase):
         self.assertEqual(fake_get_node,
                          test_ironic_node._get_node())
         mock_gn.assert_not_called
+
+    @mock.patch('esi_leap.common.ironic.get_node')
+    def test_get_unknown_node(self, mock_gn):
+        unknown_get_node = ironic_node.UnknownIronicNode()
+        mock_gn.side_effect = exceptions.NotFound
+        test_unknown_node = ironic_node.IronicNode(fake_uuid)
+        test_unknown_node._node = unknown_get_node
+        self.assertEqual(type(unknown_get_node),
+                         type(ironic_node.UnknownIronicNode()))


### PR DESCRIPTION
Below is the stack trace from /var/log/esi-leap/esi-leap-api.log:

```
Traceback (most recent call last):

  File "/usr/local/lib/python3.6/site-packages/wsmeext/pecan.py", line 84, in callfunction
    result = f(self, *args, **kwargs)

  File "/usr/local/lib/python3.6/site-packages/esi_leap/api/controllers/v1/lease.py", line 84, in get_one
    return Lease(**utils.lease_get_dict_with_added_info(lease))

  File "/usr/local/lib/python3.6/site-packages/esi_leap/api/controllers/v1/utils.py", line 170, in lease_get_dict_with_added_info
    lease_dict['resource'] = resource.get_resource_name(node_list)

  File "/usr/local/lib/python3.6/site-packages/esi_leap/resource_objects/ironic_node.py", line 47, in get_resource_name
    return getattr(self._get_node(resource_list), 'name', '')

  File "/usr/local/lib/python3.6/site-packages/esi_leap/resource_objects/ironic_node.py", line 105, in _get_node
    self._node = ironic.get_node(self._uuid, resource_list)

  File "/usr/local/lib/python3.6/site-packages/esi_leap/common/ironic.py", line 52, in get_node
    node = get_ironic_client().node.get(node_uuid)

  File "/usr/lib/python3.6/site-packages/ironicclient/v1/node.py", line 380, in get
    global_request_id=global_request_id)

  File "/usr/lib/python3.6/site-packages/ironicclient/common/base.py", line 95, in _get
    global_request_id=global_request_id)[0]

  File "/usr/lib/python3.6/site-packages/ironicclient/common/base.py", line 236, in _list
    global_request_id=global_request_id)

  File "/usr/lib/python3.6/site-packages/ironicclient/common/base.py", line 224, in __list
    resp, body = self.api.json_request('GET', url, **kwargs)

  File "/usr/lib/python3.6/site-packages/ironicclient/common/http.py", line 405, in json_request
    resp = self._http_request(url, method, **kwargs)

  File "/usr/lib/python3.6/site-packages/ironicclient/common/http.py", line 287, in wrapper
    return func(self, url, method, **kwargs)

  File "/usr/lib/python3.6/site-packages/ironicclient/common/http.py", line 387, in _http_request
    error_json.get('debuginfo'), method, url)
```

ironicclient.common.apiclient.exceptions.NotFound: Node d747d1fb-5da0-40c0-a025-943e84b93669 could not be found. (HTTP 404)


Not sure whether I need to make some changes to ironic related python code (stack trace ironic_node.py, ironic.py)
Please let me know!