### PR TITLE
Fixed ESI-Leap API WSGI script

### DIFF
--- a/esi_leap/api/app.py
+++ b/esi_leap/api/app.py
@@ -61,3 +61,12 @@ def setup_app(config=None):
         app = auth_token.AuthProtocol(app, dict(CONF.keystone_authtoken))
 
     return app
+
+
+class WSGIApplication(object):
+    def __init__(self):
+        pecan_cfg = get_pecan_config()
+        self.app = setup_app(pecan_cfg)
+
+    def __call__(self, environ, start_response):
+        return self.app(environ, start_response)

--- a/esi_leap/api/wsgi.py
+++ b/esi_leap/api/wsgi.py
@@ -10,10 +10,26 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import oslo_i18n as i18n
+import sys
 
-_translators = i18n.TranslatorFactory(domain='esi-leap')
+from oslo_log import log as logging
 
-# The primary translation function using the well-known name "_"
-_ = _translators.primary
-install = i18n.install
+from esi_leap.api.app import WSGIApplication
+from esi_leap.common import i18n
+from esi_leap.common import service
+import esi_leap.conf
+
+
+CONF = esi_leap.conf.CONF
+LOG = logging.getLogger(__name__)
+
+
+def initialize_wsgi_app(argv=sys.argv):
+    i18n.install('esi_leap')
+
+    service.prepare_service(argv)
+
+    LOG.debug('Configuration:')
+    CONF.log_opt_values(LOG, logging.DEBUG)
+
+    return WSGIApplication()

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ console_scripts =
     esi-leap-manager = esi_leap.cmd.manager:main
 
 wsgi_scripts =
-    esi-leap-wsgi-api = esi_leap.api.wsgi:init
+    esi-leap-api-wsgi = esi_leap.api.wsgi:initialize_wsgi_app
 
 esi_leap.database.migration_backend =
     sqlalchemy = esi_leap.db.sqlalchemy.migration


### PR DESCRIPTION
Previously, the ESI-Leap install process would create an executable script `esi-leap-wsgi-api` which did nothing and was broken. This pull request adds the missing functionality and allows ESI-Leap to be run properly via uWSGI and the like. The script was also renamed to `esi-leap-api-wsgi` from `esi-leap-wsgi-api` to better mirror the naming convention of other OpenStack services (and since the script was broken no one was using it anyway so this should not be an issue)