### PR TITLE
Fixed dnspython dependency breakage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pbr!=2.1.0,>=2.0.0 # Apache-2.0
 alembic>=1.4.2 # MIT
 Babel!=2.4.0,>=2.3.4 # BSD
 eventlet!=0.18.3,!=0.20.1,>=0.18.2 # MIT
+dnspython==2.2.1 # ISC
 iso8601>=0.1.11 # MIT
 keystoneauth1>=3.4.0 # Apache-2.0
 keystonemiddleware>=4.17.0 # Apache-2.0


### PR DESCRIPTION
Recently, esi-leap has been failing to run on Python 3.7 or later with a new error. Somewhere in the process of importing `oslo_versionedobjects.base`, we run into the error `AttributeError: module 'dns.rdtypes' has no attribute 'ANY'`. `oslo_versionedobjects` depends on `oslo_concurrency`,  which in turn depends on `eventlet`, and it would appear that an update either to `eventlet` or `dnspython` has caused breakage. Others seem to be reporting similar issues, which is where I found this fix: https://stackoverflow.com/questions/75137717/eventlet-dns-python-attribute-error-module-dns-rdtypes-has-no-attribute-any/75137718. Since this is breaking other peoples' things, I imagine this will be addressed by package maintainers eventually, but for now this will solve the issue.