### PR TITLE
Updated CI, fixed dependency issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,15 +5,15 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ pbr!=2.1.0,>=2.0.0 # Apache-2.0
 
 alembic>=1.4.2 # MIT
 Babel!=2.4.0,>=2.3.4 # BSD
-eventlet!=0.18.3,!=0.20.1,>=0.18.2 # MIT
+eventlet>=0.33.3 # MIT
+importlib-metadata<5.0.0; python_version<'3.8' # Apache-2.0
 iso8601>=0.1.11 # MIT
 keystoneauth1>=3.4.0 # Apache-2.0
 keystonemiddleware>=4.17.0 # Apache-2.0
@@ -31,7 +32,7 @@ sqlalchemy-migrate>=0.11.0 # Apache-2.0
 requests>=2.18.4 # Apache-2.0
 Routes>=2.3.1 # MIT
 six>=1.10.0 # MIT
-SQLAlchemy!=1.1.5,!=1.1.6,!=1.1.7,!=1.1.8,>=1.0.10 # MIT
+SQLAlchemy!=1.1.5,!=1.1.6,!=1.1.7,!=1.1.8,>=1.0.10, <2.0 # MIT
 stevedore>=1.20.0 # Apache-2.0
 WebOb>=1.7.1 # MIT
 WSME>=0.8.0 # MIT

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ setenv = VIRTUAL_ENV={envdir}
          LC_ALL=en_US.UTF-8
          PYTHONWARNINGS=default::DeprecationWarning
          TESTS_DIR=./esi_leap/tests/
+         SQLALCHEMY_SILENCE_UBER_WARNING=1
 deps =
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
This pull request updates this project's CI config and addresses three dependency issues:

- Kombu relied on some now deprecated `importlib_metadata` behavior. This behavior has been removed in the latest version of `importlib_metadata` and Kombu has released a patch to address this. In Python 3.8, `importlib.metadata` was pulled into the CPython standard library, meaning those versions never needed to install the external `importlib_metadata` package. But since we support Python 3.6 and 3.7, and the Kombu patch has not made it into the release version (on PyPi) yet. So until it does, we should pin `importlib_metadata` to versions under 5.0.0. This fixes previous problems with running unit tests on Python 3.7. (sidenote: Python 3.6 was not affected since the newest version of `importlib_metadata` is not available for it)
- An update to `dnspython` caused a breakage in `eventlet`-- this was fixed in the latest version of `eventlet` (0.33.3) and the package is now pinned to this version or higher to prevent future dependency conflicts. Closes #128 (check that PR for more background on this).
- ESI-Leap uses features incompatible with SQLAlchemy 2.0, which produces warnings telling us to pin `sqlalchemy` to versions before 2.0. This has been done and an environment variable has been set in `tox.ini` to silence the warning.

Additionally, as part of https://github.com/CCI-MOC/esi/issues/330, this project will now lint check and run unit tests during CI for versions of Python between 3.6, the earliest version that doesn't cause [other] major dependency breakages-- thru 3.11, the newest version currently available by default on the Ubuntu 20.04 CI runner. (Ubuntu 20.04 is itself, currently the newest version of Ubuntu with Python 3.6 installed by default)
