### PR TITLE
Updated exception handling for resource objects

### DIFF
--- a/esi_leap/common/exception.py
+++ b/esi_leap/common/exception.py
@@ -144,3 +144,8 @@ class InvalidTimeRange(ESILeapException):
     msg_fmt = _('Attempted to create %(resource)s resource with an invalid '
                 'Start Time and End Time. Start Time must be strictly less '
                 'than End Time. Got %(start_time)s, %(end_time)s.')
+
+
+class NodeNotFound(ESILeapException):
+    msg_fmt = _('Encountered an error fetching info for node %(uuid)s '
+                '(%(resource_type)s): %(err)s')

--- a/esi_leap/tests/resource_objects/test_dummy_node.py
+++ b/esi_leap/tests/resource_objects/test_dummy_node.py
@@ -10,11 +10,13 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import datetime
+import json
+
+import mock
+
 from esi_leap.common import statuses
 from esi_leap.resource_objects import dummy_node
 from esi_leap.tests import base
-import json
-import mock
 
 
 start = datetime.datetime(2016, 7, 16, 19, 20, 30)
@@ -131,3 +133,9 @@ class TestDummyNode(base.TestCase):
             self.assertEqual(self.fake_admin_project_id_2,
                              self.fake_dummy_node.resource_admin_project_id())
             self.assertEqual(mock_file_open.call_count, 1)
+
+    @mock.patch('builtins.open')
+    def test_get_deleted_node_info(self, mock_open):
+        mock_open.side_effect = FileNotFoundError
+        self.assertEqual(self.fake_dummy_node.get_resource_class(),
+                         'unknown-class')

--- a/esi_leap/tests/resource_objects/test_ironic_node.py
+++ b/esi_leap/tests/resource_objects/test_ironic_node.py
@@ -11,11 +11,14 @@
 #    under the License.
 
 import datetime
+
+from ironicclient.common.apiclient import exceptions as ir_exception
+import mock
+
+from esi_leap.common import exception
 from esi_leap.common import statuses
 from esi_leap.resource_objects import ironic_node
 from esi_leap.tests import base
-from ironicclient.common.apiclient import exceptions
-import mock
 
 start = datetime.datetime(2016, 7, 16, 19, 20, 30)
 fake_uuid = '13921c8d-ce11-4b6d-99ed-10e19d184e5f'
@@ -201,9 +204,7 @@ class TestIronicNode(base.TestCase):
 
     @mock.patch('esi_leap.common.ironic.get_node')
     def test_get_unknown_node(self, mock_gn):
-        unknown_get_node = ironic_node.UnknownIronicNode()
-        mock_gn.side_effect = exceptions.NotFound
+        mock_gn.side_effect = ir_exception.NotFound
         test_unknown_node = ironic_node.IronicNode(fake_uuid)
-        test_unknown_node._node = unknown_get_node
-        self.assertEqual(type(unknown_get_node),
-                         type(ironic_node.UnknownIronicNode()))
+        self.assertRaises(exception.NodeNotFound,
+                          test_unknown_node._get_node)


### PR DESCRIPTION
Addresses #131.

Changes the internal behavior of the various `get_*` interfaces of dummy nodes and Ironic nodes to prevent uncaught internal exceptions from causing unexpected API errors.