### PR TITLE
Resource object interface refactoring

### DIFF
--- a/esi_leap/api/controllers/v1/lease.py
+++ b/esi_leap/api/controllers/v1/lease.py
@@ -104,7 +104,7 @@ class LeasesController(rest.RestController):
                 resource_type = CONF.api.default_resource_type
 
             resource = get_resource_object(resource_type, resource_uuid)
-            resource_uuid = resource.get_resource_uuid()
+            resource_uuid = resource.get_uuid()
 
         filters = LeasesController._lease_get_all_authorize_filters(
             cdict, project_id=project_id, owner_id=owner_id,
@@ -153,7 +153,7 @@ class LeasesController(rest.RestController):
             lease_dict['resource_type'] = CONF.api.default_resource_type
         resource = get_resource_object(lease_dict['resource_type'],
                                        lease_dict['resource_uuid'])
-        lease_dict['resource_uuid'] = resource.get_resource_uuid()
+        lease_dict['resource_uuid'] = resource.get_uuid()
 
         if 'project_id' in lease_dict:
             lease_dict['project_id'] = keystone.get_project_uuid_from_ident(

--- a/esi_leap/api/controllers/v1/offer.py
+++ b/esi_leap/api/controllers/v1/offer.py
@@ -112,7 +112,7 @@ class OffersController(rest.RestController):
             if resource_type is None:
                 resource_type = CONF.api.default_resource_type
             resource = get_resource_object(resource_type, resource_uuid)
-            resource_uuid = resource.get_resource_uuid()
+            resource_uuid = resource.get_uuid()
 
         # either both are defined or both are None
         if bool(start_time) != bool(end_time):
@@ -204,7 +204,7 @@ class OffersController(rest.RestController):
             offer_dict['resource_type'] = CONF.api.default_resource_type
         resource = get_resource_object(offer_dict['resource_type'],
                                        offer_dict['resource_uuid'])
-        offer_dict['resource_uuid'] = resource.get_resource_uuid()
+        offer_dict['resource_uuid'] = resource.get_uuid()
 
         if 'lessee_id' in offer_dict:
             offer_dict['lessee_id'] = keystone.get_project_uuid_from_ident(

--- a/esi_leap/objects/lease.py
+++ b/esi_leap/objects/lease.py
@@ -127,7 +127,7 @@ class Lease(base.ESILEAPObject):
             try:
                 resource = self.resource_object()
                 if resource.get_lease_uuid() == self.uuid:
-                    resource.expire_lease(self)
+                    resource.remove_lease(self)
                     if self.parent_lease_uuid is not None:
                         parent_lease = Lease.get(self.parent_lease_uuid)
                         resource.set_lease(parent_lease)
@@ -191,7 +191,7 @@ class Lease(base.ESILEAPObject):
             try:
                 resource = self.resource_object()
                 if resource.get_lease_uuid() == self.uuid:
-                    resource.expire_lease(self)
+                    resource.remove_lease(self)
                     if self.parent_lease_uuid is not None:
                         parent_lease = Lease.get(self.parent_lease_uuid)
                         resource.set_lease(parent_lease)

--- a/esi_leap/resource_objects/base.py
+++ b/esi_leap/resource_objects/base.py
@@ -21,45 +21,45 @@ class ResourceObjectInterface(object, metaclass=abc.ABCMeta):
     resource_type = 'base'
 
     @abc.abstractmethod
-    def get_resource_uuid(self):
-        """Returns resource's uuid"""
+    def get_uuid(self):
+        """Return resource's uuid"""
 
     @abc.abstractmethod
-    def get_resource_name(self, resource_list):
-        """Returns resource's name"""
-
-    @abc.abstractmethod
-    def get_lease_uuid(self):
-        """Returns resource's associated lease, if any"""
-
-    @abc.abstractmethod
-    def get_project_id(self):
-        """Returns resource's associated lessee, if any"""
-
-    @abc.abstractmethod
-    def get_node_config(self):
-        """Returns resource's associated config, if any"""
+    def get_name(self, resource_list):
+        """Return resource's name, if any"""
 
     @abc.abstractmethod
     def get_resource_class(self, resource_list):
-        """Returns resource's associated class, if any"""
+        """Return resource's associated class, if any"""
+
+    @abc.abstractmethod
+    def get_config(self):
+        """Return resource's associated config, if any"""
+
+    @abc.abstractmethod
+    def get_owner_project_id(self):
+        """Return the project id of the resource's owner"""
+
+    @abc.abstractmethod
+    def get_lease_uuid(self):
+        """Return the uuid of the associated lease, if any"""
+
+    @abc.abstractmethod
+    def get_lessee_project_id(self):
+        """Return the project id of the associated lessee, if any"""
 
     @abc.abstractmethod
     def set_lease(self, lease):
-        """Set the lease on the node"""
+        """Associates a lease with the resource"""
 
     @abc.abstractmethod
-    def expire_lease(self, lease):
-        """Expire the lease on the node"""
-
-    @abc.abstractmethod
-    def resource_admin_project_id(self):
-        """Return project_id of resource admin"""
+    def remove_lease(self, lease):
+        """Disassociates a lease from the resource"""
 
     def verify_availability(self, start_time, end_time):
         self.dbapi.resource_verify_availability(
             self.resource_type,
-            self.get_resource_uuid(),
+            self.get_uuid(),
             start_time,
             end_time,
         )

--- a/esi_leap/resource_objects/error.py
+++ b/esi_leap/resource_objects/error.py
@@ -1,0 +1,21 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+UNKNOWN = {
+    'uuid': 'unknown-uuid',
+    'name': 'unknown-name',
+    'resource_class': 'unknown-class',
+    'config': {},
+    'owner_project_id': 'unknown-owner',
+    'lease_uuid': 'unknown-lease',
+    'lessee_project_id': 'unknown-lessee',
+}

--- a/esi_leap/resource_objects/test_node.py
+++ b/esi_leap/resource_objects/test_node.py
@@ -21,29 +21,29 @@ class TestNode(base.ResourceObjectInterface):
         self._uuid = uuid
         self._project_id = project_id
 
-    def get_resource_uuid(self):
+    def get_uuid(self):
         return self._uuid
 
-    def get_resource_name(self, resource_list=None):
+    def get_name(self, resource_list=None):
         return 'test-node-%s' % self._uuid
-
-    def get_lease_uuid(self):
-        return '12345'
-
-    def get_project_id(self):
-        return self._project_id
-
-    def get_node_config(self):
-        return {}
 
     def get_resource_class(self, resource_list=None):
         return 'fake'
 
+    def get_config(self):
+        return {}
+
+    def get_owner_project_id(self):
+        return self._project_id
+
+    def get_lease_uuid(self):
+        return '12345'
+
+    def get_lessee_project_id(self):
+        return self._project_id
+
     def set_lease(self, lease):
         return
 
-    def expire_lease(self, lease):
+    def remove_lease(self, lease):
         return
-
-    def resource_admin_project_id(self):
-        return self._project_id

--- a/esi_leap/tests/api/controllers/v1/test_utils.py
+++ b/esi_leap/tests/api/controllers/v1/test_utils.py
@@ -154,9 +154,7 @@ class TestGetObjectUtils(testtools.TestCase):
 
     @mock.patch('oslo_utils.uuidutils.is_uuid_like')
     @mock.patch('esi_leap.objects.offer.Offer.get')
-    def test_get_offer_uuid_available(self,
-                                      mock_offer_get,
-                                      mock_is_uuid_like):
+    def test_get_offer_uuid_available(self, mock_offer_get, mock_is_uuid_like):
 
         mock_is_uuid_like.return_value = True
         mock_offer_get.return_value = test_offer
@@ -170,8 +168,7 @@ class TestGetObjectUtils(testtools.TestCase):
 
     @mock.patch('oslo_utils.uuidutils.is_uuid_like')
     @mock.patch('esi_leap.objects.offer.Offer.get')
-    def test_get_offer_uuid_bad_status(self,
-                                       mock_offer_get,
+    def test_get_offer_uuid_bad_status(self, mock_offer_get,
                                        mock_is_uuid_like):
 
         mock_is_uuid_like.return_value = True
@@ -186,8 +183,7 @@ class TestGetObjectUtils(testtools.TestCase):
 
     @mock.patch('oslo_utils.uuidutils.is_uuid_like')
     @mock.patch('esi_leap.objects.offer.Offer.get_all')
-    def test_get_offer_name_available(self,
-                                      mock_offer_get_all,
+    def test_get_offer_name_available(self, mock_offer_get_all,
                                       mock_is_uuid_like):
 
         mock_is_uuid_like.return_value = False
@@ -200,8 +196,7 @@ class TestGetObjectUtils(testtools.TestCase):
         mock_is_uuid_like.assert_called_once_with(test_offer.name)
         mock_offer_get_all.assert_called_once_with(
             {'name': test_offer.name,
-             'status': statuses.AVAILABLE}
-        )
+             'status': statuses.AVAILABLE})
 
     @mock.patch('oslo_utils.uuidutils.is_uuid_like')
     @mock.patch('esi_leap.objects.lease.Lease.get')
@@ -219,9 +214,7 @@ class TestGetObjectUtils(testtools.TestCase):
 
     @mock.patch('oslo_utils.uuidutils.is_uuid_like')
     @mock.patch('esi_leap.objects.lease.Lease.get')
-    def test_get_lease_uuid_available(self,
-                                      mock_lease_get,
-                                      mock_is_uuid_like):
+    def test_get_lease_uuid_available(self, mock_lease_get, mock_is_uuid_like):
 
         mock_is_uuid_like.return_value = True
         mock_lease_get.return_value = test_lease
@@ -235,8 +228,7 @@ class TestGetObjectUtils(testtools.TestCase):
 
     @mock.patch('oslo_utils.uuidutils.is_uuid_like')
     @mock.patch('esi_leap.objects.lease.Lease.get')
-    def test_get_lease_uuid_bad_status(self,
-                                       mock_lease_get,
+    def test_get_lease_uuid_bad_status(self, mock_lease_get,
                                        mock_is_uuid_like):
 
         mock_is_uuid_like.return_value = True
@@ -251,8 +243,7 @@ class TestGetObjectUtils(testtools.TestCase):
 
     @mock.patch('oslo_utils.uuidutils.is_uuid_like')
     @mock.patch('esi_leap.objects.lease.Lease.get_all')
-    def test_get_lease_name_active(self,
-                                   mock_lease_get_all,
+    def test_get_lease_name_active(self, mock_lease_get_all,
                                    mock_is_uuid_like):
 
         mock_is_uuid_like.return_value = False
@@ -265,32 +256,26 @@ class TestGetObjectUtils(testtools.TestCase):
         mock_is_uuid_like.assert_called_once_with(test_lease.name)
         mock_lease_get_all.assert_called_once_with(
             {'name': test_lease.name,
-             'status': statuses.ACTIVE}
-        )
+             'status': statuses.ACTIVE})
 
 
 class TestCheckResourceAdminUtils(testtools.TestCase):
 
-    @mock.patch.object(test_node_1, 'resource_admin_project_id')
+    @mock.patch.object(test_node_1, 'get_owner_project_id')
     @mock.patch('esi_leap.api.controllers.v1.utils.resource_policy_authorize')
-    def test_check_resource_admin_owner(self,
-                                        mock_authorize,
-                                        mock_ra):
-        mock_ra.return_value = owner_ctx.project_id
+    def test_check_resource_admin_owner(self, mock_authorize, mock_gopi):
+        mock_gopi.return_value = owner_ctx.project_id
 
         utils.check_resource_admin(owner_ctx.to_policy_values(),
                                    test_node_1,
                                    test_offer.project_id)
+        mock_gopi.assert_called_once()
+        mock_authorize.assert_not_called()
 
-        mock_ra.assert_called_once()
-        assert not mock_authorize.called
-
-    @mock.patch.object(test_node_2, 'resource_admin_project_id')
+    @mock.patch.object(test_node_2, 'get_owner_project_id')
     @mock.patch('esi_leap.api.controllers.v1.utils.resource_policy_authorize')
-    def test_check_resource_admin_admin(self,
-                                        mock_authorize,
-                                        mock_ra):
-        mock_ra.return_value = owner_ctx_2.project_id
+    def test_check_resource_admin_admin(self, mock_authorize, mock_gopi):
+        mock_gopi.return_value = owner_ctx_2.project_id
 
         bad_test_offer = offer.Offer(
             resource_type='test_node',
@@ -302,18 +287,17 @@ class TestCheckResourceAdminUtils(testtools.TestCase):
                                    test_node_2,
                                    bad_test_offer.project_id)
 
-        mock_ra.assert_called_once()
+        mock_gopi.assert_called_once()
         mock_authorize.assert_called_once_with('esi_leap:offer:offer_admin',
                                                admin_ctx.to_policy_values(),
                                                admin_ctx.to_policy_values(),
                                                'test_node', test_node_2._uuid)
 
-    @mock.patch.object(test_node_2, 'resource_admin_project_id')
+    @mock.patch.object(test_node_2, 'get_owner_project_id')
     @mock.patch('esi_leap.api.controllers.v1.utils.resource_policy_authorize')
-    def test_check_resource_admin_invalid_owner(self,
-                                                mock_authorize,
-                                                mock_ra):
-        mock_ra.return_value = owner_ctx_2.project_id
+    def test_check_resource_admin_invalid_owner(self, mock_authorize,
+                                                mock_gopi):
+        mock_gopi.return_value = owner_ctx_2.project_id
         mock_authorize.side_effect = exception.HTTPResourceForbidden(
             resource_type='test_node', resource=test_node_2._uuid)
 
@@ -329,7 +313,7 @@ class TestCheckResourceAdminUtils(testtools.TestCase):
                           test_node_2,
                           bad_test_offer.project_id)
 
-        mock_ra.assert_called_once()
+        mock_gopi.assert_called_once()
         mock_authorize.assert_called_once_with('esi_leap:offer:offer_admin',
                                                owner_ctx_2.to_policy_values(),
                                                owner_ctx_2.to_policy_values(),
@@ -357,11 +341,9 @@ class TestCheckResourceLeaseAdminUtils(testtools.TestCase):
     @mock.patch('esi_leap.objects.lease.Lease.get')
     @mock.patch.object(test_node_1, 'get_lease_uuid',
                        return_value='a-lease-uuid')
-    @mock.patch.object(test_node_1, 'get_project_id',
+    @mock.patch.object(test_node_1, 'get_lessee_project_id',
                        return_value=test_offer.project_id)
-    def test_check_resource_lease_admin_okay(self,
-                                             mock_gpi,
-                                             mock_glu,
+    def test_check_resource_lease_admin_okay(self, mock_glpi, mock_glu,
                                              mock_lease_get):
         mock_lease_get.return_value = self.test_lease
         parent_lease_uuid = utils.check_resource_lease_admin(
@@ -371,7 +353,7 @@ class TestCheckResourceLeaseAdminUtils(testtools.TestCase):
             datetime.datetime(2016, 7, 16, 19, 20, 30),
             datetime.datetime(2016, 8, 16, 19, 20, 30))
 
-        mock_gpi.assert_called_once()
+        mock_glpi.assert_called_once()
         mock_glu.assert_called_once()
         mock_lease_get.assert_called_once_with('a-lease-uuid')
         self.assertEqual('a-lease-uuid', parent_lease_uuid)
@@ -379,11 +361,9 @@ class TestCheckResourceLeaseAdminUtils(testtools.TestCase):
     @mock.patch('esi_leap.objects.lease.Lease.get')
     @mock.patch.object(test_node_1, 'get_lease_uuid',
                        return_value='a-lease-uuid')
-    @mock.patch.object(test_node_1, 'get_project_id',
+    @mock.patch.object(test_node_1, 'get_lessee_project_id',
                        return_value='other-lessee')
-    def test_check_resource_lease_admin_not_lessee(self,
-                                                   mock_gpi,
-                                                   mock_glu,
+    def test_check_resource_lease_admin_not_lessee(self, mock_glpi, mock_glu,
                                                    mock_lease_get):
         mock_lease_get.return_value = self.test_lease
         parent_lease_uuid = utils.check_resource_lease_admin(
@@ -393,7 +373,7 @@ class TestCheckResourceLeaseAdminUtils(testtools.TestCase):
             datetime.datetime(2016, 7, 16, 19, 20, 30),
             datetime.datetime(2016, 8, 16, 19, 20, 30))
 
-        mock_gpi.assert_called_once()
+        mock_glpi.assert_called_once()
         mock_glu.assert_not_called()
         mock_lease_get.assert_not_called()
         self.assertIsNone(parent_lease_uuid)
@@ -401,10 +381,10 @@ class TestCheckResourceLeaseAdminUtils(testtools.TestCase):
     @mock.patch('esi_leap.objects.lease.Lease.get')
     @mock.patch.object(test_node_1, 'get_lease_uuid',
                        return_value=None)
-    @mock.patch.object(test_node_1, 'get_project_id',
+    @mock.patch.object(test_node_1, 'get_lessee_project_id',
                        return_value=test_offer.project_id)
     def test_check_resource_lease_admin_not_lease(self,
-                                                  mock_gpi,
+                                                  mock_glpi,
                                                   mock_glu,
                                                   mock_lease_get):
         mock_lease_get.return_value = self.test_lease
@@ -415,7 +395,7 @@ class TestCheckResourceLeaseAdminUtils(testtools.TestCase):
             datetime.datetime(2016, 7, 16, 19, 20, 30),
             datetime.datetime(2016, 8, 16, 19, 20, 30))
 
-        mock_gpi.assert_called_once()
+        mock_glpi.assert_called_once()
         mock_glu.assert_called_once()
         mock_lease_get.assert_not_called()
         self.assertIsNone(parent_lease_uuid)
@@ -423,10 +403,10 @@ class TestCheckResourceLeaseAdminUtils(testtools.TestCase):
     @mock.patch('esi_leap.objects.lease.Lease.get')
     @mock.patch.object(test_node_1, 'get_lease_uuid',
                        return_value='a-lease-uuid')
-    @mock.patch.object(test_node_1, 'get_project_id',
+    @mock.patch.object(test_node_1, 'get_lessee_project_id',
                        return_value=test_offer.project_id)
     def test_check_resource_lease_admin_parent_lease(self,
-                                                     mock_gpi,
+                                                     mock_glpi,
                                                      mock_glu,
                                                      mock_lease_get):
         mock_lease_get.return_value = self.test_lease_with_parent
@@ -437,7 +417,7 @@ class TestCheckResourceLeaseAdminUtils(testtools.TestCase):
             datetime.datetime(2016, 7, 16, 19, 20, 30),
             datetime.datetime(2016, 8, 16, 19, 20, 30))
 
-        mock_gpi.assert_called_once()
+        mock_glpi.assert_called_once()
         mock_glu.assert_called_once()
         mock_lease_get.assert_called_once_with('a-lease-uuid')
         self.assertIsNone(parent_lease_uuid)
@@ -445,11 +425,9 @@ class TestCheckResourceLeaseAdminUtils(testtools.TestCase):
     @mock.patch('esi_leap.objects.lease.Lease.get')
     @mock.patch.object(test_node_1, 'get_lease_uuid',
                        return_value='a-lease-uuid')
-    @mock.patch.object(test_node_1, 'get_project_id',
+    @mock.patch.object(test_node_1, 'get_lessee_project_id',
                        return_value=test_offer.project_id)
-    def test_check_resource_lease_admin_bad_time(self,
-                                                 mock_gpi,
-                                                 mock_glu,
+    def test_check_resource_lease_admin_bad_time(self, mock_glpi, mock_glu,
                                                  mock_lease_get):
         mock_lease_get.return_value = self.test_lease
         self.assertRaises(exception.ResourceNoPermissionTime,
@@ -459,8 +437,7 @@ class TestCheckResourceLeaseAdminUtils(testtools.TestCase):
                           test_offer.project_id,
                           datetime.datetime(2016, 7, 15, 19, 20, 30),
                           datetime.datetime(2016, 8, 16, 19, 20, 30))
-
-        mock_gpi.assert_called_once()
+        mock_glpi.assert_called_once()
         mock_glu.assert_called_once()
         mock_lease_get.assert_called_once_with('a-lease-uuid')
 
@@ -697,15 +674,13 @@ class TestLeaseGetDictWithAddedInfoUtils(testtools.TestCase):
             parent_lease_uuid=None
         )
 
-    @mock.patch('esi_leap.resource_objects.test_node.TestNode.'
-                'get_resource_name')
+    @mock.patch('esi_leap.resource_objects.test_node.TestNode.get_name')
     @mock.patch('esi_leap.common.keystone.get_project_name')
     @mock.patch('esi_leap.objects.lease.get_resource_object')
-    def test_lease_get_dict_with_added_info(self, mock_gro, mock_gpn,
-                                            mock_grn):
+    def test_lease_get_dict_with_added_info(self, mock_gro, mock_gpn, mock_gn):
         mock_gro.return_value = TestNode('111')
         mock_gpn.return_value = 'project-name'
-        mock_grn.return_value = 'resource-name'
+        mock_gn.return_value = 'resource-name'
 
         output_dict = utils.lease_get_dict_with_added_info(self.test_lease)
 
@@ -717,5 +692,5 @@ class TestLeaseGetDictWithAddedInfoUtils(testtools.TestCase):
 
         mock_gro.assert_called_once()
         self.assertEqual(2, mock_gpn.call_count)
-        mock_grn.assert_called_once()
+        mock_gn.assert_called_once()
         self.assertEqual(expected_output_dict, output_dict)

--- a/esi_leap/tests/objects/test_lease.py
+++ b/esi_leap/tests/objects/test_lease.py
@@ -279,9 +279,9 @@ class TestLeaseObject(base.DBTestCase):
     @mock.patch('esi_leap.objects.lease.Lease.get')
     @mock.patch('esi_leap.objects.lease.Lease.resource_object')
     @mock.patch('esi_leap.resource_objects.test_node.TestNode.get_lease_uuid')
-    @mock.patch('esi_leap.resource_objects.test_node.TestNode.expire_lease')
+    @mock.patch('esi_leap.resource_objects.test_node.TestNode.remove_lease')
     @mock.patch('esi_leap.objects.lease.Lease.save')
-    def test_cancel(self, mock_save, mock_expire_lease, mock_glu, mock_ro,
+    def test_cancel(self, mock_save, mock_rl, mock_glu, mock_ro,
                     mock_lg, mock_sl):
         lease = lease_obj.Lease(self.context, **self.test_lease_dict)
         test_node = TestNode('test-node', '12345')
@@ -295,7 +295,7 @@ class TestLeaseObject(base.DBTestCase):
         mock_lg.assert_not_called()
         mock_ro.assert_called_once()
         mock_glu.assert_called_once()
-        mock_expire_lease.assert_called_once()
+        mock_rl.assert_called_once()
         mock_save.assert_called_once()
         self.assertEqual(lease.status, statuses.DELETED)
 
@@ -303,16 +303,16 @@ class TestLeaseObject(base.DBTestCase):
     @mock.patch('esi_leap.objects.lease.Lease.get')
     @mock.patch('esi_leap.objects.lease.Lease.resource_object')
     @mock.patch('esi_leap.resource_objects.test_node.TestNode.get_lease_uuid')
-    @mock.patch('esi_leap.resource_objects.test_node.TestNode.expire_lease')
+    @mock.patch('esi_leap.resource_objects.test_node.TestNode.remove_lease')
     @mock.patch('esi_leap.objects.lease.Lease.save')
-    def test_cancel_error(self, mock_save, mock_expire_lease, mock_glu,
+    def test_cancel_error(self, mock_save, mock_rl, mock_glu,
                           mock_ro, mock_lg, mock_sl):
         lease = lease_obj.Lease(self.context, **self.test_lease_dict)
         test_node = TestNode('test-node', '12345')
 
         mock_ro.return_value = test_node
         mock_glu.return_value = lease.uuid
-        mock_expire_lease.side_effect = Exception('bad')
+        mock_rl.side_effect = Exception('bad')
 
         lease.cancel()
 
@@ -320,7 +320,7 @@ class TestLeaseObject(base.DBTestCase):
         mock_lg.assert_not_called()
         mock_ro.assert_called_once()
         mock_glu.assert_called_once()
-        mock_expire_lease.assert_called_once()
+        mock_rl.assert_called_once()
         mock_save.assert_called_once()
         self.assertEqual(lease.status, statuses.WAIT_CANCEL)
 
@@ -328,9 +328,9 @@ class TestLeaseObject(base.DBTestCase):
     @mock.patch('esi_leap.objects.lease.Lease.get')
     @mock.patch('esi_leap.objects.lease.Lease.resource_object')
     @mock.patch('esi_leap.resource_objects.test_node.TestNode.get_lease_uuid')
-    @mock.patch('esi_leap.resource_objects.test_node.TestNode.expire_lease')
+    @mock.patch('esi_leap.resource_objects.test_node.TestNode.remove_lease')
     @mock.patch('esi_leap.objects.lease.Lease.save')
-    def test_cancel_with_parent(self, mock_save, mock_expire_lease, mock_glu,
+    def test_cancel_with_parent(self, mock_save, mock_rl, mock_glu,
                                 mock_ro, mock_lg, mock_sl):
         lease = lease_obj.Lease(self.context,
                                 **self.test_lease_parent_lease_dict)
@@ -345,15 +345,15 @@ class TestLeaseObject(base.DBTestCase):
         mock_lg.assert_called_once()
         mock_ro.assert_called_once()
         mock_glu.assert_called_once()
-        mock_expire_lease.assert_called_once()
+        mock_rl.assert_called_once()
         mock_save.assert_called_once()
         self.assertEqual(lease.status, statuses.DELETED)
 
     @mock.patch('esi_leap.objects.lease.Lease.resource_object')
     @mock.patch('esi_leap.resource_objects.test_node.TestNode.get_lease_uuid')
-    @mock.patch('esi_leap.resource_objects.test_node.TestNode.expire_lease')
+    @mock.patch('esi_leap.resource_objects.test_node.TestNode.remove_lease')
     @mock.patch('esi_leap.objects.lease.Lease.save')
-    def test_cancel_no_expire(self, mock_save, mock_expire_lease, mock_glu,
+    def test_cancel_no_expire(self, mock_save, mock_rl, mock_glu,
                               mock_ro):
         lease = lease_obj.Lease(self.context, **self.test_lease_dict)
         test_node = TestNode('test-node', '12345')
@@ -365,7 +365,7 @@ class TestLeaseObject(base.DBTestCase):
 
         mock_ro.assert_called_once()
         mock_glu.assert_called_once()
-        mock_expire_lease.assert_not_called()
+        mock_rl.assert_not_called()
         mock_save.assert_called_once()
         self.assertEqual(lease.status, statuses.DELETED)
 
@@ -373,9 +373,9 @@ class TestLeaseObject(base.DBTestCase):
     @mock.patch('esi_leap.objects.lease.Lease.get')
     @mock.patch('esi_leap.objects.lease.Lease.resource_object')
     @mock.patch('esi_leap.resource_objects.test_node.TestNode.get_lease_uuid')
-    @mock.patch('esi_leap.resource_objects.test_node.TestNode.expire_lease')
+    @mock.patch('esi_leap.resource_objects.test_node.TestNode.remove_lease')
     @mock.patch('esi_leap.objects.lease.Lease.save')
-    def test_expire(self, mock_save, mock_expire_lease, mock_glu, mock_ro,
+    def test_expire(self, mock_save, mock_rl, mock_glu, mock_ro,
                     mock_lg, mock_sl):
         lease = lease_obj.Lease(self.context, **self.test_lease_dict)
         test_node = TestNode('test-node', '12345')
@@ -389,7 +389,7 @@ class TestLeaseObject(base.DBTestCase):
         mock_lg.assert_not_called()
         mock_ro.assert_called_once()
         mock_glu.assert_called_once()
-        mock_expire_lease.assert_called_once()
+        mock_rl.assert_called_once()
         mock_save.assert_called_once()
         self.assertEqual(lease.status, statuses.EXPIRED)
 
@@ -397,16 +397,16 @@ class TestLeaseObject(base.DBTestCase):
     @mock.patch('esi_leap.objects.lease.Lease.get')
     @mock.patch('esi_leap.objects.lease.Lease.resource_object')
     @mock.patch('esi_leap.resource_objects.test_node.TestNode.get_lease_uuid')
-    @mock.patch('esi_leap.resource_objects.test_node.TestNode.expire_lease')
+    @mock.patch('esi_leap.resource_objects.test_node.TestNode.remove_lease')
     @mock.patch('esi_leap.objects.lease.Lease.save')
-    def test_expire_error(self, mock_save, mock_expire_lease, mock_glu,
+    def test_expire_error(self, mock_save, mock_rl, mock_glu,
                           mock_ro, mock_lg, mock_sl):
         lease = lease_obj.Lease(self.context, **self.test_lease_dict)
         test_node = TestNode('test-node', '12345')
 
         mock_ro.return_value = test_node
         mock_glu.return_value = lease.uuid
-        mock_expire_lease.side_effect = Exception('bad')
+        mock_rl.side_effect = Exception('bad')
 
         lease.expire()
 
@@ -414,7 +414,7 @@ class TestLeaseObject(base.DBTestCase):
         mock_lg.assert_not_called()
         mock_ro.assert_called_once()
         mock_glu.assert_called_once()
-        mock_expire_lease.assert_called_once()
+        mock_rl.assert_called_once()
         mock_save.assert_called_once()
         self.assertEqual(lease.status, statuses.WAIT_EXPIRE)
 
@@ -422,9 +422,9 @@ class TestLeaseObject(base.DBTestCase):
     @mock.patch('esi_leap.objects.lease.Lease.get')
     @mock.patch('esi_leap.objects.lease.Lease.resource_object')
     @mock.patch('esi_leap.resource_objects.test_node.TestNode.get_lease_uuid')
-    @mock.patch('esi_leap.resource_objects.test_node.TestNode.expire_lease')
+    @mock.patch('esi_leap.resource_objects.test_node.TestNode.remove_lease')
     @mock.patch('esi_leap.objects.lease.Lease.save')
-    def test_expire_with_parent(self, mock_save, mock_expire_lease, mock_glu,
+    def test_expire_with_parent(self, mock_save, mock_rl, mock_glu,
                                 mock_ro, mock_lg, mock_sl):
         lease = lease_obj.Lease(self.context,
                                 **self.test_lease_parent_lease_dict)
@@ -439,16 +439,15 @@ class TestLeaseObject(base.DBTestCase):
         mock_lg.assert_called_once()
         mock_ro.assert_called_once()
         mock_glu.assert_called_once()
-        mock_expire_lease.assert_called_once()
+        mock_rl.assert_called_once()
         mock_save.assert_called_once()
         self.assertEqual(lease.status, statuses.EXPIRED)
 
     @mock.patch('esi_leap.objects.lease.Lease.resource_object')
     @mock.patch('esi_leap.resource_objects.test_node.TestNode.get_lease_uuid')
-    @mock.patch('esi_leap.resource_objects.test_node.TestNode.expire_lease')
+    @mock.patch('esi_leap.resource_objects.test_node.TestNode.remove_lease')
     @mock.patch('esi_leap.objects.lease.Lease.save')
-    def test_expire_no_expire(self, mock_save, mock_expire_lease, mock_glu,
-                              mock_ro):
+    def test_expire_no_expire(self, mock_save, mock_rl, mock_glu, mock_ro):
         lease = lease_obj.Lease(self.context, **self.test_lease_dict)
         test_node = TestNode('test-node', '12345')
 
@@ -459,7 +458,7 @@ class TestLeaseObject(base.DBTestCase):
 
         mock_ro.assert_called_once()
         mock_glu.assert_called_once()
-        mock_expire_lease.assert_not_called()
+        mock_rl.assert_not_called()
         mock_save.assert_called_once()
         self.assertEqual(lease.status, statuses.EXPIRED)
 
@@ -467,9 +466,7 @@ class TestLeaseObject(base.DBTestCase):
         lease = lease_obj.Lease(self.context, **self.test_lease_dict)
         with mock.patch.object(self.db_api, 'lease_destroy',
                                autospec=True) as mock_lease_cancel:
-
             lease.destroy()
-
             mock_lease_cancel.assert_called_once_with(lease.uuid)
 
     def test_save(self):

--- a/esi_leap/tests/resource_objects/test_ironic_node.py
+++ b/esi_leap/tests/resource_objects/test_ironic_node.py
@@ -48,69 +48,32 @@ class FakeLease(object):
 
 class TestIronicNode(base.TestCase):
 
-    def setUp(self):
-        super(TestIronicNode, self).setUp()
-        self.fake_admin_project_id_1 = '123'
-        self.fake_admin_project_id_2 = '123456'
-
     def test_resource_type(self):
         test_ironic_node = ironic_node.IronicNode(fake_uuid)
         self.assertEqual('ironic_node', test_ironic_node.resource_type)
 
-    def test_get_resource_uuid(self):
+    def test_get_uuid(self):
         test_ironic_node = ironic_node.IronicNode(fake_uuid)
-        self.assertEqual(fake_uuid, test_ironic_node.get_resource_uuid())
+        self.assertEqual(fake_uuid, test_ironic_node.get_uuid())
 
     @mock.patch('esi_leap.resource_objects.ironic_node.IronicNode._get_node')
-    def test_get_resource_name(self, mock_gn):
+    def test_get_name(self, mock_gn):
         test_ironic_node = ironic_node.IronicNode(fake_uuid)
         fake_get_node = FakeIronicNode()
         mock_gn.return_value = fake_get_node
 
-        name = test_ironic_node.get_resource_name()
-
-        self.assertEqual('fake-node', name)
+        self.assertEqual(fake_get_node.name, test_ironic_node.get_name())
         mock_gn.assert_called_once()
 
     @mock.patch.object(ironic_node, 'get_ironic_client', autospec=True)
-    def test_get_by_name(self, mock_gn):
+    def test_init_with_name(self, mock_gn):
         fake_get_node = FakeIronicNode()
         mock_gn.return_value.node.get.return_value = fake_get_node
         test_ironic_node = ironic_node.IronicNode('node-name')
-        self.assertEqual(fake_uuid, test_ironic_node.get_resource_uuid())
+
+        self.assertEqual(fake_uuid, test_ironic_node.get_uuid())
         mock_gn.assert_called_once()
         mock_gn.return_value.node.get.assert_called_once_with('node-name')
-
-    @mock.patch('esi_leap.resource_objects.ironic_node.IronicNode._get_node')
-    def test_get_lease_uuid(self, mock_gn):
-        fake_get_node = FakeIronicNode()
-        mock_gn.return_value = fake_get_node
-        test_ironic_node = ironic_node.IronicNode(fake_uuid)
-        lease_uuid = test_ironic_node.get_lease_uuid()
-        expected_lease_uuid = fake_get_node.properties.get('lease_uuid')
-        self.assertEqual(lease_uuid, expected_lease_uuid)
-        mock_gn.assert_called_once()
-
-    @mock.patch('esi_leap.resource_objects.ironic_node.IronicNode._get_node')
-    def test_get_project_id(self, mock_gn):
-        fake_get_node = FakeIronicNode()
-        mock_gn.return_value = fake_get_node
-        test_ironic_node = ironic_node.IronicNode(fake_uuid)
-        project_id = test_ironic_node.get_project_id()
-        expected_project_id = fake_get_node.lessee
-        self.assertEqual(project_id, expected_project_id)
-        mock_gn.assert_called_once()
-
-    @mock.patch('esi_leap.resource_objects.ironic_node.IronicNode._get_node')
-    def test_get_node_config(self, mock_gn):
-        fake_get_node = FakeIronicNode()
-        mock_gn.return_value = fake_get_node
-        test_ironic_node = ironic_node.IronicNode(fake_uuid)
-        config = test_ironic_node.get_node_config()
-        expected_config = fake_get_node.properties
-        expected_config.pop('lease_uuid', None)
-        self.assertEqual(config, expected_config)
-        mock_gn.assert_called_once()
 
     @mock.patch('esi_leap.resource_objects.ironic_node.IronicNode._get_node')
     def test_get_resource_class(self, mock_gn):
@@ -119,49 +82,91 @@ class TestIronicNode(base.TestCase):
         mock_gn.return_value = fake_get_node
 
         resource_class = test_ironic_node.get_resource_class()
-
         self.assertEqual('baremetal', resource_class)
+        mock_gn.assert_called_once()
+
+    @mock.patch('esi_leap.resource_objects.ironic_node.IronicNode._get_node')
+    def test_get_config(self, mock_gn):
+        fake_get_node = FakeIronicNode()
+        mock_gn.return_value = fake_get_node
+        test_ironic_node = ironic_node.IronicNode(fake_uuid)
+
+        config = test_ironic_node.get_config()
+        expected_config = fake_get_node.properties
+        expected_config.pop('lease_uuid', None)
+        self.assertEqual(config, expected_config)
+        mock_gn.assert_called_once()
+
+    @mock.patch('esi_leap.resource_objects.ironic_node.IronicNode._get_node')
+    def test_get_owner_project_id(self, mock_gn):
+        fake_get_node = FakeIronicNode()
+        mock_gn.return_value = fake_get_node
+        test_ironic_node = ironic_node.IronicNode(fake_uuid)
+
+        self.assertEqual(test_ironic_node.get_owner_project_id(),
+                         fake_get_node.owner)
+        mock_gn.assert_called_once()
+
+    @mock.patch('esi_leap.resource_objects.ironic_node.IronicNode._get_node')
+    def test_get_lease_uuid(self, mock_gn):
+        fake_get_node = FakeIronicNode()
+        mock_gn.return_value = fake_get_node
+        test_ironic_node = ironic_node.IronicNode(fake_uuid)
+
+        self.assertEqual(test_ironic_node.get_lease_uuid(),
+                         fake_get_node.properties.get('lease_uuid'))
+        mock_gn.assert_called_once()
+
+    @mock.patch('esi_leap.resource_objects.ironic_node.IronicNode._get_node')
+    def test_get_lessee_project_id(self, mock_gn):
+        fake_get_node = FakeIronicNode()
+        mock_gn.return_value = fake_get_node
+        test_ironic_node = ironic_node.IronicNode(fake_uuid)
+
+        self.assertEqual(test_ironic_node.get_lessee_project_id(),
+                         fake_get_node.lessee)
         mock_gn.assert_called_once()
 
     @mock.patch.object(ironic_node, 'get_ironic_client', autospec=True)
     def test_set_lease(self, client_mock):
         test_ironic_node = ironic_node.IronicNode(fake_uuid)
         fake_lease = FakeLease()
+
         test_ironic_node.set_lease(fake_lease)
         client_mock.assert_called_once()
         client_mock.return_value.node.update.assert_called_once_with(
-            fake_uuid, [
-                {'op': 'add',
-                 'path': '/properties/lease_uuid', 'value': '001'},
-                {'op': 'add', 'path': '/lessee', 'value': '654321'}])
+            fake_uuid, [{'op': 'add',
+                         'path': '/properties/lease_uuid',
+                         'value': fake_lease.uuid},
+                        {'op': 'add',
+                         'path': '/lessee',
+                         'value': fake_lease.project_id}])
 
     @mock.patch('esi_leap.resource_objects.ironic_node.IronicNode.'
-                'get_project_id')
+                'get_lessee_project_id')
     @mock.patch('esi_leap.resource_objects.ironic_node.IronicNode.'
                 'get_lease_uuid')
     @mock.patch('esi_leap.resource_objects.ironic_node.IronicNode._get_node')
     @mock.patch.object(ironic_node, 'get_ironic_client', autospec=True)
-    def test_expire_lease(self, mock_client, mock_gn, mock_glu, mock_gpi):
+    def test_remove_lease(self, mock_client, mock_gn, mock_glu, mock_glpi):
         fake_get_node = FakeIronicNode()
         fake_get_node.provision_state = 'active'
         fake_lease = FakeLease()
 
         mock_gn.return_value = fake_get_node
         mock_glu.return_value = fake_lease.uuid
-        mock_gpi.return_value = fake_lease.project_id
+        mock_glpi.return_value = fake_lease.project_id
 
-        fake_lease = FakeLease()
         test_ironic_node = ironic_node.IronicNode(fake_uuid)
-        test_ironic_node.expire_lease(fake_lease)
+        test_ironic_node.remove_lease(fake_lease)
 
-        mock_gpi.assert_called_once()
+        mock_glpi.assert_called_once()
         mock_glu.assert_called_once()
         self.assertEqual(mock_gn.call_count, 1)
         self.assertEqual(mock_client.call_count, 2)
         mock_client.return_value.node.update.assert_called_once_with(
-            fake_uuid, [
-                {'op': 'remove', 'path': '/properties/lease_uuid'},
-                {'op': 'remove', 'path': '/lessee'}])
+            fake_uuid, [{'op': 'remove', 'path': '/properties/lease_uuid'},
+                        {'op': 'remove', 'path': '/lessee'}])
         mock_client.return_value.node.set_provision_state. \
             assert_called_once_with(fake_uuid, 'deleted')
 
@@ -171,25 +176,17 @@ class TestIronicNode(base.TestCase):
         mock_glu.return_value = 'none'
         test_ironic_node = ironic_node.IronicNode(fake_uuid)
         fake_lease = FakeLease()
-        test_ironic_node.expire_lease(fake_lease)
-        mock_glu.assert_called_once()
 
-    @mock.patch('esi_leap.resource_objects.ironic_node.IronicNode._get_node')
-    def test_resource_admin_project_id(self, mock_gn):
-        fake_get_node = FakeIronicNode()
-        mock_gn.return_value = fake_get_node
-        test_ironic_node = ironic_node.IronicNode(fake_uuid)
-        self.assertEqual(self.fake_admin_project_id_2,
-                         test_ironic_node.resource_admin_project_id())
-        mock_gn.assert_called_once()
+        test_ironic_node.remove_lease(fake_lease)
+        mock_glu.assert_called_once()
 
     @mock.patch('esi_leap.common.ironic.get_node')
     def test_get_node(self, mock_gn):
         fake_get_node = FakeIronicNode()
         mock_gn.return_value = fake_get_node
         test_ironic_node = ironic_node.IronicNode(fake_uuid)
-        self.assertEqual(fake_get_node,
-                         test_ironic_node._get_node())
+
+        self.assertEqual(test_ironic_node._get_node(), fake_get_node)
         mock_gn.assert_called_once_with(fake_uuid, None)
 
     @mock.patch('esi_leap.common.ironic.get_node')
@@ -198,13 +195,15 @@ class TestIronicNode(base.TestCase):
         mock_gn.return_value = fake_get_node
         test_ironic_node = ironic_node.IronicNode(fake_uuid)
         test_ironic_node._node = fake_get_node
+
         self.assertEqual(fake_get_node,
                          test_ironic_node._get_node())
-        mock_gn.assert_not_called
+        mock_gn.assert_not_called()
 
     @mock.patch('esi_leap.common.ironic.get_node')
     def test_get_unknown_node(self, mock_gn):
         mock_gn.side_effect = ir_exception.NotFound
         test_unknown_node = ironic_node.IronicNode(fake_uuid)
+
         self.assertRaises(exception.NodeNotFound,
                           test_unknown_node._get_node)

--- a/esi_leap/tests/resource_objects/test_resource_objects.py
+++ b/esi_leap/tests/resource_objects/test_resource_objects.py
@@ -53,7 +53,7 @@ class TestResourceObjects(base.TestCase):
 
         mock_iul.assert_called_once_with('1111')
         self.assertIsInstance(node, resource_objects.ironic_node.IronicNode)
-        self.assertEqual('1111', node.get_resource_uuid())
+        self.assertEqual('1111', node.get_uuid())
 
     @mock.patch('esi_leap.resource_objects.ironic_node.get_ironic_client')
     @mock.patch('esi_leap.resource_objects.ironic_node.is_uuid_like')
@@ -73,19 +73,19 @@ class TestResourceObjects(base.TestCase):
         mock_uuid.assert_called_once_with()
         mock_ironic_client.node.get.assert_called_once_with('node-name')
         self.assertIsInstance(node, resource_objects.ironic_node.IronicNode)
-        self.assertEqual('1111', node.get_resource_uuid())
+        self.assertEqual('1111', node.get_uuid())
 
     def test_dummy_node(self):
         node = resource_objects.get_resource_object('dummy_node', '1111')
 
         self.assertIsInstance(node, resource_objects.dummy_node.DummyNode)
-        self.assertEqual('1111', node.get_resource_uuid())
+        self.assertEqual('1111', node.get_uuid())
 
     def test_test_node(self):
         node = resource_objects.get_resource_object('test_node', '1111')
 
         self.assertIsInstance(node, resource_objects.test_node.TestNode)
-        self.assertEqual('1111', node.get_resource_uuid())
+        self.assertEqual('1111', node.get_uuid())
 
     def test_unknown_resource_type(self):
         self.assertRaises(exception.ResourceTypeUnknown,

--- a/esi_leap/tests/resource_objects/test_test_node.py
+++ b/esi_leap/tests/resource_objects/test_test_node.py
@@ -41,45 +41,36 @@ class TestTestNode(base.TestCase):
     def setUp(self):
         super(TestTestNode, self).setUp()
         self.fake_test_node = test_node.TestNode('1111', '123456')
-        self.fake_admin_project_id_1 = '123'
-        self.fake_admin_project_id_2 = '123456'
 
     def test_resource_type(self):
         resource_type = self.fake_test_node.resource_type
         self.assertEqual(resource_type, 'test_node')
 
-    def test_get_resource_uuid(self):
-        resource_uuid = self.fake_test_node.get_resource_uuid()
-        self.assertEqual(resource_uuid, '1111')
+    def test_get_uuid(self):
+        self.assertEqual(self.fake_test_node.get_uuid(), '1111')
 
-    def test_get_resource_name(self):
-        self.assertEqual('test-node-1111',
-                         self.fake_test_node.get_resource_name())
-
-    def test_get_lease_uuid(self):
-        lease_uuid = self.fake_test_node.get_lease_uuid()
-        self.assertEqual(lease_uuid, '12345')
-
-    def test_get_project_id(self):
-        project_id = self.fake_test_node.get_project_id()
-        self.assertEqual(project_id, '123456')
-
-    def test_get_node_config(self):
-        config = self.fake_test_node.get_node_config()
-        self.assertEqual(config, {})
+    def test_get_name(self):
+        self.assertEqual(self.fake_test_node.get_name(), 'test-node-1111')
 
     def test_get_resource_class(self):
-        resource_class = self.fake_test_node.get_resource_class()
-        self.assertEqual(resource_class, 'fake')
+        self.assertEqual(self.fake_test_node.get_resource_class(), 'fake')
+
+    def test_get_config(self):
+        self.assertEqual(self.fake_test_node.get_config(), {})
+
+    def test_get_owner_project_id(self):
+        self.assertEqual(self.fake_test_node.get_owner_project_id(), '123456')
+
+    def test_get_lease_uuid(self):
+        self.assertEqual(self.fake_test_node.get_lease_uuid(), '12345')
+
+    def test_get_lessee_project_id(self):
+        self.assertEqual(self.fake_test_node.get_lessee_project_id(), '123456')
 
     def test_set_lease(self):
         fake_lease = get_test_lease()
         self.assertEqual(self.fake_test_node.set_lease(fake_lease), None)
 
-    def test_expire_lease(self):
+    def test_remove_lease(self):
         fake_lease = get_test_lease()
-        self.assertEqual(self.fake_test_node.expire_lease(fake_lease), None)
-
-    def test_resource_admin_project_id(self):
-        self.assertEqual(self.fake_admin_project_id_2,
-                         self.fake_test_node.resource_admin_project_id())
+        self.assertEqual(self.fake_test_node.remove_lease(fake_lease), None)


### PR DESCRIPTION
The interfaces for interacting with resource objects are inconsistent in naming and behavior. This patch seeks to address this by making the following changes:

- `get_resource_uuid()` and `get_resource_name()` have been renamed to `get_uuid()` and `get_name()`, respectively. This was done to make `Object.get_attribute()`-style calls more concise and legible.
- `get_node_config()` has been renamed to `get_config()`. This was done in part for the same reason as the previously mentioned change, but was also done to make it easier to potentially add new types of resource objects that aren't nodes in the future.
- `resource_admin_project_id()` has been renamed to `get_owner_project_id()`. The `get_` prefix was added for the sake of naming consistency and the term `admin` was replaced with `owner`. The latter change was made because in the existing code, the names of the attributes being retrieved contain the word `owner` instead of `admin`.
- `get_project_id()` has been renamed to `get_lessee_project_id()` to prevent confusion with the newly named `get_owner_project_id()`.
- `expire_lease()` has been renamed to `remove_lease()` to more accurately reflect what the method is doing. Specifically, in the existing code, the implementations of this function never expire the lease [in the ESI Leap database]-- they only remove the association between the lease/lessee and the resource object itself.
- The values returned by the various `get_` methods that *can* fail have been made consistent across the existing types of resource objects.
- The unit test suite for the resource object base has been updated to allow the base class to be tested as directly as possible.