### PR TITLE
Fix various issues with esi-leap Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,44 +1,24 @@
-# This file will contain the configuration for containerized esi-leap
+# This file contains the configuration for containerized esi-leap
 
 # Use python as the parent image for esi-leap
-
 FROM python:3.11
 
-# Use label descriptor
-
-LABEL description="ESI-LEAP container file"
-
-# Maintainer details
-
-MAINTAINER <tzumainn@redhat.com>
+LABEL description="ESI-LEAP -- ESI lease policy manager"
 
 # The working directory for esi-leap inside the container
-
 WORKDIR /esi-leap
 
 # Copy the files of esi leap inside the container
-# Syntax : COPY <src> <destination>
-
 COPY run_services.sh run_services.sh
 
-# Run command to install dependencies for esi-leap
-
-RUN pip install esi-leap
-
-RUN pip install mysql-connector
-
 RUN mkdir -p /var/log/esi-leap
-
 RUN touch /var/log/esi-leap/esi-leap-dbsync.log
 
 # Run command to install dependencies for esi-leap
 RUN apt update -y && apt install -y python3-pymysql
+RUN pip3 install esi-leap mysql-connector pymysql
 
-RUN pip3 install pymysql
-
-# Expose the default port for esi-leap-api
-# Use -p flag while running the image to map ports
-
+# Indicate that service listens on this port
 EXPOSE 7777
-RUN ["chmod", "+x", "./run_services.sh"]
-CMD ./run_services.sh
+
+CMD ["bash", "./run_services.sh"]


### PR DESCRIPTION
This commit fixes several issues with the esi-leap Containerfile:

1. The `MAINTAINER` field is deprecated [1] and should not be used. The
   maintainer can change over time; using `git log` is a better method for
   determining who is responsible for a file.

2. Be consistent about using `pip3` or `pip` and consolidate the `pip3
   install` commands. This generally results in a shorter build time
   because we only need to calculate dependencies once.

3. Make the `CMD` entry independent of the permissions on
   `run_services.sh`.

[1]: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
