### PR TITLE
Enforce openstacksdk<1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ iso8601>=0.1.11 # MIT
 keystoneauth1>=3.4.0 # Apache-2.0
 keystonemiddleware>=4.17.0 # Apache-2.0
 kombu!=4.0.2,>=4.0.0 # BSD
+openstacksdk<1.3.0
 oslo.concurrency>=3.26.0 # Apache-2.0
 oslo.config>=5.2.0 # Apache-2.0
 oslo.db>=4.27.0 # Apache-2.0


### PR DESCRIPTION
openstacksdk 1.3.0 includes a change that requires python 3.7 or higher. We would still like to support python 3.6