### PR TITLE
Fix bug that causes expired leases to not be reflected on ironic nodes

### DIFF
--- a/esi_leap/objects/lease.py
+++ b/esi_leap/objects/lease.py
@@ -100,7 +100,9 @@ class LeaseCRUDPayload(notification.NotificationPayloadBase):
         setattr(node, 'node_name', node.get_name())
         setattr(node, 'node_provision_state', node.get_node_provision_state())
         setattr(node, 'node_power_state', node.get_node_power_state())
-        setattr(node, 'node_properties', node.get_config())
+        node_config = node.get_config().copy()
+        node_config.pop('lease_uuid', None)
+        setattr(node, 'node_properties', node_config)
 
         self.populate_schema(lease=lease, node=node)
 

--- a/esi_leap/resource_objects/ironic_node.py
+++ b/esi_leap/resource_objects/ironic_node.py
@@ -65,7 +65,6 @@ class IronicNode(base.ResourceObjectInterface):
         config = self._get_node_attr('properties', {},
                                      err_msg='Error getting resource config',
                                      err_val=error.UNKNOWN['config'])
-        config.pop('lease_uuid', None)
         return config
 
     def get_owner_project_id(self):

--- a/esi_leap/tests/resource_objects/test_ironic_node.py
+++ b/esi_leap/tests/resource_objects/test_ironic_node.py
@@ -94,7 +94,6 @@ class TestIronicNode(base.TestCase):
 
         config = test_ironic_node.get_config()
         expected_config = fake_get_node.properties
-        expected_config.pop('lease_uuid', None)
         self.assertEqual(config, expected_config)
         mock_gn.assert_called_once()
 


### PR DESCRIPTION
The ironic_node resource_object automatically popped the lease_uuid from its properties dict when calling get_config. However, this is permanently reflected on the resource object, and results in future queries of the resource object's lease_uuid returning None.