### PR TITLE
Fix bug with claiming offer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/esi_leap/api/controllers/v1/offer.py
+++ b/esi_leap/api/controllers/v1/offer.py
@@ -272,7 +272,8 @@ class OffersController(rest.RestController):
             lease_dict['start_time'] = datetime.datetime.now()
 
         if 'end_time' not in lease_dict:
-            q = offer.get_first_availability(lease_dict['start_time'])
+            q = offer.get_next_lease_start_time(
+                lease_dict['start_time'])
             if q is None:
                 lease_dict['end_time'] = offer.end_time
             else:

--- a/esi_leap/db/api.py
+++ b/esi_leap/db/api.py
@@ -92,9 +92,9 @@ def offer_get_conflict_times(offer_ref):
     return IMPL.offer_get_conflict_times(offer_ref)
 
 
-def offer_get_first_availability(offer_uuid, start, end):
-    return IMPL.offer_get_first_availability(
-        offer_uuid, start, end)
+def offer_get_next_lease_start_time(offer_uuid, start):
+    return IMPL.offer_get_next_lease_start_time(
+        offer_uuid, start)
 
 
 def offer_verify_availability(offer_ref, start, end):

--- a/esi_leap/db/sqlalchemy/api.py
+++ b/esi_leap/db/sqlalchemy/api.py
@@ -169,7 +169,7 @@ def offer_get_conflict_times(offer_ref):
                ).all()
 
 
-def offer_get_first_availability(offer_uuid, start):
+def offer_get_next_lease_start_time(offer_uuid, start):
     l_query = model_query(models.Lease)
 
     return l_query.with_entities(
@@ -179,7 +179,8 @@ def offer_get_first_availability(offer_uuid, start):
                (models.Lease.status == statuses.ACTIVE)
                ).\
         order_by(models.Lease.start_time).\
-        filter(models.Lease.end_time >= start).first()
+        filter((models.Lease.end_time >= start) &
+               (models.Lease.start_time >= start)).first()
 
 
 def offer_verify_availability(offer_ref, start, end):

--- a/esi_leap/objects/offer.py
+++ b/esi_leap/objects/offer.py
@@ -113,8 +113,9 @@ class Offer(base.ESILEAPObject):
 
         return avails
 
-    def get_first_availability(self, start):
-        return self.dbapi.offer_get_first_availability(self.uuid, start)
+    def get_next_lease_start_time(self, start):
+        return self.dbapi.offer_get_next_lease_start_time(
+            self.uuid, start)
 
     def create(self, context=None):
         updates = self.obj_get_changes()

--- a/esi_leap/tests/db/sqlalchemy/test_api.py
+++ b/esi_leap/tests/db/sqlalchemy/test_api.py
@@ -169,6 +169,20 @@ test_lease_6 = dict(
     status=statuses.EXPIRED,
 )
 
+test_lease_7 = dict(
+    uuid='77777',
+    project_id='1e5533_2',
+    owner_id='0wn3r_2',
+    name='l1',
+    resource_uuid='1111',
+    resource_type='dummy_node',
+    purpose='test_purpose',
+    start_time=now - datetime.timedelta(days=10),
+    end_time=now + datetime.timedelta(days=10),
+    properties={},
+    status=statuses.ACTIVE,
+)
+
 test_event_1 = dict(
     id=1,
     event_type='fake:event:start',
@@ -340,15 +354,18 @@ class TestOfferAPI(base.DBTestCase):
                          [(now + datetime.timedelta(days=50),
                           now + datetime.timedelta(days=60))])
 
-    def test_offer_get_first_availability(self):
+    def test_offer_get_next_lease_start_time(self):
         o1 = api.offer_create(test_offer_1)
-        self.assertEqual(api.offer_get_first_availability
+        self.assertEqual(api.offer_get_next_lease_start_time
                          (o1.uuid, o1.start_time,), None)
         test_lease_3['offer_uuid'] = o1.uuid
         api.lease_create(test_lease_3)
-        self.assertEqual(api.offer_get_first_availability(o1.uuid,
-                                                          o1.start_time),
-                         (now + datetime.timedelta(days=50),))
+        test_lease_7['offer_uuid'] = o1.uuid
+        api.lease_create(test_lease_7)
+        self.assertEqual(
+            api.offer_get_next_lease_start_time(
+                o1.uuid, o1.start_time),
+            (now + datetime.timedelta(days=50),))
 
     def test_offer_get_by_uuid(self):
         o1 = api.offer_create(test_offer_1)


### PR DESCRIPTION
If an offer is claimed for its entire duration, and someone else tries to claim the offer without specifying a start/end time, then the db function will think that the next available end time is before the current time. This fixes that issue, as well as renaming the db function to be clearer regarding its function.