### PR TITLE
Remove python 3.7 from version Matrix (and add 3.12)

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This matches Ironic, which requires Python >= 3.8 [1].

[1]: https://github.com/openstack/ironic/blob/18f50f2886d22252b294f871bddb1a24062dfc40/setup.cfg#L9