### PR TITLE
Fix test warnings and errors under pytest

### DIFF
--- a/esi_leap/db/sqlalchemy/models.py
+++ b/esi_leap/db/sqlalchemy/models.py
@@ -14,7 +14,7 @@ from oslo_db.sqlalchemy import models
 from oslo_db.sqlalchemy import types as db_types
 
 from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy import orm
 from sqlalchemy import Column, DateTime, ForeignKey
 from sqlalchemy import Index, Integer, String

--- a/esi_leap/resource_objects/__init__.py
+++ b/esi_leap/resource_objects/__init__.py
@@ -15,7 +15,7 @@ from esi_leap.resource_objects import base
 # types derived from base won't show as subclasses unless imported somewhere
 from esi_leap.resource_objects import dummy_node  # noqa: F401
 from esi_leap.resource_objects import ironic_node  # noqa: F401
-from esi_leap.resource_objects import test_node  # noqa: F401
+from esi_leap.resource_objects import fake_node  # noqa: F401
 
 
 _RESOURCE_TYPE_MAP = {

--- a/esi_leap/resource_objects/fake_node.py
+++ b/esi_leap/resource_objects/fake_node.py
@@ -13,7 +13,7 @@
 from esi_leap.resource_objects import base
 
 
-class TestNode(base.ResourceObjectInterface):
+class FakeNode(base.ResourceObjectInterface):
     resource_type = "test_node"
 
     def __init__(self, uuid, project_id="12345"):

--- a/esi_leap/tests/api/controllers/v1/test_event.py
+++ b/esi_leap/tests/api/controllers/v1/test_event.py
@@ -14,7 +14,7 @@ from datetime import datetime
 import mock
 
 from esi_leap.common import exception
-from esi_leap.resource_objects.test_node import TestNode
+from esi_leap.resource_objects.fake_node import FakeNode
 from esi_leap.tests.api import base as test_api_base
 
 
@@ -82,7 +82,7 @@ class TestEventsController(test_api_base.APITestCase):
         fake_event = FakeEvent()
         expected_filters = {"resource_type": "test_node", "resource_uuid": "1111"}
         mock_pa.side_effect = None
-        mock_gro.return_value = TestNode("1111")
+        mock_gro.return_value = FakeNode("1111")
         mock_ega.return_value = [fake_event]
 
         data = self.get_json("/events?resource_uuid=1111&resource_type=test_node")

--- a/esi_leap/tests/api/controllers/v1/test_lease.py
+++ b/esi_leap/tests/api/controllers/v1/test_lease.py
@@ -23,7 +23,7 @@ from esi_leap.common import exception
 from esi_leap.common import statuses
 from esi_leap.objects import lease as lease_obj
 from esi_leap.resource_objects.ironic_node import IronicNode
-from esi_leap.resource_objects.test_node import TestNode
+from esi_leap.resource_objects.fake_node import FakeNode
 from esi_leap.tests.api import base as test_api_base
 
 
@@ -98,7 +98,7 @@ class TestLeasesController(test_api_base.APITestCase):
         mock_gro,
         mock_lgdwai,
     ):
-        resource = TestNode("1234567890")
+        resource = FakeNode("1234567890")
         data = {
             "project_id": "lesseeid",
             "resource_type": "test_node",
@@ -453,7 +453,7 @@ class TestLeasesController(test_api_base.APITestCase):
     def test_get_resource_filter(
         self, mock_get_all, mock_lgaaf, mock_gro, mock_lgdwai, mock_gpl, mock_gnl
     ):
-        mock_gro.return_value = TestNode("54321")
+        mock_gro.return_value = FakeNode("54321")
         mock_get_all.return_value = [self.test_lease, self.test_lease]
         mock_gpl.return_value = []
         mock_gnl.return_value = []

--- a/esi_leap/tests/api/controllers/v1/test_lease.py
+++ b/esi_leap/tests/api/controllers/v1/test_lease.py
@@ -59,7 +59,7 @@ class TestLeasesController(test_api_base.APITestCase):
             resource_uuid="111",
             project_id="lesseeid",
             owner_id="ownerid",
-            parent_lease_uuid="parent-lease-uuid",
+            parent_lease_uuid=uuidutils.generate_uuid(),
         )
 
     def test_empty(self):

--- a/esi_leap/tests/api/controllers/v1/test_offer.py
+++ b/esi_leap/tests/api/controllers/v1/test_offer.py
@@ -19,7 +19,7 @@ from esi_leap.common import exception
 from esi_leap.common import statuses
 from esi_leap.objects import offer
 from esi_leap.resource_objects.ironic_node import IronicNode
-from esi_leap.resource_objects.test_node import TestNode
+from esi_leap.resource_objects.fake_node import FakeNode
 from esi_leap.tests.api import base as test_api_base
 
 
@@ -124,7 +124,7 @@ class TestOffersController(test_api_base.APITestCase):
     def test_post(
         self, mock_ogdwai, mock_create, mock_cra, mock_generate_uuid, mock_gro
     ):
-        resource = TestNode(self.test_offer.resource_uuid)
+        resource = FakeNode(self.test_offer.resource_uuid)
         mock_gro.return_value = resource
         mock_generate_uuid.return_value = self.test_offer.uuid
         mock_create.return_value = self.test_offer
@@ -210,7 +210,7 @@ class TestOffersController(test_api_base.APITestCase):
         mock_gpufi,
         mock_gro,
     ):
-        resource = TestNode(self.test_offer_lessee.resource_uuid)
+        resource = FakeNode(self.test_offer_lessee.resource_uuid)
         mock_gro.return_value = resource
         mock_gpufi.return_value = "lessee_uuid"
         mock_generate_uuid.return_value = self.test_offer_lessee.uuid
@@ -260,7 +260,7 @@ class TestOffersController(test_api_base.APITestCase):
         mock_gro,
         mock_crla,
     ):
-        resource = TestNode(self.test_offer_with_parent.resource_uuid)
+        resource = FakeNode(self.test_offer_with_parent.resource_uuid)
         mock_gro.return_value = resource
         mock_generate_uuid.return_value = self.test_offer_with_parent.uuid
         mock_create.return_value = self.test_offer_with_parent
@@ -320,7 +320,7 @@ class TestOffersController(test_api_base.APITestCase):
         mock_gro,
         mock_crla,
     ):
-        resource = TestNode(self.test_offer_with_parent.resource_uuid)
+        resource = FakeNode(self.test_offer_with_parent.resource_uuid)
         mock_gro.return_value = resource
         mock_generate_uuid.return_value = self.test_offer_with_parent.uuid
         mock_create.return_value = self.test_offer_with_parent
@@ -496,7 +496,7 @@ class TestOffersController(test_api_base.APITestCase):
             _get_offer_response(self.test_offer, use_datetime=True),
             _get_offer_response(self.test_offer_2, use_datetime=True),
         ]
-        mock_gro.return_value = TestNode("54321")
+        mock_gro.return_value = FakeNode("54321")
         mock_gpl.return_value = []
         mock_gnl.return_value = []
 

--- a/esi_leap/tests/api/controllers/v1/test_offer.py
+++ b/esi_leap/tests/api/controllers/v1/test_offer.py
@@ -109,7 +109,7 @@ class TestOffersController(test_api_base.APITestCase):
             start_time=start,
             end_time=start + datetime.timedelta(days=100),
             project_id=self.context.project_id,
-            parent_lease_uuid="parent-lease-uuid",
+            parent_lease_uuid=uuidutils.generate_uuid(),
         )
 
     def test_empty(self):
@@ -651,71 +651,70 @@ class TestOffersController(test_api_base.APITestCase):
         )
         mock_ogdwai.assert_called_once_with(self.test_offer)
 
-    @mock.patch("oslo_utils.uuidutils.generate_uuid")
     @mock.patch("esi_leap.objects.lease.Lease.create")
     @mock.patch("esi_leap.api.controllers.v1.utils.check_offer_lessee")
     @mock.patch("esi_leap.api.controllers.v1.utils." "check_offer_policy_and_retrieve")
     @mock.patch("esi_leap.api.controllers.v1.utils." "lease_get_dict_with_added_info")
-    def test_claim(
-        self, mock_lgdwai, mock_copar, mock_col, mock_lease_create, mock_generate_uuid
-    ):
-        lease_uuid = "12345"
-        mock_generate_uuid.return_value = lease_uuid
-        mock_copar.return_value = self.test_offer
-        data = {
-            "name": "lease_claim",
-            "start_time": "2016-07-16T19:20:30",
-            "end_time": "2016-08-16T19:20:30",
-        }
+    def test_claim(self, mock_lgdwai, mock_copar, mock_col, mock_lease_create):
+        lease_uuid = uuidutils.generate_uuid()
 
-        request = self.post_json("/offers/" + self.test_offer.uuid + "/claim", data)
+        with mock.patch("oslo_utils.uuidutils.generate_uuid") as mock_generate_uuid:
+            mock_generate_uuid.return_value = lease_uuid
+            mock_copar.return_value = self.test_offer
+            data = {
+                "name": "lease_claim",
+                "start_time": "2016-07-16T19:20:30",
+                "end_time": "2016-08-16T19:20:30",
+            }
 
-        mock_copar.assert_called_once_with(
-            self.context,
-            "esi_leap:offer:claim",
-            self.test_offer.uuid,
-            [statuses.AVAILABLE],
-        )
-        mock_col.assert_called_once_with(
-            self.context.to_policy_values(), self.test_offer
-        )
-        mock_lease_create.assert_called_once()
-        mock_lgdwai.assert_called_once()
-        self.assertEqual(http_client.CREATED, request.status_int)
+            request = self.post_json("/offers/" + self.test_offer.uuid + "/claim", data)
 
-    @mock.patch("oslo_utils.uuidutils.generate_uuid")
+            mock_copar.assert_called_once_with(
+                self.context,
+                "esi_leap:offer:claim",
+                self.test_offer.uuid,
+                [statuses.AVAILABLE],
+            )
+            mock_col.assert_called_once_with(
+                self.context.to_policy_values(), self.test_offer
+            )
+            mock_lease_create.assert_called_once()
+            mock_lgdwai.assert_called_once()
+            self.assertEqual(http_client.CREATED, request.status_int)
+
     @mock.patch("esi_leap.objects.lease.Lease.create")
     @mock.patch("esi_leap.api.controllers.v1.utils.check_offer_lessee")
     @mock.patch("esi_leap.api.controllers.v1.utils." "check_offer_policy_and_retrieve")
     @mock.patch("esi_leap.api.controllers.v1.utils." "lease_get_dict_with_added_info")
     def test_claim_parent_lease(
-        self, mock_lgdwai, mock_copar, mock_col, mock_lease_create, mock_generate_uuid
+        self, mock_lgdwai, mock_copar, mock_col, mock_lease_create
     ):
-        lease_uuid = "12345"
-        mock_generate_uuid.return_value = lease_uuid
-        mock_copar.return_value = self.test_offer_with_parent
-        data = {
-            "name": "lease_claim",
-            "start_time": "2016-07-16T19:20:30",
-            "end_time": "2016-08-16T19:20:30",
-        }
+        lease_uuid = uuidutils.generate_uuid()
+        with mock.patch("oslo_utils.uuidutils.generate_uuid") as mock_generate_uuid:
+            mock_generate_uuid.return_value = lease_uuid
+            mock_copar.return_value = self.test_offer_with_parent
+            data = {
+                "name": "lease_claim",
+                "start_time": "2016-07-16T19:20:30",
+                "end_time": "2016-08-16T19:20:30",
+            }
 
-        request = self.post_json(
-            "/offers/" + self.test_offer_with_parent.uuid + "/claim", data
-        )
+            request = self.post_json(
+                "/offers/" + self.test_offer_with_parent.uuid + "/claim", data
+            )
 
-        mock_copar.assert_called_once_with(
-            self.context,
-            "esi_leap:offer:claim",
-            self.test_offer_with_parent.uuid,
-            [statuses.AVAILABLE],
-        )
-        mock_col.assert_called_once_with(
-            self.context.to_policy_values(), self.test_offer_with_parent
-        )
-        mock_lease_create.assert_called_once()
-        mock_lgdwai.assert_called_once()
-        self.assertEqual(http_client.CREATED, request.status_int)
+            mock_copar.assert_called_once_with(
+                self.context,
+                "esi_leap:offer:claim",
+                self.test_offer_with_parent.uuid,
+                [statuses.AVAILABLE],
+            )
+            mock_col.assert_called_once_with(
+                self.context.to_policy_values(), self.test_offer_with_parent
+            )
+            mock_lease_create.assert_called_once()
+            mock_lgdwai.assert_called_once()
+            self.assertEqual(http_client.CREATED, request.status_int)
 
     @mock.patch("esi_leap.api.controllers.v1.utils." "check_offer_policy_and_retrieve")
     @mock.patch("esi_leap.objects.offer.Offer.cancel")

--- a/esi_leap/tests/api/controllers/v1/test_utils.py
+++ b/esi_leap/tests/api/controllers/v1/test_utils.py
@@ -24,7 +24,7 @@ from esi_leap.common import policy
 from esi_leap.common import statuses
 from esi_leap.objects import lease
 from esi_leap.objects import offer
-from esi_leap.resource_objects.test_node import TestNode
+from esi_leap.resource_objects.fake_node import FakeNode
 
 
 admin_ctx = ctx.RequestContext(project_id="adminid", roles=["admin"])
@@ -45,8 +45,8 @@ start_iso = "2016-07-16T00:00:00"
 end = start + datetime.timedelta(days=100)
 end_iso = "2016-10-24T00:00:00"
 
-test_node_1 = TestNode("111", owner_ctx.project_id)
-test_node_2 = TestNode("bbb", owner_ctx_2.project_id)
+test_node_1 = FakeNode("111", owner_ctx.project_id)
+test_node_2 = FakeNode("bbb", owner_ctx_2.project_id)
 
 o_uuid = uuidutils.generate_uuid()
 
@@ -684,11 +684,11 @@ class TestLeaseGetDictWithAddedInfoUtils(testtools.TestCase):
             parent_lease_uuid=None,
         )
 
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.get_name")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.get_name")
     @mock.patch("esi_leap.common.keystone.get_project_name")
     @mock.patch("esi_leap.objects.lease.get_resource_object")
     def test_lease_get_dict_with_added_info(self, mock_gro, mock_gpn, mock_gn):
-        mock_gro.return_value = TestNode("111")
+        mock_gro.return_value = FakeNode("111")
         mock_gpn.return_value = "project-name"
         mock_gn.return_value = "resource-name"
 

--- a/esi_leap/tests/api/controllers/v1/test_utils.py
+++ b/esi_leap/tests/api/controllers/v1/test_utils.py
@@ -328,7 +328,7 @@ class TestCheckResourceLeaseAdminUtils(testtools.TestCase):
             uuid=uuidutils.generate_uuid(),
             start_time=datetime.datetime(2016, 7, 16, 19, 20, 30),
             end_time=datetime.datetime(2016, 8, 16, 19, 20, 30),
-            parent_lease_uuid="parent-lease-uuid",
+            parent_lease_uuid=uuidutils.generate_uuid(),
         )
 
     @mock.patch("esi_leap.objects.lease.Lease.get")

--- a/esi_leap/tests/base.py
+++ b/esi_leap/tests/base.py
@@ -60,6 +60,15 @@ class TestCase(base.BaseTestCase):
                 auth_token=None, project_id="12345", is_admin=True, overwrite=False
             )
 
+    def catch_exception(self, func, exc=Exception):
+        def wrapper(*args, **kwargs):
+            try:
+                func(*args, **kwargs)
+            except exc:
+                pass
+
+        return wrapper
+
 
 class DBTestCase(TestCase):
     def setUp(self):

--- a/esi_leap/tests/common/test_notification_utils.py
+++ b/esi_leap/tests/common/test_notification_utils.py
@@ -18,7 +18,7 @@ from oslo_utils import uuidutils
 from esi_leap.common import notification_utils as notif_utils
 from esi_leap.objects import fields
 from esi_leap.objects import lease as lease_obj
-from esi_leap.resource_objects.test_node import TestNode
+from esi_leap.resource_objects.fake_node import FakeNode
 from esi_leap.tests import base as tests_base
 
 
@@ -48,7 +48,7 @@ class NotifyTestCase(tests_base.TestCase):
             status="created",
             purpose=None,
         )
-        self.node = TestNode(uuidutils.generate_uuid(), "12345")
+        self.node = FakeNode(uuidutils.generate_uuid(), "12345")
 
     def test_emit_notification(self):
         self.config(host="fake-host")

--- a/esi_leap/tests/common/test_notification_utils.py
+++ b/esi_leap/tests/common/test_notification_utils.py
@@ -13,6 +13,7 @@
 import datetime
 
 import mock
+from oslo_utils import uuidutils
 
 from esi_leap.common import notification_utils as notif_utils
 from esi_leap.objects import fields
@@ -47,7 +48,7 @@ class NotifyTestCase(tests_base.TestCase):
             status="created",
             purpose=None,
         )
-        self.node = TestNode("test-node", "12345")
+        self.node = TestNode(uuidutils.generate_uuid(), "12345")
 
     def test_emit_notification(self):
         self.config(host="fake-host")

--- a/esi_leap/tests/common/test_rpc.py
+++ b/esi_leap/tests/common/test_rpc.py
@@ -24,30 +24,21 @@ CONF = cfg.CONF
 
 # TestUtils borrowed from Ironic
 class TestUtils(base.TestCase):
-    @mock.patch.object(messaging, "Notifier", autospec=True)
-    @mock.patch.object(messaging, "JsonPayloadSerializer", autospec=True)
-    @mock.patch.object(messaging, "get_notification_transport", autospec=True)
-    def test_init_globals_notifications_disabled(
-        self, mock_get_notification, mock_json_serializer, mock_notifier
-    ):
-        self._test_init_globals(
-            False, mock_get_notification, mock_json_serializer, mock_notifier
-        )
+    def test_init_globals_notifications_disabled(self):
+        self._test_init_globals(False)
 
-    @mock.patch.object(messaging, "Notifier", autospec=True)
-    @mock.patch.object(messaging, "JsonPayloadSerializer", autospec=True)
-    @mock.patch.object(messaging, "get_notification_transport", autospec=True)
-    def test_init_globals_notifications_enabled(
-        self, mock_get_notification, mock_json_serializer, mock_notifier
-    ):
+    def test_init_globals_notifications_enabled(self):
         self.config(notification_level="debug", group="notification")
-        self._test_init_globals(
-            True, mock_get_notification, mock_json_serializer, mock_notifier
-        )
+        self._test_init_globals(True)
 
+    @mock.patch.object(messaging, "Notifier", autospec=True)
+    @mock.patch.object(messaging, "JsonPayloadSerializer", autospec=True)
+    @mock.patch.object(messaging, "get_notification_transport", autospec=True)
+    @mock.patch.object(rpc, "RequestContextSerializer", autospec=True)
     def _test_init_globals(
         self,
         notifications_enabled,
+        mock_request_serializer,
         mock_get_notification,
         mock_json_serializer,
         mock_notifier,
@@ -55,10 +46,7 @@ class TestUtils(base.TestCase):
     ):
         rpc.NOTIFICATION_TRANSPORT = None
         rpc.VERSIONED_NOTIFIER = None
-        mock_request_serializer = mock.Mock()
         mock_request_serializer.return_value = mock.Mock()
-        rpc.RequestContextSerializer = mock_request_serializer
-
         mock_notifier.return_value = mock.Mock()
 
         rpc.init(CONF)

--- a/esi_leap/tests/objects/test_lease.py
+++ b/esi_leap/tests/objects/test_lease.py
@@ -21,7 +21,7 @@ from esi_leap.common import statuses
 from esi_leap.objects import fields as obj_fields
 from esi_leap.objects import lease as lease_obj
 from esi_leap.objects import offer as offer_obj
-from esi_leap.resource_objects.test_node import TestNode
+from esi_leap.resource_objects.fake_node import FakeNode
 from esi_leap.tests import base
 
 
@@ -243,12 +243,12 @@ class TestLeaseObject(base.DBTestCase):
                 mock_save.assert_called_once()
 
     @mock.patch("esi_leap.objects.lease.Lease.resource_object")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.set_lease")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.set_lease")
     @mock.patch("esi_leap.objects.lease.Lease.save")
     @mock.patch("esi_leap.common.notification_utils" "._emit_notification")
     def test_fulfill(self, mock_notify, mock_save, mock_set_lease, mock_ro):
         lease = lease_obj.Lease(self.context, **self.test_lease_dict)
-        test_node = TestNode(uuidutils.generate_uuid(), "12345")
+        test_node = FakeNode(uuidutils.generate_uuid(), "12345")
 
         mock_ro.return_value = test_node
 
@@ -282,12 +282,12 @@ class TestLeaseObject(base.DBTestCase):
         self.assertEqual(lease.status, statuses.ACTIVE)
 
     @mock.patch("esi_leap.objects.lease.Lease.resource_object")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.set_lease")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.set_lease")
     @mock.patch("esi_leap.objects.lease.Lease.save")
     @mock.patch("esi_leap.common.notification_utils" "._emit_notification")
     def test_fulfill_error(self, mock_notify, mock_save, mock_set_lease, mock_ro):
         lease = lease_obj.Lease(self.context, **self.test_lease_dict)
-        test_node = TestNode(uuidutils.generate_uuid(), "12345")
+        test_node = FakeNode(uuidutils.generate_uuid(), "12345")
 
         mock_ro.return_value = test_node
         mock_set_lease.side_effect = Exception("bad")
@@ -321,18 +321,18 @@ class TestLeaseObject(base.DBTestCase):
         mock_save.assert_called_once()
         self.assertEqual(lease.status, statuses.WAIT_FULFILL)
 
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.set_lease")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.set_lease")
     @mock.patch("esi_leap.objects.lease.Lease.get")
     @mock.patch("esi_leap.objects.lease.Lease.resource_object")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.get_lease_uuid")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.remove_lease")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.get_lease_uuid")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.remove_lease")
     @mock.patch("esi_leap.objects.lease.Lease.save")
     @mock.patch("esi_leap.common.notification_utils" "._emit_notification")
     def test_cancel(
         self, mock_notify, mock_save, mock_rl, mock_glu, mock_ro, mock_lg, mock_sl
     ):
         lease = lease_obj.Lease(self.context, **self.test_lease_dict)
-        test_node = TestNode(uuidutils.generate_uuid(), "12345")
+        test_node = FakeNode(uuidutils.generate_uuid(), "12345")
 
         mock_ro.return_value = test_node
         mock_glu.return_value = lease.uuid
@@ -368,18 +368,18 @@ class TestLeaseObject(base.DBTestCase):
         mock_save.assert_called_once()
         self.assertEqual(lease.status, statuses.DELETED)
 
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.set_lease")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.set_lease")
     @mock.patch("esi_leap.objects.lease.Lease.get")
     @mock.patch("esi_leap.objects.lease.Lease.resource_object")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.get_lease_uuid")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.remove_lease")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.get_lease_uuid")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.remove_lease")
     @mock.patch("esi_leap.objects.lease.Lease.save")
     @mock.patch("esi_leap.common.notification_utils" "._emit_notification")
     def test_cancel_error(
         self, mock_notify, mock_save, mock_rl, mock_glu, mock_ro, mock_lg, mock_sl
     ):
         lease = lease_obj.Lease(self.context, **self.test_lease_dict)
-        test_node = TestNode(uuidutils.generate_uuid(), "12345")
+        test_node = FakeNode(uuidutils.generate_uuid(), "12345")
 
         mock_ro.return_value = test_node
         mock_glu.return_value = lease.uuid
@@ -417,18 +417,18 @@ class TestLeaseObject(base.DBTestCase):
         mock_save.assert_called_once()
         self.assertEqual(lease.status, statuses.WAIT_CANCEL)
 
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.set_lease")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.set_lease")
     @mock.patch("esi_leap.objects.lease.Lease.get")
     @mock.patch("esi_leap.objects.lease.Lease.resource_object")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.get_lease_uuid")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.remove_lease")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.get_lease_uuid")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.remove_lease")
     @mock.patch("esi_leap.objects.lease.Lease.save")
     @mock.patch("esi_leap.common.notification_utils" "._emit_notification")
     def test_cancel_with_parent(
         self, mock_notify, mock_save, mock_rl, mock_glu, mock_ro, mock_lg, mock_sl
     ):
         lease = lease_obj.Lease(self.context, **self.test_lease_parent_lease_dict)
-        test_node = TestNode(uuidutils.generate_uuid(), "12345")
+        test_node = FakeNode(uuidutils.generate_uuid(), "12345")
 
         mock_ro.return_value = test_node
         mock_glu.return_value = lease.uuid
@@ -466,13 +466,13 @@ class TestLeaseObject(base.DBTestCase):
         self.assertEqual(lease.status, statuses.DELETED)
 
     @mock.patch("esi_leap.objects.lease.Lease.resource_object")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.get_lease_uuid")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.remove_lease")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.get_lease_uuid")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.remove_lease")
     @mock.patch("esi_leap.objects.lease.Lease.save")
     @mock.patch("esi_leap.common.notification_utils" "._emit_notification")
     def test_cancel_no_expire(self, mock_notify, mock_save, mock_rl, mock_glu, mock_ro):
         lease = lease_obj.Lease(self.context, **self.test_lease_dict)
-        test_node = TestNode(uuidutils.generate_uuid(), "12345")
+        test_node = FakeNode(uuidutils.generate_uuid(), "12345")
 
         mock_ro.return_value = test_node
         mock_glu.return_value = "some-other-lease-uuid"
@@ -507,18 +507,18 @@ class TestLeaseObject(base.DBTestCase):
         mock_save.assert_called_once()
         self.assertEqual(lease.status, statuses.DELETED)
 
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.set_lease")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.set_lease")
     @mock.patch("esi_leap.objects.lease.Lease.get")
     @mock.patch("esi_leap.objects.lease.Lease.resource_object")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.get_lease_uuid")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.remove_lease")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.get_lease_uuid")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.remove_lease")
     @mock.patch("esi_leap.objects.lease.Lease.save")
     @mock.patch("esi_leap.common.notification_utils" "._emit_notification")
     def test_expire(
         self, mock_notify, mock_save, mock_rl, mock_glu, mock_ro, mock_lg, mock_sl
     ):
         lease = lease_obj.Lease(self.context, **self.test_lease_dict)
-        test_node = TestNode(uuidutils.generate_uuid(), "12345")
+        test_node = FakeNode(uuidutils.generate_uuid(), "12345")
 
         mock_ro.return_value = test_node
         mock_glu.return_value = lease.uuid
@@ -555,18 +555,18 @@ class TestLeaseObject(base.DBTestCase):
         mock_save.assert_called_once()
         self.assertEqual(lease.status, statuses.EXPIRED)
 
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.set_lease")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.set_lease")
     @mock.patch("esi_leap.objects.lease.Lease.get")
     @mock.patch("esi_leap.objects.lease.Lease.resource_object")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.get_lease_uuid")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.remove_lease")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.get_lease_uuid")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.remove_lease")
     @mock.patch("esi_leap.objects.lease.Lease.save")
     @mock.patch("esi_leap.common.notification_utils" "._emit_notification")
     def test_expire_error(
         self, mock_notify, mock_save, mock_rl, mock_glu, mock_ro, mock_lg, mock_sl
     ):
         lease = lease_obj.Lease(self.context, **self.test_lease_dict)
-        test_node = TestNode(uuidutils.generate_uuid(), "12345")
+        test_node = FakeNode(uuidutils.generate_uuid(), "12345")
 
         mock_ro.return_value = test_node
         mock_glu.return_value = lease.uuid
@@ -604,18 +604,18 @@ class TestLeaseObject(base.DBTestCase):
         mock_save.assert_called_once()
         self.assertEqual(lease.status, statuses.WAIT_EXPIRE)
 
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.set_lease")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.set_lease")
     @mock.patch("esi_leap.objects.lease.Lease.get")
     @mock.patch("esi_leap.objects.lease.Lease.resource_object")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.get_lease_uuid")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.remove_lease")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.get_lease_uuid")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.remove_lease")
     @mock.patch("esi_leap.objects.lease.Lease.save")
     @mock.patch("esi_leap.common.notification_utils" "._emit_notification")
     def test_expire_with_parent(
         self, mock_notify, mock_save, mock_rl, mock_glu, mock_ro, mock_lg, mock_sl
     ):
         lease = lease_obj.Lease(self.context, **self.test_lease_parent_lease_dict)
-        test_node = TestNode(uuidutils.generate_uuid(), "12345")
+        test_node = FakeNode(uuidutils.generate_uuid(), "12345")
 
         mock_ro.return_value = test_node
         mock_glu.return_value = lease.uuid
@@ -653,13 +653,13 @@ class TestLeaseObject(base.DBTestCase):
         self.assertEqual(lease.status, statuses.EXPIRED)
 
     @mock.patch("esi_leap.objects.lease.Lease.resource_object")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.get_lease_uuid")
-    @mock.patch("esi_leap.resource_objects.test_node.TestNode.remove_lease")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.get_lease_uuid")
+    @mock.patch("esi_leap.resource_objects.fake_node.FakeNode.remove_lease")
     @mock.patch("esi_leap.objects.lease.Lease.save")
     @mock.patch("esi_leap.common.notification_utils" "._emit_notification")
     def test_expire_no_expire(self, mock_notify, mock_save, mock_rl, mock_glu, mock_ro):
         lease = lease_obj.Lease(self.context, **self.test_lease_dict)
-        test_node = TestNode(uuidutils.generate_uuid(), "12345")
+        test_node = FakeNode(uuidutils.generate_uuid(), "12345")
 
         mock_ro.return_value = test_node
         mock_glu.return_value = "some-other-lease-uuid"
@@ -863,7 +863,7 @@ class TestLeaseCRUDPayloads(base.DBTestCase):
             status="created",
             purpose=None,
         )
-        self.node = TestNode(uuidutils.generate_uuid(), "12345")
+        self.node = FakeNode(uuidutils.generate_uuid(), "12345")
 
     def test_lease_crud_payload(self):
         payload = lease_obj.LeaseCRUDPayload(self.lease, self.node)

--- a/esi_leap/tests/objects/test_offer.py
+++ b/esi_leap/tests/objects/test_offer.py
@@ -55,7 +55,7 @@ class TestOfferObject(base.DBTestCase):
         }
         self.test_offer_create_parent_lease_data = self.test_offer_create_data.copy()
         self.test_offer_create_parent_lease_data["parent_lease_uuid"] = (
-            "parent-lease-uuid"
+            uuidutils.generate_uuid()
         )
         self.test_parent_lease = lease.Lease(
             uuid=uuidutils.generate_uuid(), status=statuses.ACTIVE
@@ -267,7 +267,9 @@ class TestOfferObject(base.DBTestCase):
 
         o.create(self.context)
 
-        mock_lg.assert_called_once_with("parent-lease-uuid")
+        mock_lg.assert_called_once_with(
+            self.test_offer_create_parent_lease_data["parent_lease_uuid"]
+        )
         mock_lvca.assert_called_once_with(
             self.test_parent_lease, o.start_time, o.end_time
         )
@@ -284,7 +286,9 @@ class TestOfferObject(base.DBTestCase):
 
         self.assertRaises(exception.LeaseNotActive, o.create, self.context)
 
-        mock_lg.assert_called_once_with("parent-lease-uuid")
+        mock_lg.assert_called_once_with(
+            self.test_offer_create_parent_lease_data["parent_lease_uuid"]
+        )
         mock_lvca.assert_not_called()
         mock_oc.assert_not_called()
 
@@ -300,8 +304,8 @@ class TestOfferObject(base.DBTestCase):
 
         mock_oc.side_effect = update_mock
 
-        thread = threading.Thread(target=o.create)
-        thread2 = threading.Thread(target=o2.create)
+        thread = threading.Thread(target=self.catch_exception(o.create))
+        thread2 = threading.Thread(target=self.catch_exception(o2.create))
 
         thread.start()
         thread2.start()

--- a/esi_leap/tests/resource_objects/test_resource_objects.py
+++ b/esi_leap/tests/resource_objects/test_resource_objects.py
@@ -22,7 +22,7 @@ class TestResourceObjects(base.TestCase):
         types = {
             "ironic_node": resource_objects.ironic_node.IronicNode,
             "dummy_node": resource_objects.dummy_node.DummyNode,
-            "test_node": resource_objects.test_node.TestNode,
+            "test_node": resource_objects.fake_node.FakeNode,
         }
 
         for type_name, expected_type in types.items():
@@ -84,7 +84,7 @@ class TestResourceObjects(base.TestCase):
     def test_test_node(self):
         node = resource_objects.get_resource_object("test_node", "1111")
 
-        self.assertIsInstance(node, resource_objects.test_node.TestNode)
+        self.assertIsInstance(node, resource_objects.fake_node.FakeNode)
         self.assertEqual("1111", node.get_uuid())
 
     def test_unknown_resource_type(self):

--- a/esi_leap/tests/resource_objects/test_test_node.py
+++ b/esi_leap/tests/resource_objects/test_test_node.py
@@ -12,7 +12,7 @@
 
 import datetime
 from esi_leap.common import statuses
-from esi_leap.resource_objects import test_node
+from esi_leap.resource_objects import fake_node
 from esi_leap.tests import base
 
 start = datetime.datetime(2016, 7, 16, 19, 20, 30)
@@ -36,10 +36,10 @@ def get_test_lease():
     }
 
 
-class TestTestNode(base.TestCase):
+class TestFakeNode(base.TestCase):
     def setUp(self):
-        super(TestTestNode, self).setUp()
-        self.fake_test_node = test_node.TestNode("1111", "123456")
+        super(TestFakeNode, self).setUp()
+        self.fake_test_node = fake_node.FakeNode("1111", "123456")
 
     def test_resource_type(self):
         resource_type = self.fake_test_node.resource_type


### PR DESCRIPTION
This is prep work for adding some integration tests to this repository. I would like to be able to use pytest [fixtures](https://docs.pytest.org/en/6.2.x/fixture.html) as part of the integration tests, but in order to do that we need to ensure that the existing tests run cleanly under pytest.

I tried running the test suite using pytest, and while it mostly works, there were a number of errors and warnings that cropped up. Primarily:

1. We need to catch exceptions in threads spawned during the test process.

2. We need to pass valid UUIDs to anything expecting a UUID; failure to do so yields a warning. So many warnings.

With this pull request, all tests run cleanly under pytest. There are still warnings, but they all come from third party modules and so are somebody else's problem.