### PR TITLE
Clear instance_info when removing lease from a node

### DIFF
--- a/esi_leap/resource_objects/ironic_node.py
+++ b/esi_leap/resource_objects/ironic_node.py
@@ -154,6 +154,13 @@ class IronicNode(base.ResourceObjectInterface):
                     "path": "/lessee",
                 }
             )
+        if len(self._get_node().instance_info) > 0:
+            patches.append(
+                {
+                    "op": "remove",
+                    "path": "/instance_info",
+                }
+            )
         if len(patches) > 0:
             get_ironic_client().node.update(self._uuid, patches)
         state = self._get_node().provision_state

--- a/esi_leap/tests/resource_objects/test_ironic_node.py
+++ b/esi_leap/tests/resource_objects/test_ironic_node.py
@@ -35,6 +35,7 @@ class FakeIronicNode(object):
         self.uuid = fake_uuid
         self.resource_class = "baremetal"
         self.power_state = "off"
+        self.instance_info = {"foo": "bar"}
 
 
 class FakeLease(object):
@@ -187,13 +188,14 @@ class TestIronicNode(base.TestCase):
 
         mock_glpi.assert_called_once()
         mock_glu.assert_called_once()
-        self.assertEqual(mock_gn.call_count, 1)
+        self.assertEqual(mock_gn.call_count, 2)
         self.assertEqual(mock_client.call_count, 2)
         mock_client.return_value.node.update.assert_called_once_with(
             fake_uuid,
             [
                 {"op": "remove", "path": "/properties/lease_uuid"},
                 {"op": "remove", "path": "/lessee"},
+                {"op": "remove", "path": "/instance_info"},
             ],
         )
         mock_client.return_value.node.set_provision_state.assert_called_once_with(


### PR DESCRIPTION
If a node had instance_info set but was not deployed, then removing the lease would not clear the instance_info. This change fixes that issue.