### PR TITLE
Eliminate test warnings due to invalid uuids

### DIFF
--- a/esi_leap/tests/api/controllers/v1/test_console_auth_token.py
+++ b/esi_leap/tests/api/controllers/v1/test_console_auth_token.py
@@ -12,6 +12,7 @@
 
 import http.client as http_client
 import mock
+import uuid
 from oslo_utils import uuidutils
 
 from esi_leap.common import ironic
@@ -28,6 +29,7 @@ class TestConsoleAuthTokensController(test_api_base.APITestCase):
     )
     @mock.patch.object(ironic, "get_ironic_client", autospec=True)
     def test_post(self, mock_client, mock_authorize):
+        mock_client.return_value.node.get.return_value = mock.Mock(uuid=uuid.uuid4())
         mock_authorize.return_value = "fake-token"
 
         data = {"node_uuid_or_name": self.node_uuid}

--- a/esi_leap/tests/objects/test_console_auth_token.py
+++ b/esi_leap/tests/objects/test_console_auth_token.py
@@ -12,6 +12,7 @@
 
 from datetime import datetime
 import mock
+import uuid
 
 from oslo_db.exception import DBDuplicateEntry
 from oslo_utils import uuidutils
@@ -31,7 +32,7 @@ class TestConsoleAuthTokenObject(base.DBTestCase):
 
         self.test_cat_dict = {
             "id": 1,
-            "node_uuid": "test-node",
+            "node_uuid": str(uuid.uuid4()),
             "token": self.token,
             "expires": 1,
             "created_at": self.created_at,
@@ -40,7 +41,7 @@ class TestConsoleAuthTokenObject(base.DBTestCase):
 
         self.test_authorized_cat_dict = {
             "id": 1,
-            "node_uuid": "test-node",
+            "node_uuid": str(uuid.uuid4()),
             "token_hash": self.token_hash,
             "expires": 1,
             "created_at": self.created_at,
@@ -48,7 +49,7 @@ class TestConsoleAuthTokenObject(base.DBTestCase):
         }
 
         self.test_unauthorized_cat_dict = {
-            "node_uuid": "test-node",
+            "node_uuid": str(uuid.uuid4()),
             "token": self.token,
             "expires": 1,
             "created_at": self.created_at,


### PR DESCRIPTION
Tests results would include warnings along the lines of:

> FutureWarning: b"'test-node'" is an invalid UUID. Using UUIDFields with
> invalid UUIDs is no longer supported, and will be removed in a future
> release. Please update your code to input valid UUIDs or accept ValueErrors
> for invalid UUIDs.

This commit ensures that tests are using valid UUIDs.
