### PR TITLE
Make dates timezone aware

### DIFF
--- a/esi_leap/api/controllers/v1/lease.py
+++ b/esi_leap/api/controllers/v1/lease.py
@@ -28,6 +28,7 @@ from esi_leap.common import exception
 from esi_leap.common import ironic
 from esi_leap.common import keystone
 from esi_leap.common import statuses
+from esi_leap.common import utils as common_utils
 import esi_leap.conf
 from esi_leap.objects import lease as lease_obj
 from esi_leap.resource_objects import get_resource_object
@@ -328,7 +329,10 @@ class LeasesController(rest.RestController):
             raise exception.InvalidTimeAPICommand(
                 resource="a lease", start_time=str(start_time), end_time=str(end_time)
             )
-        if (start_time or end_time) and (end_time <= start_time):
+        if (start_time or end_time) and (
+            common_utils.datetime_aware(end_time)
+            <= common_utils.datetime_aware(start_time)
+        ):
             raise exception.InvalidTimeAPICommand(
                 resource="a lease", start_time=str(start_time), end_time=str(end_time)
             )

--- a/esi_leap/api/controllers/v1/offer.py
+++ b/esi_leap/api/controllers/v1/offer.py
@@ -28,6 +28,7 @@ from esi_leap.common import exception
 from esi_leap.common import ironic
 from esi_leap.common import keystone
 from esi_leap.common import statuses
+from esi_leap.common import utils as common_utils
 import esi_leap.conf
 from esi_leap.objects import lease as lease_obj
 from esi_leap.objects import offer as offer_obj
@@ -137,7 +138,10 @@ class OffersController(rest.RestController):
             raise exception.InvalidTimeAPICommand(
                 resource="an offer", start_time=str(start_time), end_time=str(end_time)
             )
-        if (start_time or end_time) and (end_time <= start_time):
+        if (start_time or end_time) and (
+            common_utils.datetime_aware(end_time)
+            <= common_utils.datetime_aware(start_time)
+        ):
             raise exception.InvalidTimeAPICommand(
                 resource="an offer", start_time=str(start_time), end_time=str(end_time)
             )
@@ -147,7 +151,8 @@ class OffersController(rest.RestController):
                 a_start=str(available_start_time), a_end=str(available_end_time)
             )
         if (available_start_time or available_end_time) and (
-            available_end_time <= available_start_time
+            common_utils.datetime_aware(available_end_time)
+            <= common_utils.datetime_aware(available_start_time)
         ):
             raise exception.InvalidAvailabilityAPICommand(
                 a_start=str(available_start_time), a_end=str(available_end_time)

--- a/esi_leap/common/utils.py
+++ b/esi_leap/common/utils.py
@@ -10,6 +10,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import datetime
 
 from oslo_concurrency import lockutils
 
@@ -19,3 +20,9 @@ lock = lockutils.lock_with_prefix(_prefix)
 
 def get_resource_lock_name(resource_type, resource_uuid):
     return resource_type + "-" + resource_uuid
+
+
+def datetime_aware(dt):
+    if dt.tzinfo is not None and dt.tzinfo.utcoffset(dt) is not None:
+        return dt
+    return dt.replace(tzinfo=datetime.timezone.utc)

--- a/esi_leap/db/sqlalchemy/api.py
+++ b/esi_leap/db/sqlalchemy/api.py
@@ -25,6 +25,7 @@ from esi_leap.common import constants
 from esi_leap.common import exception
 from esi_leap.common import keystone
 from esi_leap.common import statuses
+from esi_leap.common import utils
 from esi_leap.db.sqlalchemy import models
 
 
@@ -192,7 +193,9 @@ def offer_get_next_lease_start_time(offer_uuid, start):
 
 
 def offer_verify_availability(offer_ref, start, end):
-    if start < offer_ref.start_time or end > offer_ref.end_time:
+    if utils.datetime_aware(start) < utils.datetime_aware(
+        offer_ref.start_time
+    ) or utils.datetime_aware(end) > utils.datetime_aware(offer_ref.end_time):
         raise exception.OfferNoTimeAvailabilities(
             offer_uuid=offer_ref.uuid, start_time=start, end_time=end
         )
@@ -366,7 +369,9 @@ def lease_destroy(lease_uuid):
 
 
 def lease_verify_child_availability(lease_ref, start, end):
-    if start < lease_ref.start_time or end > lease_ref.end_time:
+    if utils.datetime_aware(start) < utils.datetime_aware(
+        lease_ref.start_time
+    ) or utils.datetime_aware(end) > utils.datetime_aware(lease_ref.end_time):
         raise exception.LeaseNoTimeAvailabilities(
             lease_uuid=lease_ref.uuid, start_time=start, end_time=end
         )


### PR DESCRIPTION
If one datetime is offset-aware and another is offset-naive, any comparision between the two will fail. This PR enforces updates these comparisions so that they are always offset-aware.