### PR TITLE
Clear 'extra' field when lease is removed

### DIFF
--- a/esi_leap/resource_objects/ironic_node.py
+++ b/esi_leap/resource_objects/ironic_node.py
@@ -162,6 +162,13 @@ class IronicNode(base.ResourceObjectInterface):
                     "path": "/instance_info",
                 }
             )
+        if len(self._get_node().extra) > 0:
+            patches.append(
+                {
+                    "op": "remove",
+                    "path": "/extra",
+                }
+            )
         if len(patches) > 0:
             # remove lease information and instance_info
             get_ironic_client().node.update(self._uuid, patches)

--- a/esi_leap/tests/resource_objects/test_ironic_node.py
+++ b/esi_leap/tests/resource_objects/test_ironic_node.py
@@ -36,6 +36,7 @@ class FakeIronicNode(object):
         self.resource_class = "baremetal"
         self.power_state = "off"
         self.instance_info = {"foo": "bar"}
+        self.extra = {"bar": "foo"}
 
 
 class FakeLease(object):
@@ -191,7 +192,7 @@ class TestIronicNode(base.TestCase):
 
         mock_glpi.assert_called_once()
         mock_glu.assert_called_once()
-        self.assertEqual(mock_gn.call_count, 2)
+        self.assertEqual(mock_gn.call_count, 3)
         self.assertEqual(mock_client.call_count, 3)
         mock_client.return_value.node.update.assert_called_once_with(
             fake_uuid,
@@ -199,6 +200,7 @@ class TestIronicNode(base.TestCase):
                 {"op": "remove", "path": "/properties/lease_uuid"},
                 {"op": "remove", "path": "/lessee"},
                 {"op": "remove", "path": "/instance_info"},
+                {"op": "remove", "path": "/extra"},
             ],
         )
         mock_client.return_value.node.set_console_mode.assert_called_once_with(
@@ -235,7 +237,7 @@ class TestIronicNode(base.TestCase):
 
         mock_glpi.assert_called_once()
         mock_glu.assert_called_once()
-        self.assertEqual(mock_gn.call_count, 2)
+        self.assertEqual(mock_gn.call_count, 3)
         self.assertEqual(mock_client.call_count, 3)
         mock_client.return_value.node.update.assert_called_once_with(
             fake_uuid,
@@ -243,6 +245,7 @@ class TestIronicNode(base.TestCase):
                 {"op": "remove", "path": "/properties/lease_uuid"},
                 {"op": "remove", "path": "/lessee"},
                 {"op": "remove", "path": "/instance_info"},
+                {"op": "remove", "path": "/extra"},
             ],
         )
         mock_client.return_value.node.set_console_mode.assert_called_once_with(


### PR DESCRIPTION
We currently clear the 'instance_info' field when a lease is removed; however a user may also set values in 'extra'. This PR removes them.